### PR TITLE
CSV compression

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,6 @@ deploy_filter: &deploy_filter
     branches:
       only:
         - master
-        - csv-compression
 
 version: 2
 jobs:

--- a/client/build_code/copy_static_assets.js
+++ b/client/build_code/copy_static_assets.js
@@ -227,7 +227,7 @@ function build_proj(PROJ){
     } = get_footnote_file_defs(parsed_bilingual_models, lang);
 
     _.each( _.merge(dept_footnotes, tag_footnotes), (file_str, subj_id) => {
-      // reminder: the fucky .json.js exstension is to ensure that Cloudflare caches these, as it usually won't cache .json
+      // reminder: the funky .json.js exstension is to ensure that Cloudflare caches these, as it usually won't cache .json
       fs.writeFileSync(
         `${footnotes_dir}/fn_${lang}_${subj_id}.json.js`,
         file_str

--- a/client/src/models/populate_footnotes.js
+++ b/client/src/models/populate_footnotes.js
@@ -94,7 +94,7 @@ function load_footnotes_bundle(subject){
     return Promise.resolve();
   }
 
-  // reminder: the fucky .json.js exstension is to ensure that Cloudflare caches these, as it usually won't cache .json
+  // reminder: the funky .json.js exstension is to ensure that Cloudflare caches these, as it usually won't cache .json
   return make_request(get_static_url(`footnotes/fn_${lang}_${subject_code}.json.js`))
     .then( csv_str => {
       populate_footnotes_info(csv_str);

--- a/client/src/models/populate_stores.js
+++ b/client/src/models/populate_stores.js
@@ -324,7 +324,7 @@ function process_lookups(data){
 };
 
 export const populate_stores = function(){
-  // reminder: the fucky .json.js exstension is to ensure that Cloudflare caches these, as it usually won't cache .json
+  // reminder: the funky .json.js exstension is to ensure that Cloudflare caches these, as it usually won't cache .json
   return make_request(get_static_url(`lookups_${window.lang}.json.js`))
     .then( text => {
       process_lookups(JSON.parse(text));


### PR DESCRIPTION
Cloudflare doesn't compress `text/csv`.  Set the `Content-Type` of all our csv's to `text/plain` in the google bucket and now we've got them compressing. Tested on the gov finance infographic and had a total transferred savings of 0.7 mb (27% reduction) :tada: 