### PR TITLE
Status badge consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![CircleCI](https://circleci.com/gh/TBS-EACPD/infobase.svg?style=svg)](https://circleci.com/gh/TBS-EACPD/infobase)
+[![CircleCI](https://circleci.com/gh/TBS-EACPD/infobase.svg?style=shield](https://circleci.com/gh/TBS-EACPD/infobase)
 
 *(Le Français suit)*
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-*(Le Français suit)*
-
 [![CircleCI](https://circleci.com/gh/TBS-EACPD/infobase.svg?style=svg)](https://circleci.com/gh/TBS-EACPD/infobase)
+
+*(Le Français suit)*
 
 # InfoBase Mono-Repo
 

--- a/client/README.md
+++ b/client/README.md
@@ -1,4 +1,4 @@
-[![CircleCI](https://circleci.com/gh/TBS-EACPD/infobase.svg?style=svg)](https://circleci.com/gh/TBS-EACPD/infobase)
+[![CircleCI](https://circleci.com/gh/TBS-EACPD/infobase.svg?style=shield)](https://circleci.com/gh/TBS-EACPD/infobase)
 
 *(le Français suit)*
 

--- a/client/README.md
+++ b/client/README.md
@@ -1,25 +1,23 @@
+[![CircleCI](https://circleci.com/gh/TBS-EACPD/infobase.svg?style=svg)](https://circleci.com/gh/TBS-EACPD/infobase)
+
 *(le Français suit)*
 
 GC InfoBase
 ========
-
-[![CircleCI](https://circleci.com/gh/TBS-EACPD/infobase.svg?style=svg)](https://circleci.com/gh/TBS-EACPD/infobase)
 
 Client-side code and content for the GC InfoBase. / Code et contenu pour le côté client de l'InfoBase du GC.
 
 *(Le Français suit)*
 
 ## Table of Contents
-- [GC InfoBase](#GC-InfoBase)
-  - [Table of Contents](#Table-of-Contents)
-  - [Getting Started](#Getting-Started)
-    - [First time setup](#First-time-setup)
-    - [Building the InfoBase](#Building-the-InfoBase)
-    - [Visiting a local build](#Visiting-a-local-build)
-  - [Tests](#Tests)
-    - [Browser tests](#Browser-tests)
-      - [Route load tests](#Route-load-tests)
-
+- [GC InfoBase](#gc-infobase)
+  - [Getting Started](#getting-started)
+    - [First time setup](#first-time-setup)
+    - [Building the InfoBase](#building-the-infobase)
+    - [Visiting a local build](#visiting-a-local-build)
+  - [Tests](#tests)
+    - [Browser tests](#browser-tests)
+      - [Route load tests](#route-load-tests)
 
 ## Getting Started
 
@@ -64,15 +62,14 @@ InfoBase du GC
 
 ## Table des matières 
 
-- [InfoBase du GC](#InfoBase-du-GC)
-  - [Table des matières](#Table-des-matières)
-  - [Commencer](#Commencer)
-    - [Première installation](#Première-installation)
-    - [Lancez la compilation de l'InfoBase](#Lancez-la-compilation-de-lInfoBase)
-    - [Visitez une copie locale](#Visitez-une-copie-locale)
-  - [Tests](#Tests-1)
-    - [Tests de navigateur](#Tests-de-navigateur)
-      - [Tests de chargement](#Tests-de-chargement)
+- [InfoBase du GC](#infobase-du-gc)
+  - [Commencer](#commencer)
+    - [Première installation](#premi%c3%a8re-installation)
+    - [Lancez la compilation de l'InfoBase](#lancez-la-compilation-de-linfobase)
+    - [Visitez une copie locale](#visitez-une-copie-locale)
+  - [Tests](#tests-1)
+    - [Tests de navigateur](#tests-de-navigateur)
+      - [Tests de chargement](#tests-de-chargement)
 
 ## Commencer
 

--- a/email_backend/README.md
+++ b/email_backend/README.md
@@ -1,7 +1,7 @@
+[![CircleCI](https://circleci.com/gh/TBS-EACPD/infobase.svg?style=svg)](https://circleci.com/gh/TBS-EACPD/infobase)
+
 Email Server
 =======
-
-[![CircleCI](https://circleci.com/gh/TBS-EACPD/infobase.svg?style=svg)](https://circleci.com/gh/TBS-EACPD/infobase)
 
 Google Cloud Function email backend. More user-friendly and secure/configurable than a mail-to link. Acts as a source of email templates for use in the front end, validates completed email templates received from the front-end, and sends valid, formatted, emails on to recipient email accounts. The backend sending/receiving emails remain unknown to the client submitting the email, to protect both the client's identity and our inboxes from spam. Also has mitigations in place for attempts to spam the receiving address through the send email API.
 

--- a/email_backend/README.md
+++ b/email_backend/README.md
@@ -1,4 +1,4 @@
-[![CircleCI](https://circleci.com/gh/TBS-EACPD/infobase.svg?style=svg)](https://circleci.com/gh/TBS-EACPD/infobase)
+[![CircleCI](https://circleci.com/gh/TBS-EACPD/infobase.svg?style=shield)](https://circleci.com/gh/TBS-EACPD/infobase)
 
 Email Server
 =======

--- a/server/README.md
+++ b/server/README.md
@@ -1,36 +1,35 @@
+[![CircleCI](https://circleci.com/gh/TBS-EACPD/infobase.svg?style=svg)](https://circleci.com/gh/TBS-EACPD/infobase)
+
 *(le Français suit)*
 
 InfoBase API
 ========
 
-[![CircleCI](https://circleci.com/gh/TBS-EACPD/infobase.svg?style=svg)](https://circleci.com/gh/TBS-EACPD/infobase)
-
 GraphQL API for InfoBase data.
 
 ## Table of Contents
-- [InfoBase API](#InfoBase-API)
-  - [Table of Contents](#Table-of-Contents)
-  - [Getting started](#Getting-started)
-    - [Running the API server locally](#Running-the-API-server-locally)
-  - [Tests](#Tests)
-    - [Snapshot tests](#Snapshot-tests)
-  - [File structure](#File-structure)
+- [InfoBase API](#infobase-api)
+  - [Getting started](#getting-started)
+    - [Running the API server locally](#running-the-api-server-locally)
+  - [Tests](#tests)
+    - [Snapshot tests](#snapshot-tests)
+  - [File structure](#file-structure)
     - [models/](#models)
-  - [Cloud stuff](#Cloud-stuff)
-    - [Mongodb Atlas](#Mongodb-Atlas)
-    - [Google Cloud Function](#Google-Cloud-Function)
+  - [Cloud stuff](#cloud-stuff)
+    - [Mongodb Atlas](#mongodb-atlas)
+    - [Google Cloud Function](#google-cloud-function)
 
 
 ## Getting started
 
 ### Running the API server locally
-0. Install node ^9.0.0, npm ^5.7.1, and mongo
-1. run `mongod` in the background/a spare shell
-2. open a shell in `/server`
-3. `npm ci` to load the required node_modules
-4. `npm run populate_db` to populate a local mongo database (named `infobase`). Can be left running to watch for changes in `../data`
-5. `npm start` to start the express/GraphQL server listening on `localhost:1337`. Watches for changes in `src`
-6. Optional: visit `http://localhost:1337` for a GraphiQL instance, test some queries
+1. Install node ^9.0.0, npm ^5.7.1, and mongo
+2. run `mongod` in the background/a spare shell
+3. open a shell in `/server`
+4. `npm ci` to load the required node_modules
+5. `npm run populate_db` to populate a local mongo database (named `infobase`). Can be left running to watch for changes in `../data`
+6. `npm start` to start the express/GraphQL server listening on `localhost:1337`. Watches for changes in `src`
+7. Optional: visit `http://localhost:1337` for a GraphiQL instance, test some queries
 
 ## Tests
 
@@ -63,17 +62,14 @@ The production environment for the express/GraphQL server is a Google Cloud Func
 L'interface de programmation d'applications (API) de l'InfoBase
 ========
 
-[![CircleCI](https://circleci.com/gh/TBS-EACPD/InfoBase.svg?style=svg&circle-token=a99b6b8309e5edd904b0386c4a92c10bf5f43e29)](https://circleci.com/gh/TBS-EACPD/InfoBase)
-
 Une interface de programmation d'applications GraphQL pour les données de l'InfoBase.
 
 ## Table des matières
-- [l'interface de programmation d'applications (API) de l'InfoBase](#linterface-de-programmation-dapplications-api-de-linfobase)
-  - [Table des matières](#table-des-matières)
+- [L'interface de programmation d'applications (API) de l'InfoBase](#linterface-de-programmation-dapplications-api-de-linfobase)
   - [Commencer](#commencer)
     - [Lancer le serveur de l'API](#lancer-le-serveur-de-lapi)
   - [Tests](#tests-1)
-    - [Tests «Snapshot»](#tests--snapshot-)
+    - [Tests « Snapshot »](#tests-%c2%ab-snapshot-%c2%bb)
   - [Structure des fichiers](#structure-des-fichiers)
     - [fichier models/](#fichier-models)
   - [Outils infonuagiques](#outils-infonuagiques)
@@ -84,13 +80,13 @@ Une interface de programmation d'applications GraphQL pour les données de l'Inf
 
 ### Lancer le serveur de l'API
 
-0. Installez node ^9.0.0, npm ^5.7.1, et mongo
-1. Lancez `mongod` avec un commande d'exécution supplémentaire ou en arrière-plan
-2. Lancez un commande d'exécution à le fichier `/server`
-3. `npm ci` pour installer les node_modules nécessitées
-4. `npm run populate_db` pour peupler une base de données mongo (au nom `infobase`). Peut être laissé regardant aux changements dans le fichier `../data`
-5. `npm start` pour lancer le serveur express/GraphQL qui entend à `localhost:1337`. Ce processus détecte les changements au fichier `src`
-6. Facultatif: visitez `http://localhost:1337`, où se trouve une instance GraphiQL, pour tester quelques requêtes
+1. Installez node ^9.0.0, npm ^5.7.1, et mongo
+2. Lancez `mongod` avec un commande d'exécution supplémentaire ou en arrière-plan
+3. Lancez un commande d'exécution à le fichier `/server`
+4. `npm ci` pour installer les node_modules nécessitées
+5. `npm run populate_db` pour peupler une base de données mongo (au nom `infobase`). Peut être laissé regardant aux changements dans le fichier `../data`
+6. `npm start` pour lancer le serveur express/GraphQL qui entend à `localhost:1337`. Ce processus détecte les changements au fichier `src`
+7. Facultatif: visitez `http://localhost:1337`, où se trouve une instance GraphiQL, pour tester quelques requêtes
 
 ## Tests
 

--- a/server/README.md
+++ b/server/README.md
@@ -1,4 +1,4 @@
-[![CircleCI](https://circleci.com/gh/TBS-EACPD/infobase.svg?style=svg)](https://circleci.com/gh/TBS-EACPD/infobase)
+[![CircleCI](https://circleci.com/gh/TBS-EACPD/infobase.svg?style=shield)](https://circleci.com/gh/TBS-EACPD/infobase)
 
 *(le Français suit)*
 


### PR DESCRIPTION
All of the README files have the same CircleCI badge in them, but they were not consistent (some files had them once at the top, others twice under both language section's header). Moved them all to the top of file.

Also switched them from the default style to the "shield" style, because I think it looks better and, since it uses text instead of their logo, is more understandable to anyone not familiar with CircleCI.