### PR TITLE
Clarify version link

### DIFF
--- a/client/src/components/PageDetails.js
+++ b/client/src/components/PageDetails.js
@@ -20,8 +20,8 @@ class VersionNumber extends React.Component {
   render(){
     return (
       <span>
-        { text_maker("infobase_version_number") }
-        <ExternalLink href={github_link} title={text_maker("infobase_release_link_title")}>
+        { text_maker("infobase_version") }
+        <ExternalLink href={github_link} title={text_maker("infobase_version_link_title")}>
           { ` ${window.sha} ` }
           <IconGitHub inline={true} />
         </ExternalLink>

--- a/client/src/components/PageDetails.js
+++ b/client/src/components/PageDetails.js
@@ -21,7 +21,7 @@ class VersionNumber extends React.Component {
     return (
       <span>
         { text_maker("infobase_version_number") }
-        <ExternalLink href={github_link}>
+        <ExternalLink href={github_link} title={text_maker("infobase_release_link_title")}>
           { ` ${window.sha} ` }
           <IconGitHub inline={true} />
         </ExternalLink>

--- a/client/src/components/PageDetails.yaml
+++ b/client/src/components/PageDetails.yaml
@@ -8,6 +8,10 @@ infobase_version_number:
   fr: |
     Numéro de version:
 
+infobase_release_link_title:
+  en: Change log for current release
+  fr: TODO
+
 infobase_build_date:
   transform: [handlebars]
   en: (built {{build_date}})

--- a/client/src/components/PageDetails.yaml
+++ b/client/src/components/PageDetails.yaml
@@ -10,7 +10,7 @@ infobase_version:
 
 infobase_version_link_title:
   en: Change log for the current version
-  fr: TODO
+  fr: Journal des modifications pour la version actuelle
 
 infobase_build_date:
   transform: [handlebars]

--- a/client/src/components/PageDetails.yaml
+++ b/client/src/components/PageDetails.yaml
@@ -2,14 +2,14 @@ report_a_problem:
   en: Report a problem or mistake on this page
   fr: Signaler un problème ou une erreur sur cette page
 
-infobase_version_number:
+infobase_version:
   en: |
-    Version number:
+    Version:
   fr: |
-    Numéro de version:
+    Version:
 
-infobase_release_link_title:
-  en: Change log for current release
+infobase_version_link_title:
+  en: Change log for the current version
   fr: TODO
 
 infobase_build_date:

--- a/client/src/components/misc_util_components.js
+++ b/client/src/components/misc_util_components.js
@@ -13,7 +13,7 @@ import { TextMaker, TM } from './TextMaker.js';
 
 // Misc. utility components that don't justify having their own file in ./components, for various reasons
 
-const ExternalLink = ({children, href}) => <a target="_blank" rel="noopener noreferrer" href={href}>{children}</a>;
+const ExternalLink = ({children, href, title}) => <a target="_blank" rel="noopener noreferrer" href={href} title={title}>{children}</a>;
 
 function lang(obj){ return obj[window.lang] || obj.text || ""; }
 


### PR DESCRIPTION
"Version number" felt clunky now that it's a link to a change log and not just a vague identifier. Tweaked the wording and added a title to the link explaining what's linked to, since it's going to be a bit surprising to get thrown in to a git diff for the average user.