### PR TITLE
CircleCI reorg

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -260,8 +260,6 @@ jobs:
       - run: (cd client && ./deploy_scripts/push_to_gcloud_bucket.sh)
 
 
-# One workflow that runs all three jobs (build -> test -> deploy_data/server/client), each requiring the previous to have passed
-# Note that deploy steps are filtered by branch to only run on master
 workflows:
   version: 2
   test_email_backend:


### PR DESCRIPTION
Split test_email_backend and cleanup_dev_dbs in to their own CI workflows, give us clearer failure notifications.