### PR TITLE
Add names to client's API queries, include those names in API's logs

### DIFF
--- a/client/src/graphql_utils.js
+++ b/client/src/graphql_utils.js
@@ -20,7 +20,7 @@ const get_api_url = async () => {
       // Only give the query 1 second to respond before going to fallback.
       const controller = new AbortController();
       const id_for_test_timeout = setTimeout(() => controller.abort(), 1000);
-      api_url = await fetch(`${api_url}?query={ root(lang: "en") { non_field } }`, {signal: controller.signal})
+      api_url = await fetch(`${api_url}?query={ root(lang: "en") { non_field } }&query_name=dev_connection_test`, {signal: controller.signal})
         .then( (response ) => {
           clearTimeout(id_for_test_timeout);
           return api_url;

--- a/client/src/models/populate_budget_measures.js
+++ b/client/src/models/populate_budget_measures.js
@@ -83,7 +83,8 @@ export function api_load_subject_has_measures(subject, years){
 
   const time_at_request = Date.now();
   const client = get_client();
-  return client.query({ 
+  return client.query({
+    query_name: 'subject_has_measures',
     query,
     variables: {
       lang: window.lang,
@@ -250,7 +251,8 @@ export function api_load_budget_measures(subject, years){
 
   const time_at_request = Date.now();
   const client = get_client();
-  return client.query({ 
+  return client.query({
+    query_name: 'budget_measures',
     query,
     variables: {
       lang: window.lang, 

--- a/client/src/models/populate_budget_measures.js
+++ b/client/src/models/populate_budget_measures.js
@@ -84,11 +84,11 @@ export function api_load_subject_has_measures(subject, years){
   const time_at_request = Date.now();
   const client = get_client();
   return client.query({
-    query_name: 'subject_has_measures',
     query,
     variables: {
       lang: window.lang,
       id,
+      _query_name: 'subject_has_measures',
     },
   })
     .then( (response) => {
@@ -252,11 +252,11 @@ export function api_load_budget_measures(subject, years){
   const time_at_request = Date.now();
   const client = get_client();
   return client.query({
-    query_name: 'budget_measures',
     query,
     variables: {
       lang: window.lang, 
       id,
+      _query_name: 'budget_measures',
     },
   })
     .then( (response) => {

--- a/client/src/models/populate_results.js
+++ b/client/src/models/populate_results.js
@@ -43,7 +43,11 @@ export function subject_has_results(subject){
 
     const id_key = level === "org" ? "org_id" : "id";
 
-    return client.query({ query: has_results_query(level, id_key), variables: {lang: window.lang, id: id} })
+    return client.query({ 
+      query_name: `has_results`,
+      query: has_results_query(level, id_key), 
+      variables: {lang: window.lang, id: id},
+    })
       .then( (response) => {
         const resp_time = Date.now() - time_at_request;
 
@@ -399,6 +403,7 @@ export function api_load_results_bundle(subject, result_docs){
   const time_at_request = Date.now();
   const client = get_client();
   return client.query({ 
+    query_name: 'results_bundle',
     query,
     variables: {
       lang: window.lang, 
@@ -502,7 +507,11 @@ export function api_load_results_counts(level = "summary"){
   } else {
     const time_at_request = Date.now();
     const client = get_client();
-    return client.query({ query: load_results_counts_query(level), variables: {lang: window.lang} })
+    return client.query({
+      query_name: 'results_counts',
+      query: load_results_counts_query(level), 
+      variables: {lang: window.lang},
+    })
       .then( (response) => {
         const resp_time = Date.now() - time_at_request;
 

--- a/client/src/models/populate_results.js
+++ b/client/src/models/populate_results.js
@@ -43,10 +43,10 @@ export function subject_has_results(subject){
 
     const id_key = level === "org" ? "org_id" : "id";
 
-    return client.query({ 
-      query_name: `has_results`,
+    return client.query({
       query: has_results_query(level, id_key), 
       variables: {lang: window.lang, id: id},
+      _query_name: 'has_results',
     })
       .then( (response) => {
         const resp_time = Date.now() - time_at_request;
@@ -402,12 +402,12 @@ export function api_load_results_bundle(subject, result_docs){
 
   const time_at_request = Date.now();
   const client = get_client();
-  return client.query({ 
-    query_name: 'results_bundle',
+  return client.query({
     query,
     variables: {
       lang: window.lang, 
       id,
+      _query_name: 'results_bundle',
     },
   })
     .then( (response) => {
@@ -508,9 +508,11 @@ export function api_load_results_counts(level = "summary"){
     const time_at_request = Date.now();
     const client = get_client();
     return client.query({
-      query_name: 'results_counts',
       query: load_results_counts_query(level), 
-      variables: {lang: window.lang},
+      variables: {
+        lang: window.lang,
+        _query_name: 'results_counts',
+      },
     })
       .then( (response) => {
         const resp_time = Date.now() - time_at_request;

--- a/server/src/app.js
+++ b/server/src/app.js
@@ -45,6 +45,8 @@ const log_query = (req) => {
         !_.isEmpty(request_content.variables) ? 
           `\nvariables: ${JSON.stringify(request_content.variables)}` : 
           ''
+      } \nquery_name: ${
+        request_content.query_name
       } \nquery_hash: ${ // Include a hash because the query itself can be longer than the (undocumented?) stackdriver textPayload limit
         md5(request_content.query)
       } \nquery: ${ // put the query at the bottom of the textPayload so it doesn't push anything else out if its length causes a cut-off

--- a/server/src/app.js
+++ b/server/src/app.js
@@ -16,12 +16,16 @@ import { connect_db } from "./db_utils.js";
 
 const convert_get_with_compressed_query_to_post_request = (req) => {
   const decoded_decompressed_query = decompressFromBase64(req.headers['encoded-compressed-query']);
-  const [query, variables] = decoded_decompressed_query.split("&variables=");
+  const [query, mixed_variables] = decoded_decompressed_query.split("&variables=");
   
+  // Client should be throwing an additional variable, _query_name, in with the actual variables. Grab that out
+  const { _query_name, ...query_variables } = JSON.parse(mixed_variables);
+
   req.method = "POST";
   req.body = {
+    query_name: _query_name,
     query,
-    variables: JSON.parse(variables),
+    variables: query_variables,
     operationName: null,
   };
 };
@@ -41,12 +45,12 @@ const log_query = (req) => {
         req.headers.origin
       } \nrequest_method: ${
         request_method
+      } \nquery_name: ${
+        request_content.query_name
       } ${
         !_.isEmpty(request_content.variables) ? 
           `\nvariables: ${JSON.stringify(request_content.variables)}` : 
           ''
-      } \nquery_name: ${
-        request_content.query_name
       } \nquery_hash: ${ // Include a hash because the query itself can be longer than the (undocumented?) stackdriver textPayload limit
         md5(request_content.query)
       } \nquery: ${ // put the query at the bottom of the textPayload so it doesn't push anything else out if its length causes a cut-off


### PR DESCRIPTION
Close #247 

Query names are high level, the specifics of the query (subject etc) can always be found by looking at the logged variables.