### PR TITLE
graph legend make color clickable

### DIFF
--- a/client/src/charts/declarative_charts.js
+++ b/client/src/charts/declarative_charts.js
@@ -20,7 +20,8 @@ const GraphLegend = ({
             { backgroundColor: color, border: "1px solid " + color } : 
             { border: "1px solid " + color }
           }
-          className="legend-color-checkbox"
+          className={ onClick ? "legend-color-checkbox span-hover" : "legend-color-checkbox" }
+          onClick={ () => onClick && onClick(id) }
         />
         { onClick ?
           <span
@@ -28,8 +29,8 @@ const GraphLegend = ({
             aria-checked={active}
             tabIndex={0}
             className="link-styled"
-            onClick={()=> onClick(id)}
-            onKeyDown={(e)=> (e.keyCode===13 || e.keyCode===32) && onClick(id)}
+            onClick={ () => onClick(id) }
+            onKeyDown={ (e) => (e.keyCode===13 || e.keyCode===32) && onClick(id) }
           > 
             { label }
           </span> : 

--- a/client/src/common_css/site.scss
+++ b/client/src/common_css/site.scss
@@ -181,6 +181,13 @@ header, h1, h2, h3, h4, h5, h6, .h1, .h2, .h3, .h4, .h5, .h6 {
   }
 }
 
+.span-hover {
+  cursor: pointer;
+  &:focus, &:hover {
+    opacity: 0.5;
+  }
+}
+
 .text-only-page-root {
   h2, h3, h4 {
     text-transform: uppercase;


### PR DESCRIPTION
I'm not sure if it's only me, but I always thought it'd make more sense to have the color part of `GraphLegend` interactive (to toggle that series), instead of only having text part interactive. (It took me some time to realize our legends were interactive.. and even now, I still always click on the color part first intuitively to toggle it)

I didn't bother with the tabbing because the text was doing that already, let me know if that's a problem or if this is not a good idea!