### PR TITLE
Actually fix the Chrome cookie warnings

### DIFF
--- a/client/src/core/analytics.js
+++ b/client/src/core/analytics.js
@@ -33,7 +33,7 @@ const get_client_id = () => {
 function initialize_analytics(){
   const is_dev = String(window.location.hostname).indexOf("tbs-sct.gc.ca") === -1;
   
-  ga('create', 'UA-97024958-1', 'auto', {Secure: true, SameSite: 'None'});
+  ga('create', 'UA-97024958-1', 'none', 'infobase_ga_cookie', {Secure: true, SameSite: 'None'});
   ga('set', 'anonymizeIp', true);
 
   ga(tracker => {


### PR DESCRIPTION
#286 didn't do it, my bad for testing in Chromium because it looks like those warnings are Chrome-only in the first place (at least right now).

There's another warning about a canada.ca cookie, haven't tracked the source of that one down yet, but might be google analytics/google tag manager related too.