### PR TITLE
Faster time-out of graphQL IP test in dev

### DIFF
--- a/client/src/graphql_utils.js
+++ b/client/src/graphql_utils.js
@@ -20,7 +20,7 @@ const get_api_url = async () => {
       // Only give the query 1 second to respond before going to fallback.
       const controller = new AbortController();
       const id_for_test_timeout = setTimeout(() => controller.abort(), 1000);
-      api_url = await fetch(`${api_url}?query={ root(lang: "en") { gov { id } } }`, {signal: controller.signal})
+      api_url = await fetch(`${api_url}?query={ root(lang: "en") { non_field } }`, {signal: controller.signal})
         .then( (response ) => {
           clearTimeout(id_for_test_timeout);
           return api_url;


### PR DESCRIPTION
In dev only, we make a test query to see if the ip env var from the last webpack build is still accurate. If this query fails, we fall back to localhost.

Reminder: we can't always use localhost to talk to the api in dev, we need to use our dev machine ip if we want other local devices to be able to test dev builds.

The way I had this set up, it often took quite a while for this test query to time out (something like 10 or more seconds? long enough to feel like something was broken for sure). That's why we've had so many painfully slow loads while demoing lately (I think Ross was having a problem due to this recently too).

Anyway, I've taken measures so that the test query only has 1 second to work. It's the most trivial query possible, so 1 second should be plenty, but if there's ever a problem connecting local devices to local dev builds in the future than we may need to increase it slightly, at the trade off of lost time in other cases.