### PR TITLE
Featured content refresh

### DIFF
--- a/client/src/home/home-data.js
+++ b/client/src/home/home-data.js
@@ -1,6 +1,10 @@
 
 const featured_content_items = _.compact([
   {
+    text_key: 'igoc',
+    href: '#igoc',
+  },
+  {
     text_key: 'quick_link_people_2019',
     href: '#orgs/gov/gov/infograph/people',
   },

--- a/client/src/home/home-data.js
+++ b/client/src/home/home-data.js
@@ -3,12 +3,10 @@ const featured_content_items = _.compact([
   {
     text_key: 'quick_link_people_2019',
     href: '#orgs/gov/gov/infograph/people',
-    is_new: true,
   },
   {
     text_key: 'quick_link_infolab',
     href: '#lab',
-    is_new: true,
   },
   {
     text_key: 'quick_link_budget_2019',


### PR DESCRIPTION
Haven't had a big data update in a while, but it was definitely time to remove the new badges from the people and lab links.

Might be a good time to break from "Featured Content" being primarily a list of recent updates. What should we specifically and intentionally feature?