### PR TITLE
add new badge to results explorer

### DIFF
--- a/client/src/common_css/_common-variables.scss
+++ b/client/src/common_css/_common-variables.scss
@@ -21,6 +21,9 @@ $linkColor: #2b4380;
 $linkFocusColor: #0535d2;
 $linkVisitedColor: #7834bc;
 
+$highlightPaleColor: #ffa8a8;
+$highlightDarkColor: #B12320;
+
 
 /*media breakpoints, default to min-width queries whenever possible*/
 /*keep ../core/breakpoint_defs.js in sync with these*/
@@ -38,7 +41,7 @@ $maxLargeDevice: 1199px;
 /* dark and light colours don't have enough contrast between them for text, so don't use them that way! Use black text on light, or (check contrast) white text on dark*/
 $successLightColor: #cbedbd;
 $successDarkColor: #45a64d;
-$failLightColor: #ffa8a8;
+$failLightColor: $highlightPaleColor;
 $failDarkColor: $highlightColor;
 $warnLightColor: #ffecce;
 $warnDarkColor: #fdb84c;

--- a/client/src/common_text/result_lang.yaml
+++ b/client/src/common_text/result_lang.yaml
@@ -11,9 +11,6 @@ indicator:
   en: Indicator
   fr: Indicateur
 
-new_indicator:
-  en: New indicator
-  fr: Nouvel indicateur
 
 indicators:
   en: Indicators

--- a/client/src/panels/result_graphs/result_components.js
+++ b/client/src/panels/result_graphs/result_components.js
@@ -136,19 +136,7 @@ const IndicatorResultDisplay = ({
     }
   };
 
