### PR TITLE
API logging improvements

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -2107,6 +2107,11 @@
       "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
       "dev": true
     },
+    "charenc": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+      "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc="
+    },
     "chokidar": {
       "version": "2.1.8",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
@@ -2465,6 +2470,11 @@
         "shebang-command": "^1.2.0",
         "which": "^1.2.9"
       }
+    },
+    "crypt": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+      "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs="
     },
     "crypto-random-string": {
       "version": "1.0.0",
@@ -4554,8 +4564,7 @@
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "dev": true
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
     },
     "is-callable": {
       "version": "1.1.4",
@@ -6130,6 +6139,16 @@
       "dev": true,
       "requires": {
         "object-visit": "^1.0.0"
+      }
+    },
+    "md5": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/md5/-/md5-2.2.1.tgz",
+      "integrity": "sha1-U6s41f48iJG6RlMp6iP6wFQBJvk=",
+      "requires": {
+        "charenc": "~0.0.1",
+        "crypt": "~0.0.1",
+        "is-buffer": "~1.1.1"
       }
     },
     "media-typer": {

--- a/server/package.json
+++ b/server/package.json
@@ -23,6 +23,7 @@
     "graphql-tools": "^2.24.0",
     "lodash": "^4.17.15",
     "lz-string": "^1.4.4",
+    "md5": "^2.2.1",
     "mongoose": "^5.7.1"
   },
   "devDependencies": {

--- a/server/src/app.js
+++ b/server/src/app.js
@@ -5,6 +5,7 @@ import compression from 'compression';
 import cors from 'cors';
 import depthLimit from 'graphql-depth-limit';
 import { decompressFromBase64 } from 'lz-string';
+import md5 from 'md5';
 
 import {
   create_models,
@@ -40,12 +41,14 @@ const log_query = (req) => {
         req.headers.origin
       } \nrequest_method: ${
         request_method
-      } \nquery: ${
-        request_content.query
-      }${
+      } ${
         !_.isEmpty(request_content.variables) ? 
           `\nvariables: ${JSON.stringify(request_content.variables)}` : 
           ''
+      } \nquery_hash: ${ // Include a hash because the query itself can be longer than the (undocumented?) stackdriver textPayload limit
+        md5(request_content.query)
+      } \nquery: ${ // put the query at the bottom of the textPayload so it doesn't push anything else out if its length causes a cut-off
+        request_content.query
       }`
     );
 };


### PR DESCRIPTION
Closes #237

- [x] add information about the initiating request (post, get, or the client's special get requests)
- [x] some logs seem to be larger than google's limit (didn't know they had one? check that)
  - can't find any information about a limit. Note that google's logging API is [stackdriver](https://cloud.google.com/logging/docs/reference/v2/rest/). We've been using it via `console.log` which generates a basic LogEntry with the console-logged content in its textPayload field. If we were using a stackdriver library or otherwise leveraging more of its API, we could be uploading queries as JSON instead of text, but I don't know if that would have the same apparent length limit problem
  - well, for now just mitigating the cut-off by making sure nothing is logged after the query and by including a hash of the full query above that