### PR TITLE
Enable and tweak GitHub link in about page text

### DIFF
--- a/client/src/about/about.yaml
+++ b/client/src/about/about.yaml
@@ -219,7 +219,7 @@ behind_scenes_sub_text_3:
     {{ext_link "Apache license version 2.0" "https://www.apache.org/licenses/LICENSE-2.0"}}, or © {{ext_link "The Wikimedia Foundation, Inc" "https://commons.wikimedia.org/wiki/Main_Page"}}, licensed 
     under the {{ext_link "MIT license" "https://opensource.org/licenses/MIT"}}.
   fr: |
-    Vous pouvez trouver le code source du InfoBase du GC {{ext_link "à GitHub" "https://github.com/TBS-EACPD/infobase"}}.
+    Vous pouvez trouver le code source du l'InfoBase du GC {{ext_link "sur GitHub" "https://github.com/TBS-EACPD/infobase"}}.
     
     Sauf indication contraire, le code source de ce projet est protégé par le droit d'auteur de la Couronne du gouvernement du Canada et distribué 
     sous la {{ext_link "licence MIT" "https://github.com/TBS-EACPD/infobase/blob/master/LICENSE"}}.

--- a/client/src/about/about.yaml
+++ b/client/src/about/about.yaml
@@ -212,14 +212,14 @@ behind_scenes_sub_text_3:
 
     The Canada wordmark and related graphics associated with this distribution are protected under trademark law and copyright law. No permission is granted to use them outside the
     parameters of the Government of Canada's corporate identity program. For more information, see
-    {{ext_link "Federal identity requirements" "https://www.canada.ca/en/treasury-board-secretariat/topics/government-communications/federal-identity-requirements.html"}}.{{/if}}
+    {{ext_link "Federal identity requirements" "https://www.canada.ca/en/treasury-board-secretariat/topics/government-communications/federal-identity-requirements.html"}}.
 
     Certain icons are © {{ext_link "Font Awesome" "https://github.com/FortAwesome/Font-Awesome"}}, licensed under 
     {{ext_link "CC BY 4.0 License" "https://creativecommons.org/licenses/by/4.0/"}}. Others are from {{ext_link "Material Design" "https://material.io/"}} © Google Inc, licensed under
     {{ext_link "Apache license version 2.0" "https://www.apache.org/licenses/LICENSE-2.0"}}, or © {{ext_link "The Wikimedia Foundation, Inc" "https://commons.wikimedia.org/wiki/Main_Page"}}, licensed 
     under the {{ext_link "MIT license" "https://opensource.org/licenses/MIT"}}.
   fr: |
-    Vous pouvez trouver le code source de l'InfoBase du GC {{ext_link "à GitHub" "https://github.com/TBS-EACPD/infobase"}}.
+    Vous pouvez trouver le code source du InfoBase du GC {{ext_link "à GitHub" "https://github.com/TBS-EACPD/infobase"}}.
     
     Sauf indication contraire, le code source de ce projet est protégé par le droit d'auteur de la Couronne du gouvernement du Canada et distribué 
     sous la {{ext_link "licence MIT" "https://github.com/TBS-EACPD/infobase/blob/master/LICENSE"}}.
@@ -227,7 +227,7 @@ behind_scenes_sub_text_3:
     Le mot-symbole « Canada » et les éléments graphiques connexes liés à cette distribution sont protégés en vertu des lois portant sur les marques de commerce et le droit d'auteur.
     Aucune autorisation n'est accordée pour leur utilisation à l'extérieur des paramètres du programme de coordination de l'image de marque du gouvernement du Canada. Pour obtenir
     davantage de renseignements à ce sujet, veuillez consulter les
-    {{ext_link "Exigences pour l'image de marque" "https://www.canada.ca/fr/secretariat-conseil-tresor/sujets/communications-gouvernementales/exigences-image-marque.html"}}.{{/if}}
+    {{ext_link "Exigences pour l'image de marque" "https://www.canada.ca/fr/secretariat-conseil-tresor/sujets/communications-gouvernementales/exigences-image-marque.html"}}.
     
     Certaines icônes sont © {{ext_link "Font Awesome" "https://github.com/FortAwesome/Font-Awesome"}}, sous license {{ext_link "CC BY 4.0" "https://creativecommons.org/licenses/by/4.0/"}}.
     D'autres proviennent de {{ext_link "Material Design" "https://material.io/"}} © Google Inc, sous license {{ext_link "Apache version 2.0" "https://www.apache.org/licenses/LICENSE-2.0"}},

--- a/client/src/about/about.yaml
+++ b/client/src/about/about.yaml
@@ -205,7 +205,7 @@ behind_scenes_sub_title_3:
 behind_scenes_sub_text_3:
   transform: [handlebars, markdown]
   en: |
-    {{#if false}}You can find the source code {{ext_link "on GitHub" "https://github.com/TBS-EACPD/infobase"}}.
+    You can find the GC InfoBase source code {{ext_link "on GitHub" "https://github.com/TBS-EACPD/infobase"}}.
     
     Unless otherwise noted, the source code of this project is covered under Crown Copyright, Government of Canada, and is distributed under the
     {{ext_link "MIT License" "https://github.com/TBS-EACPD/infobase/blob/master/LICENSE"}}.
@@ -219,7 +219,7 @@ behind_scenes_sub_text_3:
     {{ext_link "Apache license version 2.0" "https://www.apache.org/licenses/LICENSE-2.0"}}, or © {{ext_link "The Wikimedia Foundation, Inc" "https://commons.wikimedia.org/wiki/Main_Page"}}, licensed 
     under the {{ext_link "MIT license" "https://opensource.org/licenses/MIT"}}.
   fr: |
-    {{#if false}}Vous pouvez trouver le code source à {{ext_link "GitHub" "https://github.com/TBS-EACPD/infobase"}}.
+    Vous pouvez trouver le code source de l'InfoBase du GC {{ext_link "à GitHub" "https://github.com/TBS-EACPD/infobase"}}.
     
     Sauf indication contraire, le code source de ce projet est protégé par le droit d'auteur de la Couronne du gouvernement du Canada et distribué 
     sous la {{ext_link "licence MIT" "https://github.com/TBS-EACPD/infobase/blob/master/LICENSE"}}.

--- a/client/src/partition/budget_measures_subapp/BudgetMeasuresA11yContent.yaml
+++ b/client/src/partition/budget_measures_subapp/BudgetMeasuresA11yContent.yaml
@@ -10,7 +10,7 @@ budget_measure_a11y_table_open_data_link:
     For access to all available data, down to the lowest level, visit the {{ext_link "GC InfoBase Open Data Page" "https://open.canada.ca/data/en/dataset/a35cf382-690c-4221-a971-cf0fd189a46f"}}.
   fr: |
     Ce tableau donne un aperçu des décisions relatives au financement du budget de {{budget_year}}. Pour avoir accès à toutes les données disponibles, jusqu'au niveau le plus bas, 
-    consultez {{ext_link "la page de données ouvertes du InfoBase du GC" "https://ouvert.canada.ca/data/fr/dataset/a35cf382-690c-4221-a971-cf0fd189a46f"}}.
+    consultez {{ext_link "la page de données ouvertes du l'InfoBase du GC" "https://ouvert.canada.ca/data/fr/dataset/a35cf382-690c-4221-a971-cf0fd189a46f"}}.
 
 
 budget_measure_descriptions:


### PR DESCRIPTION
Made a small change in both English and French while enabling that text, can someone spot my French? Thanks!