-  const should_display_new_status = _.indexOf(dp_docs, doc) > 0 || _.indexOf(drr_docs, doc) > 0;
-  return (
-    <Fragment>
-      { get_display_case(data_type, min, max, narrative, measure) }
-      { should_display_new_status && is_new &&
-        <Fragment>
-          {" ("}
-          <TM k="new_indicator" el="strong" />
-          {")"}
-        </Fragment>
-      }
-    </Fragment>
-  );
+  return get_display_case(data_type, min, max, narrative, measure);
 };
 
 const Drr17IndicatorResultDisplay = ({
@@ -276,6 +264,7 @@ const SingleIndicatorDisplay = ({indicator}) => {
   const is_drr = /drr/.test(indicator.doc);
   const has_previous_year_target = !_.isNull(indicator.previous_year_target_type);
   const has_previous_year_result = false; // DRR_TODO: previous year results aren't in the API right now, but they probably will be for DRR18 (if not, clean this out)
+  const should_display_new_status = _.indexOf(dp_docs, indicator.doc) > 0 || _.indexOf(drr_docs, indicator.doc) > 0;
   return (
     <div className="indicator-item">
       <dl className="dl-horizontal indicator-item__dl">
@@ -296,7 +285,7 @@ const SingleIndicatorDisplay = ({indicator}) => {
         </dt>
         <dd>
           {indicator.name}
-          {!_.includes(["drr17", "dp18"],indicator.doc) && _.isNull(indicator.previous_year_target_type) && <NewBadge/>}
+          {should_display_new_status && _.isNull(indicator.previous_year_target_type) && <NewBadge/>}
         </dd>
 
         <dt>

--- a/client/src/panels/result_graphs/result_components.js
+++ b/client/src/panels/result_graphs/result_components.js
@@ -803,7 +803,7 @@ class HorizontalStatusTable extends React.Component {
 
 const NewBadge = () => {
   return (
-    <span className="results-new-badge">
+    <span className="badge badge--is-new-indicator">
       {text_maker("new")}
     </span>
   );

--- a/client/src/panels/result_graphs/result_components.js
+++ b/client/src/panels/result_graphs/result_components.js
@@ -275,7 +275,7 @@ const IndicatorList = ({ indicators }) => (
 const SingleIndicatorDisplay = ({indicator}) => {
   const is_drr = /drr/.test(indicator.doc);
   const has_previous_year_target = !_.isNull(indicator.previous_year_target_type);
-  const has_previous_year_result = false; // previous year results aren't in the API right now, but they probably will be for DRR18 (if not, clean this out)
+  const has_previous_year_result = false; // DRR_TODO: previous year results aren't in the API right now, but they probably will be for DRR18 (if not, clean this out)
   return (
     <div className="indicator-item">
       <dl className="dl-horizontal indicator-item__dl">
@@ -296,6 +296,7 @@ const SingleIndicatorDisplay = ({indicator}) => {
         </dt>
         <dd>
           {indicator.name}
+          {!_.includes(["drr17", "dp18"],indicator.doc) && _.isNull(indicator.previous_year_target_type) && <NewBadge/>}
         </dd>
 
         <dt>
@@ -811,6 +812,14 @@ class HorizontalStatusTable extends React.Component {
   }
 }
 
+const NewBadge = () => {
+  return (
+    <span className="results-new-badge">
+      {text_maker("new")}
+    </span>
+  );
+}
+
 export {
   IndicatorDisplay,
   QuadrantDefList,
@@ -819,4 +828,5 @@ export {
   StatusIconTable,
   InlineStatusIconList,
   HorizontalStatusTable,
+  NewBadge,
 }; 

--- a/client/src/panels/result_graphs/result_drilldown.yaml
+++ b/client/src/panels/result_graphs/result_drilldown.yaml
@@ -110,3 +110,7 @@ generic_explanation:
 target_explanation:
   en: Target explanation
   fr: Explication de la cible
+
+new:
+  en: New
+  fr: Noveau

--- a/client/src/panels/result_graphs/result_drilldown.yaml
+++ b/client/src/panels/result_graphs/result_drilldown.yaml
@@ -110,7 +110,3 @@ generic_explanation:
 target_explanation:
   en: Target explanation
   fr: Explication de la cible
-
-new:
-  en: New
-  fr: Noveau

--- a/client/src/panels/result_graphs/results.scss
+++ b/client/src/panels/result_graphs/results.scss
@@ -146,16 +146,9 @@ dl.indicator-item__dl dt+dd {
   margin: 0px;
 }
 
-.results-new-badge {
-  border-radius: 10px;
-  background-color: $highlightColor;
-  padding-top: 2px;
-  padding-bottom: 2px;
-  padding-left: 5px;
-  padding-right: 5px;
-  margin-left: 5px;
-  vertical-align: 2px;
+.badge.badge--is-new-indicator {
   font-size: 9pt;
+  margin-left: 5px;
+  background-color: $highlightColor;
   color: $backgroundColor;
-  font-weight: 400;
 }

--- a/client/src/panels/result_graphs/results.scss
+++ b/client/src/panels/result_graphs/results.scss
@@ -147,7 +147,7 @@ dl.indicator-item__dl dt+dd {
 }
 
 .badge.badge--is-new-indicator {
-  font-size: 9pt;
+  font-size: 12px;
   margin-left: 5px;
   background-color: $highlightColor;
   color: $backgroundColor;

--- a/client/src/panels/result_graphs/results.scss
+++ b/client/src/panels/result_graphs/results.scss
@@ -145,3 +145,17 @@ dl.indicator-item__dl dt+dd {
 .status-icon-table--met-icon, .status-icon-table--not-met-icon, .status-icon-table--na-icon, .status-icon-table--future-icon {
   margin: 0px;
 }
+
+.results-new-badge {
+  border-radius: 10px;
+  background-color: $highlightColor;
+  padding-top: 2px;
+  padding-bottom: 2px;
+  padding-left: 5px;
+  padding-right: 5px;
+  margin-left: 5px;
+  vertical-align: 2px;
+  font-size: 9pt;
+  color: $backgroundColor;
+  font-weight: 400;
+}

--- a/client/src/panels/result_graphs/results.scss
+++ b/client/src/panels/result_graphs/results.scss
@@ -151,4 +151,5 @@ dl.indicator-item__dl dt+dd {
   margin-left: 5px;
   background-color: $highlightColor;
   color: $backgroundColor;
+  vertical-align: 0.1em;
 }


### PR DESCRIPTION
As suggested in #235.

Looks like this:

![Screen Shot 2019-10-16 at 2 43 31 PM](https://user-images.githubusercontent.com/10406459/66948901-92449300-f023-11e9-9ce3-13b4a6dd6de7.png)
