### PR TITLE
sanitize urls that might have http or https in them

### DIFF
--- a/client/src/general_utils.js
+++ b/client/src/general_utils.js
@@ -28,7 +28,6 @@ export const make_unique_func = function(){
   };
 };
 
-
 // <div id='make_unique'></div>
 // consider replacing with _.uniqueId
 export const make_unique = make_unique_func();
@@ -140,3 +139,5 @@ export const SafeJSURL = {
   stringify: (json) => make_jsurl_safe( JSURL.stringify(json) ),
   tryParse: (safe_jsurl_string) => JSURL.tryParse( pre_parse_safe_jsurl(safe_jsurl_string) ),
 };
+
+export const generate_href = (url) => url.startsWith('http') ? url : `https://${url}`;

--- a/client/src/panels/igoc/igoc_panel.js
+++ b/client/src/panels/igoc/igoc_panel.js
@@ -11,7 +11,10 @@ const {
   ExternalLink,
 } = util_components;
 
-const { sanitized_dangerous_inner_html } = general_utils;
+const {
+  sanitized_dangerous_inner_html,
+  generate_href,
+} = general_utils;
 
 
 export const declare_igoc_fields_panel = () => declare_panel({
@@ -33,8 +36,8 @@ export const declare_igoc_fields_panel = () => declare_panel({
           ["previously_named", subject.old_name],
           ["incorp_yr", subject.incorp_yr],
           ["type", subject.type],
-          ["website", !subject.is_dead && subject.website_url && <ExternalLink href={`https://${subject.website_url}`} display={subject.website_url} />],
-          ["eval_links", !subject.is_dead && subject.eval_url && <ExternalLink href={`https://${subject.eval_url}`} display={subject.eval_url} />],
+          ["website", !subject.is_dead && subject.website_url && <ExternalLink href={generate_href(subject.website_url)} display={subject.website_url} />],
+          ["eval_links", !subject.is_dead && subject.eval_url && <ExternalLink href={generate_href(subject.eval_url)} display={subject.eval_url} />],
           ["minister", !_.isEmpty(subject.minister) && _.chain(subject.minister).flatMap( (minister, ix) => [minister, <br key={ix} />]).dropRight().value()],
           ["mandate", subject.mandate && <div dangerouslySetInnerHTML={sanitized_dangerous_inner_html(subject.mandate)}/>],
           ["legislation", subject.legislation && <ExternalLink href={`https://google.com/search?q=${encodeURI(subject.legislation)}`} display={subject.legislation} />],


### PR DESCRIPTION
Fixes #227 

Partially a data issue, but I don't think it's safe to assume that data urls will be guaranteed to be a particular form (also, possible that some don't work with https so we'd want to force http in those cases)