### PR TITLE
Improve a11y/mobile of result_flat_table glossary link

### DIFF
--- a/client/src/panels/result_graphs/result_flat_table.js
+++ b/client/src/panels/result_graphs/result_flat_table.js
@@ -70,7 +70,7 @@ const subject_link = (node) => {
         {node.data.name}
         {` (${text_maker("a_masc")} `}
         <a
-          href={ (window.is_a11y_mode || window.feature_detection.is_mobile()) && glossary_href("SSP")}
+          href={window.is_a11y_mode && glossary_href("SSP")}
           className="nowrap glossary-tooltip-link"
           tabIndex={0}
           aria-hidden="true"

--- a/client/src/panels/result_graphs/result_flat_table.js
+++ b/client/src/panels/result_graphs/result_flat_table.js
@@ -6,7 +6,7 @@ import {
   HeightClippedGraph,
   breakpoints,
 } from '../shared.js';
-import { infograph_href_template } from '../../link_utils.js';
+import { infograph_href_template, glossary_href } from '../../link_utils.js';
 import { DisplayTable } from '../../components/DisplayTable.js';
 import { 
   ResultCounts,
@@ -69,7 +69,8 @@ const subject_link = (node) => {
       <span>
         {node.data.name}
         {` (${text_maker("a_masc")} `}
-        <span
+        <a
+          href={ (window.is_a11y_mode || window.feature_detection.is_mobile()) && glossary_href("SSP")}
           className="nowrap glossary-tooltip-link"
           tabIndex={0}
           aria-hidden="true"
@@ -79,7 +80,7 @@ const subject_link = (node) => {
           data-ibtt-container="body"
         >
           {text_maker(node.data.subject.level)}
-        </span>
+        </a>
         {` ${text_maker("of")} `}
         <a href={infograph_href_template(program,"results")}>
           {program_name}


### PR DESCRIPTION
Using the `data-ibtt-glossary-key` attribute on a `<span>` means it's not going to work on mobile or be accessible. Better to have it be an anchor with an href only for cases where you want it to actually be a link.

I checked the other uses of that key and they're all idiosyncratic. I don't love using the handlebars helpers for text so if I do this again I'll probably make a reusable function or component but for now this is the only case of it.