### PR TITLE
Revert #286

### DIFF
--- a/client/src/core/analytics.js
+++ b/client/src/core/analytics.js
@@ -33,7 +33,7 @@ const get_client_id = () => {
 function initialize_analytics(){
   const is_dev = String(window.location.hostname).indexOf("tbs-sct.gc.ca") === -1;
   
-  ga('create', 'UA-97024958-1', 'auto', {Secure: true, SameSite: 'None'});
+  ga('create', 'UA-97024958-1', 'auto');
   ga('set', 'anonymizeIp', true);
 
   ga(tracker => {


### PR DESCRIPTION
I was misunderstanding the `ga` API, a skim reading of part of the documentation made me think I could pass in cookie fields with `ga('create', ...)`, but that is not the case.

Upon further investigation, the warnings discussed in #266 are out of our control (unless we want to get real hacky). Those cookies are created on a Google server and sent down to the client, and the API **doesn't** let us tell the backend what we want in the relevant fields. The fix will come in its own time when Google updates their service.