### PR TITLE
Take out previous year target for new indicators

### DIFF
--- a/client/src/common_text/result_lang.yaml
+++ b/client/src/common_text/result_lang.yaml
@@ -44,7 +44,6 @@ date_to_achieve:
   en: Date to achieve target
   fr: Date d’atteinte de la cible
 
-
 indicator_targets:
   en: Indicator Targets
   fr: Cibles des indicateurs

--- a/client/src/panels/result_graphs/result_components.js
+++ b/client/src/panels/result_graphs/result_components.js
@@ -192,16 +192,13 @@ const SingleIndicatorDisplay = ({indicator}) => {
           </Fragment>
         }
 
-        { could_have_previous_year_target &&
+        { has_previous_year_target &&
           <Fragment>
             <dt>
               <TM k="previous_year_target"/>
             </dt>
             <dd>
-              {has_previous_year_target ?
-                <IndicatorResultDisplay indicator={indicator} is_actual={false} is_drr17={indicator.doc === "drr17"} is_previous={true} /> :
-                <TM k="new_indicator" el="strong" />
-              }
+              <IndicatorResultDisplay indicator={indicator} is_actual={false} is_drr17={indicator.doc === "drr17"} is_previous={true} />
             </dd>
           </Fragment>
         }


### PR DESCRIPTION
Not sure how I missed this, but new indicators were also displaying "new indicator" in the previous target field. Possibly got clobbered in a rebase.