### PR TITLE
Update GA cookie fields to satisfy upcoming Chrome changes

### DIFF
--- a/client/src/core/analytics.js
+++ b/client/src/core/analytics.js
@@ -33,7 +33,7 @@ const get_client_id = () => {
 function initialize_analytics(){
   const is_dev = String(window.location.hostname).indexOf("tbs-sct.gc.ca") === -1;
   
-  ga('create', 'UA-97024958-1', 'auto');
+  ga('create', 'UA-97024958-1', 'auto', {Secure: true, SameSite: 'None'});
   ga('set', 'anonymizeIp', true);
 
   ga(tracker => {


### PR DESCRIPTION
Closes #266 

Didn't need to update our old GA tags (good thing, those are shared with Comms so it would take some coordinating), just set the cookie fields as requested by the warning.  