### PR TITLE
Add lab landing page and text diff tool to route load test config

### DIFF
--- a/client/browser-tests/route-load-tests-config.js
+++ b/client/browser-tests/route-load-tests-config.js
@@ -190,4 +190,14 @@ module.exports.route_load_tests_config = [
     route: "resource-explorer",
     test_on: ["eng", "basic-eng"],
   },
+  {
+    name: "Data Lab landing page",
+    route: "lab",
+    test_on: ["eng", "basic-eng"],
+  },
+  {
+    name: "Indicator text comparison - TBS",
+    route: "diff/326",
+    test_on: ["eng", "basic-eng"],
+  },
 ];

--- a/client/browser-tests/route-load-tests-config.js
+++ b/client/browser-tests/route-load-tests-config.js
@@ -191,7 +191,7 @@ module.exports.route_load_tests_config = [
     test_on: ["eng", "basic-eng"],
   },
   {
-    name: "Data Lab landing page",
+    name: "InfoLab landing page",
     route: "lab",
     test_on: ["eng", "basic-eng"],
   },


### PR DESCRIPTION
Never updated the route load test config with these pages, would have surfaced that error I introduced last Thursday if we had. Ouch.