### PR TITLE
Fragile rpb links

### DIFF
--- a/client/src/EstimatesComparison/EstimatesComparison.js
+++ b/client/src/EstimatesComparison/EstimatesComparison.js
@@ -274,28 +274,25 @@ class EstimatesExplorer extends React.Component {
             marginBottom: "15px",
           }}
         >
-          <LabeledBox
-            label={ <TM k="choose_grouping_scheme"/> }
-            content={
-              <div className="centerer">
-                <RadioButtons
-                  options={[
-                    {
-                      id: "org",
-                      active: h7y_layout === "org",
-                      display: <TM k="by_org" />,
-                    },
-                    {
-                      id: "item_type",
-                      active: h7y_layout === "item_type",
-                      display: <TM k="by_item_type" />,
-                    },
-                  ]}
-                  onChange={ id => history.push(`/compare_estimates/${id}`) }
-                />
-              </div>
-            }
-          />
+          <LabeledBox label={<TM k="choose_grouping_scheme"/>}>
+            <div className="centerer">
+              <RadioButtons
+                options={[
+                  {
+                    id: "org",
+                    active: h7y_layout === "org",
+                    display: <TM k="by_org" />,
+                  },
+                  {
+                    id: "item_type",
+                    active: h7y_layout === "item_type",
+                    display: <TM k="by_item_type" />,
+                  },
+                ]}
+                onChange={ id => history.push(`/compare_estimates/${id}`) }
+              />
+            </div>
+          </LabeledBox>
         </div>
         <div>
           <form

--- a/client/src/TreeMap/TreeMapControls.js
+++ b/client/src/TreeMap/TreeMapControls.js
@@ -158,114 +158,93 @@ export class TreeMapControls extends React.Component {
     } = this.props;
     return (
       <div className="treemap-controls">
-        <TreeMapLabeledBox
-          label={text_maker("treemap_display_value_label")}
-          content={
-            <div className="cent">
-              <TreeMapRadioButtons
-                options={_.map(size_controls, ({ id, display }) => ({ id, display, active: id === perspective }))}
-                onChange={id => {this.handle_click("perspective",id);}}
-              />
-            </div>
-          }
-        />
-        <TreeMapLabeledBox
-          label={text_maker("year_format")}
-          content={
-            <div className="cent">
-              <TreeMapRadioButtons
-                options={[
-                  {
-                    id: "single_year",
-                    active: !get_changes,
-                    display: text_maker("single_year"),
-                  },
-                  {
-                    id: "year_changes",
-                    active: get_changes,
-                    display: text_maker("year_changes"),
-                  },
-                ]}
-                onChange={id => {this.handle_click("get_changes",id==="year_changes");}}
-              />
-            </div>
-          }
-        />
-        <TreeMapLabeledBox
-          label={text_maker("year")}
-          content={
-            <div className="cent">
-              <TreeMapRadioButtons
-                options={get_changes ?
-                  _.map(year_changes[perspective], (id => ({ 
-                    id, 
-                    display: `${run_template("{{" + id.split(":")[0] + "}}")} ${text_maker("to")} ${run_template("{{" + id.split(":")[1] + "}}")}`,
-                    active: id === year,
-                  }))) :
-                  _.map(years[perspective], (id => ({
-                    id,
-                    display: run_template("{{" + id + "}}"),
-                    active: id === year,
-                  })))
-                }
-                onChange={id => {this.handle_click("year",id);}}
-              />
-            </div>
-          }
-        />
+        <TreeMapLabeledBox label={text_maker("treemap_display_value_label")}>
+          <div className="cent">
+            <TreeMapRadioButtons
+              options={_.map(size_controls, ({ id, display }) => ({ id, display, active: id === perspective }))}
+              onChange={id => {this.handle_click("perspective",id);}}
+            />
+          </div>
+        </TreeMapLabeledBox>
+        <TreeMapLabeledBox label={text_maker("year_format")}>
+          <div className="cent">
+            <TreeMapRadioButtons
+              options={[
+                {
+                  id: "single_year",
+                  active: !get_changes,
+                  display: text_maker("single_year"),
+                },
+                {
+                  id: "year_changes",
+                  active: get_changes,
+                  display: text_maker("year_changes"),
+                },
+              ]}
+              onChange={id => {this.handle_click("get_changes",id==="year_changes");}}
+            />
+          </div>
+        </TreeMapLabeledBox>
+        <TreeMapLabeledBox label={text_maker("year")}>
+          <div className="cent">
+            <TreeMapRadioButtons
+              options={get_changes ?
+                _.map(year_changes[perspective], (id => ({ 
+                  id, 
+                  display: `${run_template("{{" + id.split(":")[0] + "}}")} ${text_maker("to")} ${run_template("{{" + id.split(":")[1] + "}}")}`,
+                  active: id === year,
+                }))) :
+                _.map(years[perspective], (id => ({
+                  id,
+                  display: run_template("{{" + id + "}}"),
+                  active: id === year,
+                })))
+              }
+              onChange={id => {this.handle_click("year",id);}}
+            />
+          </div>
+        </TreeMapLabeledBox>
         {perspective === "tp" &&
-          <TreeMapLabeledBox
-            label={text_maker("treemap_gc_type_filter")}
-            content={
-              <div className="cent">
-                <TreeMapRadioButtons
-                  options={_.map(gc_type_controls, ({ id, display }) => ({ id, display, active: (!filter_var && id === "All") || id === filter_var }))}
-                  onChange={id => {this.handle_click("filter_var",id);}}
-                />
-              </div>
-            }
-          />
+          <TreeMapLabeledBox label={text_maker("treemap_gc_type_filter")}>
+            <div className="cent">
+              <TreeMapRadioButtons
+                options={_.map(gc_type_controls, ({ id, display }) => ({ id, display, active: (!filter_var && id === "All") || id === filter_var }))}
+                onChange={id => {this.handle_click("filter_var",id);}}
+              />
+            </div>
+          </TreeMapLabeledBox>
         }
         {(perspective === "drf" || perspective === "drf_ftes" ) &&
-          <TreeMapLabeledBox
-            label={text_maker("treemap_color_by_label")}
-            content={
-              <div className="cent">
-                <TreeMapRadioButtons
-                  options={_.map(color_controls, ({ id, display }) => ({ id, display, active: id === color_var }))}
-                  onChange={id => {this.handle_click("color_var",id);}}
-                />
-              </div>
-            }
-          />
+          <TreeMapLabeledBox label={text_maker("treemap_color_by_label")}>
+            <div className="cent">
+              <TreeMapRadioButtons
+                options={_.map(color_controls, ({ id, display }) => ({ id, display, active: id === color_var }))}
+                onChange={id => {this.handle_click("color_var",id);}}
+              />
+            </div>
+          </TreeMapLabeledBox>
         }
         {perspective === "vote_stat" &&
-          <TreeMapLabeledBox
-            label={text_maker("treemap_vstype_filter")}
-            content={
-              <div className="cent">
-                <Fragment>
-                  <TreeMapRadioButtons
-                    options={_.map(vs_type_controls, ({ id, display }) => ({ id, display, active: (!filter_var && id === "All") || id === filter_var }))}
-                    onChange={id => {this.handle_click("filter_var",id);}}
-                  />
-                </Fragment>
-              </div>
-            }
-          />
-        }
-        {perspective === "so" &&
-          <TreeMapLabeledBox
-            label={text_maker("treemap_so_filter")}
-            content={
-              <div className="cent">
+          <TreeMapLabeledBox label={text_maker("treemap_vstype_filter")}>
+            <div className="cent">
+              <Fragment>
                 <TreeMapRadioButtons
-                  options={_.map(so_type_controls, ({ id, display }) => ({ id, display, active: (!filter_var && id === "All") || id === filter_var }))}
+                  options={_.map(vs_type_controls, ({ id, display }) => ({ id, display, active: (!filter_var && id === "All") || id === filter_var }))}
                   onChange={id => {this.handle_click("filter_var",id);}}
                 />
-              </div>
-            }
-          />
+              </Fragment>
+            </div>
+          </TreeMapLabeledBox>
+        }
+        {perspective === "so" &&
+          <TreeMapLabeledBox label={text_maker("treemap_so_filter")}>
+            <div className="cent">
+              <TreeMapRadioButtons
+                options={_.map(so_type_controls, ({ id, display }) => ({ id, display, active: (!filter_var && id === "All") || id === filter_var }))}
+                onChange={id => {this.handle_click("filter_var",id);}}
+              />
+            </div>
+          </TreeMapLabeledBox>
         }
       </div>
     );
@@ -276,7 +255,7 @@ class TreeMapLabeledBox extends React.Component {
   render() {
     const {
       label,
-      content,
+      children,
     } = this.props;
 
     return (
@@ -287,7 +266,7 @@ class TreeMapLabeledBox extends React.Component {
           </div>
         </div>
         <div className="treemap-labeled-box-content">
-          {content}
+          {children}
         </div>
       </div>
     );

--- a/client/src/components/LabeledBox.js
+++ b/client/src/components/LabeledBox.js
@@ -4,7 +4,7 @@ export class LabeledBox extends React.Component {
   render(){
     const {
       label,
-      content,
+      children,
     } = this.props;
 
     return (
@@ -15,7 +15,7 @@ export class LabeledBox extends React.Component {
           </div>
         </div>
         <div className="labeled-box-content">
-          { content }
+          { children }
         </div>
       </div>
     );

--- a/client/src/components/PresentationalPanel.scss
+++ b/client/src/components/PresentationalPanel.scss
@@ -90,25 +90,18 @@
     width: 20px;
     height: 20px;
   }
-
   button.panel-heading-utils {
     background-color: Transparent;
     border: none;
     margin-right: 5px;
     padding: 0;
+
+    &:active {
+      transform: scale(1.15);
+    }
   }
 
 .panel-separator {
   margin: 20px 60px 20px 60px;
   border-top: 1px solid rgba($separatorColor, 0.5);
-}
-
-.panel-heading-utils:active {
-  transform: scale(1.15);
-}
-
-@media (hover: none){
-  .panel-heading-utils:hover, .panel-heading-utils:active {
-    transform: scale(1.15);
-  }
 }

--- a/client/src/components/WriteToClipboard.js
+++ b/client/src/components/WriteToClipboard.js
@@ -25,6 +25,7 @@ export class WriteToClipboard extends React.Component {
       button_class_name,
       button_description,
       IconComponent,
+      icon_color,
     } = this.props;
 
     const {
@@ -53,7 +54,7 @@ export class WriteToClipboard extends React.Component {
         >
           <IconComponent
             title={button_description}
-            color={window.infobase_color_constants.textLightColor}
+            color={icon_color}
             alternate_color={false}
           />
         </button>
@@ -90,4 +91,5 @@ export class WriteToClipboard extends React.Component {
 WriteToClipboard.defaultProps = {
   button_description: text_maker("copy_to_clipboard"),
   IconComponent: IconCopy,
+  icon_color: window.infobase_color_constants.textLightColor,
 };

--- a/client/src/panels/Panel.js
+++ b/client/src/panels/Panel.js
@@ -92,7 +92,6 @@ class Panel_ extends React.Component {
               title={share_modal_title}
               button_class_name={'panel-heading-utils'} 
               button_description={text_maker("panel_share_button")}
-              subject={subject}
             />
           </LogInteractionEvents>
         }

--- a/client/src/partition/budget_measures_subapp/BudgetMeasuresControls.js
+++ b/client/src/partition/budget_measures_subapp/BudgetMeasuresControls.js
@@ -50,14 +50,27 @@ export class BudgetMeasuresControls extends React.Component {
 
     return (
       <div className="budget-measures-partition-controls">
-        <LabeledBox 
-          label = { <TextMaker text_key="budget_measure_display_value_label" /> }
-          content = {
+        <LabeledBox label={<TextMaker text_key="budget_measure_display_value_label" />}>
+          <div className="centerer">
+            <RadioButtons
+              options = { _.map( budget_value_options, ({id, display}) => ({ id, display, active: id === selected_value }) ) }
+              onChange = { id => {
+                const new_path = `/budget-tracker/${first_column}/${id}/${budget_year}`;
+                if ( history.location.pathname !== new_path ){
+                  // the first_column prop, and thus this button's active id, is updated through this route push
+                  history.push(new_path);
+                }
+              }}
+            />
+          </div>
+        </LabeledBox>
+        { selected_value !== "overview" &&
+          <LabeledBox label={<TextMaker text_key="budget_measure_group_by_label" />}>
             <div className="centerer">
               <RadioButtons
-                options = { _.map( budget_value_options, ({id, display}) => ({ id, display, active: id === selected_value }) ) }
+                options = { _.map( group_by_items, ({id, display }) => ({ id, display, active: id === first_column }) ) }
                 onChange = { id => {
-                  const new_path = `/budget-tracker/${first_column}/${id}/${budget_year}`;
+                  const new_path = `/budget-tracker/${id}/${selected_value}/${budget_year}`;
                   if ( history.location.pathname !== new_path ){
                     // the first_column prop, and thus this button's active id, is updated through this route push
                     history.push(new_path);
@@ -65,45 +78,23 @@ export class BudgetMeasuresControls extends React.Component {
                 }}
               />
             </div>
-          }
-        />
-        { selected_value !== "overview" &&
-          <LabeledBox 
-            label = { <TextMaker text_key="budget_measure_group_by_label" /> }
-            content = {
-              <div className="centerer">
-                <RadioButtons
-                  options = { _.map( group_by_items, ({id, display }) => ({ id, display, active: id === first_column }) ) }
-                  onChange = { id => {
-                    const new_path = `/budget-tracker/${id}/${selected_value}/${budget_year}`;
-                    if ( history.location.pathname !== new_path ){
-                      // the first_column prop, and thus this button's active id, is updated through this route push
-                      history.push(new_path);
-                    }
-                  }}
-                />
-              </div>
-            }
-          />
+          </LabeledBox>
         }
-        <LabeledBox 
-          label = { <TextMaker text_key="budget_measure_filter_by_label" /> }
-          content = {
-            <div>
-              <div className="centerer" style={{fontSize: "26px"}}>
-                <TextMaker text_key="budget_measure_filter_by_name_and_desc_label" />
-              </div>
-              <div className="budget-measures-search-box">
-                <DebouncedTextInput
-                  a11y_label = { text_maker("budget_measure_filter_by_name_and_desc_a11y_label") }
-                  placeHolder = { text_maker("budget_measure_filter_by_name_and_desc_placeholder") }
-                  defaultValue = { filter_string }
-                  updateCallback = { update_filter_string.bind(this) }
-                />
-              </div>
+        <LabeledBox label={<TextMaker text_key="budget_measure_filter_by_label" />}>
+          <div>
+            <div className="centerer" style={{fontSize: "26px"}}>
+              <TextMaker text_key="budget_measure_filter_by_name_and_desc_label" />
             </div>
-          }
-        />
+            <div className="budget-measures-search-box">
+              <DebouncedTextInput
+                a11y_label = { text_maker("budget_measure_filter_by_name_and_desc_a11y_label") }
+                placeHolder = { text_maker("budget_measure_filter_by_name_and_desc_placeholder") }
+                defaultValue = { filter_string }
+                updateCallback = { update_filter_string.bind(this) }
+              />
+            </div>
+          </div>
+        </LabeledBox>
       </div>
     );
   }

--- a/client/src/partition/budget_measures_subapp/BudgetMeasuresFooter.js
+++ b/client/src/partition/budget_measures_subapp/BudgetMeasuresFooter.js
@@ -32,21 +32,18 @@ export class BudgetMeasuresFooter extends React.Component {
     
     return (
       <div className="budget-measures-partition-footer">
-        <LabeledBox 
-          label = { <TextMaker text_key="data_sources" /> }
-          content = {
-            <div className="budget-measure-fancy-ul-container">
-              <FancyUL>
-                {
-                  _.map(
-                    budget_source.items(),
-                    (source_item) => FancyULBudgetSourceRow(source_item, open_data_link)
-                  )
-                }
-              </FancyUL>
-            </div>
-          }
-        />
+        <LabeledBox label={<TextMaker text_key="data_sources" />}>
+          <div className="budget-measure-fancy-ul-container">
+            <FancyUL>
+              {
+                _.map(
+                  budget_source.items(),
+                  (source_item) => FancyULBudgetSourceRow(source_item, open_data_link)
+                )
+              }
+            </FancyUL>
+          </div>
+        </LabeledBox>
       </div>
     );
   }

--- a/client/src/rpb/TablePicker.js
+++ b/client/src/rpb/TablePicker.js
@@ -1,18 +1,45 @@
 import './TablePicker.scss';
 import '../components/LabeledBox.scss';
 import { Table } from '../core/TableClass.js';
-import { 
-  GlossaryEntry,
-} from '../models/glossary.js';
+import { GlossaryEntry } from '../models/glossary.js';
+import { Fragment } from 'react';
 import { TransitionGroup, CSSTransition } from 'react-transition-group';
 import classNames from 'classnames';
+import { IconQuestion } from '../icons/icons.js';
+import { AlertBanner } from '../components';
+
 import { 
   categories,
   concepts_by_category,
   concept_filter,
 } from './table_picker_concept_filter.js';
 import { TextMaker } from './rpb_text_provider.js';
-import { IconQuestion } from '../icons/icons.js';
+
+
+const BrokenLinkBanner = () => (
+  <AlertBanner banner_class={'warning'}>
+    <TextMaker text_key="table_picker_broken_link_warning" />
+  </AlertBanner>
+);
+
+
+export const AccessibleTablePicker = ({ tables, onSelect, selected, broken_url }) => (
+  <Fragment>
+    {broken_url && <BrokenLinkBanner />}
+    <select
+      aria-labelledby="picker-label"
+      className="form-control form-control-ib rpb-simple-select"
+      value={selected}
+      onChange={evt => onSelect(evt.target.value)}
+    >
+      {_.map(tables, ({id, name}) =>
+        <option key={id} value={id}>
+          {name}
+        </option>
+      )}
+    </select>
+  </Fragment>
+);
 
 
 function toggleArrayElement(arr,el){
@@ -21,11 +48,11 @@ function toggleArrayElement(arr,el){
   arr.concat(el);
 }
 
-
 /* 
   props:
     onSelect : table_id =>  
 */
+
 
 class TablePicker extends React.Component {
   constructor(props){
@@ -72,9 +99,9 @@ class TablePicker extends React.Component {
 
   }
   render(){
-    const { 
-      active_concepts, 
-    } = this.state;
+    const { broken_url } = this.props;
+
+    const { active_concepts } = this.state;
 
     const { 
       linkage, 
@@ -122,6 +149,7 @@ class TablePicker extends React.Component {
 
     return <div ref="main" id="tbp-main">
       <h2 id="tbp-title"> <TextMaker text_key="table_picker_title" /> </h2>
+      {broken_url && <BrokenLinkBanner />}
       <p className="medium_panel_text"><TextMaker text_key="table_picker_top_instructions" /></p>
       <div>
         <TaggedItemCloud 

--- a/client/src/rpb/granular_view.js
+++ b/client/src/rpb/granular_view.js
@@ -3,6 +3,7 @@ import {
   SelectList,
   ReportDetails,
   ReportDatasets,
+  ExportButton,
   ShareReport,
   NoDataMessage,
 } from './shared.js';
@@ -14,7 +15,6 @@ import {
   AlertBanner,
 } from '../components/index.js';
 import { Details } from '../components/Details.js';
-import { rpb_link } from './rpb_link.js';
 import { Subject } from '../models/subject.js';
 
 import classNames from 'classnames';
@@ -61,27 +61,29 @@ class GranularView extends React.Component {
               </fieldset>
             </div>
             <div className="col-md-6">
-              <label className='rpb-config-header' htmlFor='filt_select'> Filter </label>
-              <TwoLevelSelect
-                className="form-control form-control-ib"
-                id="filt_select"
-                onSelect={ id=> {
-                  const [ dim_key, filt_key ] = id.split('__');
-                  on_set_filter({filter: filt_key, dimension: dim_key});
-                }}
-                selected={dimension+'__'+filter}
-                grouped_options={ 
-                  _.mapValues(filters_by_dimension, 
-                    filter_by_dim => (
-                      {
-                        ...filter_by_dim, 
-                        children: _.sortBy(filter_by_dim.children, "display"),
-                      }
-                    ) 
-                  )
-                }
-              />
-              <div className="mrgn-tp-lg">
+              <div className="rpb-config-item">
+                <label className='rpb-config-header' htmlFor='filt_select'> Filter </label>
+                <TwoLevelSelect
+                  className="form-control form-control-ib"
+                  id="filt_select"
+                  onSelect={ id=> {
+                    const [ dim_key, filt_key ] = id.split('__');
+                    on_set_filter({filter: filt_key, dimension: dim_key});
+                  }}
+                  selected={dimension+'__'+filter}
+                  grouped_options={ 
+                    _.mapValues(filters_by_dimension, 
+                      filter_by_dim => (
+                        {
+                          ...filter_by_dim, 
+                          children: _.sortBy(filter_by_dim.children, "display"),
+                        }
+                      ) 
+                    )
+                  }
+                />
+              </div>
+              <div className="rpb-config-item">
                 <ExportButton 
                   id="export_button"
                   get_csv_string={ ()=> this.get_csv_string() }
@@ -94,6 +96,7 @@ class GranularView extends React.Component {
                   }}
                 />
               </div>
+              <ShareReport />
             </div>
             <div className='clearfix'/>
           </div>
@@ -112,9 +115,6 @@ class GranularView extends React.Component {
         </LabeledBox>
         <LabeledBox label={<TextMaker text_key="blue_text_report_data_sources" />}>
           <ReportDatasets {...this.props} /> 
-        </LabeledBox>
-        <LabeledBox label={<TextMaker text_key="share_report"/>}>
-          <ShareReport /> 
         </LabeledBox>
         { table.rpb_banner && <AlertBanner>{table.rpb_banner}</AlertBanner> }
         <div id="rpb-main-content" >
@@ -380,98 +380,6 @@ class PlainTableHeader extends React.PureComponent {
     </div>;
   }
 }
-
-class ExportButton extends React.Component {
-  //note that though props may not have changed, this method doesn't get trigerred from this.setState 
-  constructor(){
-    super();
-    this.state = { 
-      success: null,
-    }; 
-  }
-  static getDerivedStateFromProps(nextProps, prevState){
-    return { 
-      success: null,
-    };
-  }
-  render(){
-    const {
-      id,
-    } = this.props;
-    const { 
-      success,
-    } = this.state;
-
-
-    if( window.feature_detection.download_attr ){
-      return <div>
-        <button 
-          id={id}
-          className="btn btn-ib-primary btn-block"
-          onClick={ ()=> { this.triggerDownload(); } }
-        >
-          <TextMaker text_key="export_table" />
-        </button>
-      </div>;
-    } else if(window.feature_detection.clipboard_access){
-      const buttonText = (
-        success === false ? 
-        <TextMaker text_key="error" /> :
-        ( 
-          success === true ?
-          <TextMaker text_key="finished_export_table_to_clipboard" /> :
-          <TextMaker text_key="export_table_to_clipboard" />
-        )
-      );
-      
-      return <div>
-        <button 
-          id={id}
-          className="btn btn-ib-primary btn-block"
-          onClick={ ()=>{ this.clipBoardClickHandler(); } }
-        >
-          { buttonText }
-        </button>
-      </div>;
-
-    } else {
-      return null;
-    }
-
-  }
-  triggerDownload(){
-    const csv_str = this.props.get_csv_string();
-    const uri = "data:text/csv;charset=UTF-8," + encodeURIComponent(csv_str);
-    
-    const temporary_anchor = document.createElement('a');
-    temporary_anchor.setAttribute("download", 'table.csv');
-    temporary_anchor.setAttribute("href", uri);
-    temporary_anchor.dispatchEvent( new MouseEvent('click') );
-  }
-   
-
-  clipBoardClickHandler(){
-    const {
-      get_excel_string,
-    } = this.props;
-
-
-    try {
-
-      window.clipboardData.setData('Text', get_excel_string());
-      this.setState({success: true});
-
-    } catch(e){
-      this.setState({success: false});
-    }
-
-    setTimeout(()=>{
-      this.setState({success: null});
-    },3000);
-
-  }
-}
-
 
 export {
   GranularView,

--- a/client/src/rpb/granular_view.js
+++ b/client/src/rpb/granular_view.js
@@ -39,85 +39,78 @@ class GranularView extends React.Component {
 
     return (
       <div>
-        <LabeledBox
-          label={ <TextMaker text_key="blue_text_table_controls" /> }
-          content={
-            <div className="row">
-              <div className='col-md-6'>
-                <fieldset className="rpb-config-item col-selection simple">
-                  <legend className="rpb-config-header"> <TextMaker text_key="select_columns" /> </legend>
-                  <SelectList 
-                    items={ _.map(
-                      all_data_columns, 
-                      ({nick, fully_qualified_name}) => ({
-                        id: nick, 
-                        display: fully_qualified_name, 
-                      }) 
-                    )}
-                    selected={ _.map(columns,'nick') }
-                    is_multi_select={true}
-                    onSelect={id=> on_toggle_col_nick(id) }
-                  />
-                </fieldset>
-              </div>
-              <div className="col-md-6">
-                <label className='rpb-config-header' htmlFor='filt_select'> Filter </label>
-                <TwoLevelSelect
-                  className="form-control form-control-ib"
-                  id="filt_select"
-                  onSelect={ id=> {
-                    const [ dim_key, filt_key ] = id.split('__');
-                    on_set_filter({filter: filt_key, dimension: dim_key});
-                  }}
-                  selected={dimension+'__'+filter}
-                  grouped_options={ 
-                    _.mapValues(filters_by_dimension, 
-                      filter_by_dim => (
-                        {
-                          ...filter_by_dim, 
-                          children: _.sortBy(filter_by_dim.children, "display"),
-                        }
-                      ) 
-                    )
-                  }
+        <LabeledBox label={<TextMaker text_key="blue_text_table_controls" />}>
+          <div className="row">
+            <div className='col-md-6'>
+              <fieldset className="rpb-config-item col-selection simple">
+                <legend className="rpb-config-header"> <TextMaker text_key="select_columns" /> </legend>
+                <SelectList 
+                  items={ _.map(
+                    all_data_columns, 
+                    ({nick, fully_qualified_name}) => ({
+                      id: nick, 
+                      display: fully_qualified_name, 
+                    }) 
+                  )}
+                  selected={ _.map(columns,'nick') }
+                  is_multi_select={true}
+                  onSelect={id=> on_toggle_col_nick(id) }
                 />
-                <div className="mrgn-tp-lg">
-                  <ExportButton 
-                    id="export_button"
-                    get_csv_string={ ()=> this.get_csv_string() }
-                    get_excel_string={ ()=> {
-                      const el = document.createElement('div');
-                      ReactDOM.render(this.get_plain_table_content(true), el);
-                      const excel_str= el.querySelector('table').outerHTML;
-                      ReactDOM.unmountComponentAtNode(el);
-                      return excel_str;
-                    }}
-                  />
-                </div>
-              </div>
-              <div className='clearfix'/>
+              </fieldset>
             </div>
-          }
-        />
-        <LabeledBox
-          label={ <TextMaker text_key="blue_text_report_details" args={{table_name: table.name}} /> }
-          content={
-            <Details
-              summary_content={
-                <div>
-                  { table.title } : {subject.name}  
-                </div>
-              }
-              content={
-                <ReportDetails {...this.props} />
-              }
-            />
-          }
-        />
-        <LabeledBox
-          label={ <TextMaker text_key="blue_text_report_data_sources" /> }
-          content={ <ReportDatasets {...this.props} /> }
-        />
+            <div className="col-md-6">
+              <label className='rpb-config-header' htmlFor='filt_select'> Filter </label>
+              <TwoLevelSelect
+                className="form-control form-control-ib"
+                id="filt_select"
+                onSelect={ id=> {
+                  const [ dim_key, filt_key ] = id.split('__');
+                  on_set_filter({filter: filt_key, dimension: dim_key});
+                }}
+                selected={dimension+'__'+filter}
+                grouped_options={ 
+                  _.mapValues(filters_by_dimension, 
+                    filter_by_dim => (
+                      {
+                        ...filter_by_dim, 
+                        children: _.sortBy(filter_by_dim.children, "display"),
+                      }
+                    ) 
+                  )
+                }
+              />
+              <div className="mrgn-tp-lg">
+                <ExportButton 
+                  id="export_button"
+                  get_csv_string={ ()=> this.get_csv_string() }
+                  get_excel_string={ ()=> {
+                    const el = document.createElement('div');
+                    ReactDOM.render(this.get_plain_table_content(true), el);
+                    const excel_str= el.querySelector('table').outerHTML;
+                    ReactDOM.unmountComponentAtNode(el);
+                    return excel_str;
+                  }}
+                />
+              </div>
+            </div>
+            <div className='clearfix'/>
+          </div>
+        </LabeledBox>
+        <LabeledBox label={<TextMaker text_key="blue_text_report_details" args={{table_name: table.name}} />}>
+          <Details
+            summary_content={
+              <div>
+                { table.title } : {subject.name}  
+              </div>
+            }
+            content={
+              <ReportDetails {...this.props} />
+            }
+          />
+        </LabeledBox>
+        <LabeledBox label={<TextMaker text_key="blue_text_report_data_sources" />}>
+          <ReportDatasets {...this.props} /> 
+        </LabeledBox>
         { table.rpb_banner && <AlertBanner>{table.rpb_banner}</AlertBanner> }
         <div id="rpb-main-content" >
           { 

--- a/client/src/rpb/granular_view.js
+++ b/client/src/rpb/granular_view.js
@@ -41,7 +41,7 @@ class GranularView extends React.Component {
 
     return (
       <div>
-        <LabeledBox label={<TextMaker text_key="blue_text_table_controls" />}>
+        <LabeledBox label={<TextMaker text_key="rpb_table_controls" />}>
           <div className="row">
             <div className='col-md-6'>
               <fieldset className="rpb-config-item col-selection simple">
@@ -101,7 +101,7 @@ class GranularView extends React.Component {
             <div className='clearfix'/>
           </div>
         </LabeledBox>
-        <LabeledBox label={<TextMaker text_key="blue_text_report_details" args={{table_name: table.name}} />}>
+        <LabeledBox label={<TextMaker text_key="rpb_report_details" args={{table_name: table.name}} />}>
           <Details
             summary_content={
               <div>
@@ -113,7 +113,7 @@ class GranularView extends React.Component {
             }
           />
         </LabeledBox>
-        <LabeledBox label={<TextMaker text_key="blue_text_report_data_sources" />}>
+        <LabeledBox label={<TextMaker text_key="rpb_report_data_sources" />}>
           <ReportDatasets {...this.props} /> 
         </LabeledBox>
         { table.rpb_banner && <AlertBanner>{table.rpb_banner}</AlertBanner> }

--- a/client/src/rpb/granular_view.js
+++ b/client/src/rpb/granular_view.js
@@ -1,9 +1,10 @@
 import { TextMaker, text_maker } from './rpb_text_provider.js';
 import { 
-  SelectList, 
-  ReportDetails, 
-  ReportDatasets, 
-  NoDataMessage, 
+  SelectList,
+  ReportDetails,
+  ReportDatasets,
+  ShareReport,
+  NoDataMessage,
 } from './shared.js';
 import { 
   Format, 
@@ -13,15 +14,16 @@ import {
   AlertBanner,
 } from '../components/index.js';
 import { Details } from '../components/Details.js';
-import classNames from 'classnames';
+import { rpb_link } from './rpb_link.js';
 import { Subject } from '../models/subject.js';
+
+import classNames from 'classnames';
 
 const { Dept } = Subject;
 const PAGE_SIZE = 600;
 
 class GranularView extends React.Component {
-
-  render() {
+  render(){
     const {
       subject,
       table,
@@ -110,6 +112,9 @@ class GranularView extends React.Component {
         </LabeledBox>
         <LabeledBox label={<TextMaker text_key="blue_text_report_data_sources" />}>
           <ReportDatasets {...this.props} /> 
+        </LabeledBox>
+        <LabeledBox label={<TextMaker text_key="share_report"/>}>
+          <ShareReport /> 
         </LabeledBox>
         { table.rpb_banner && <AlertBanner>{table.rpb_banner}</AlertBanner> }
         <div id="rpb-main-content" >

--- a/client/src/rpb/index.js
+++ b/client/src/rpb/index.js
@@ -56,6 +56,12 @@ const url_state_selector = createSelector(
               .pipe( naive=> naive_to_real_state(naive) )
               .value();
           } catch(e){
+            log_standard_event({
+              SUBAPP: sub_app_name,
+              MISC1: 'BROKEN_RPB_URL',
+              MISC2: str,
+            });
+
             return naive_to_real_state({broken_url: true});
           }
         }

--- a/client/src/rpb/index.js
+++ b/client/src/rpb/index.js
@@ -29,7 +29,7 @@ import {
 import AriaModal from 'react-aria-modal';
 
 //specific view stuff
-import { TablePicker } from './TablePicker.js';
+import { AccessibleTablePicker, TablePicker } from './TablePicker.js';
 import { SimpleView } from './simple_view.js';
 import { GranularView } from './granular_view.js';
 import { SubjectFilterPicker } from './shared.js';
@@ -56,7 +56,7 @@ const url_state_selector = createSelector(
               .pipe( naive=> naive_to_real_state(naive) )
               .value();
           } catch(e){
-            return naive_to_real_state();
+            return naive_to_real_state({broken_url: true});
           }
         }
       }
@@ -178,6 +178,7 @@ class RPB extends React.Component {
       table,
       mode, 
       subject,
+      broken_url,
 
       on_switch_mode,
       on_set_subject,
@@ -224,6 +225,7 @@ class RPB extends React.Component {
                       onSelect={id => this.pickTable(id)}
                       tables={_.reject(Table.get_all(), 'reference_table')}
                       selected={_.get(table, 'id')}
+                      broken_url={broken_url}
                     /> :
                     <button 
                       className="btn btn-ib-primary"
@@ -272,7 +274,10 @@ class RPB extends React.Component {
                     fontWeight: 400,
                   }}
                 >
-                  <TablePicker onSelect={id=> this.pickTable(id)} />
+                  <TablePicker
+                    onSelect={id=> this.pickTable(id)} 
+                    broken_url={broken_url}
+                  />
                 </div>
               </AriaModal>
             }
@@ -457,20 +462,3 @@ export default class ReportBuilder extends React.Component {
     );
   }
 }
-
-
-
-const AccessibleTablePicker = ({ tables, onSelect, selected }) => (
-  <select 
-    aria-labelledby="picker-label"
-    className="form-control form-control-ib rpb-simple-select"
-    value={selected}
-    onChange={evt => onSelect(evt.target.value)}
-  >
-    {_.map(tables, ({id, name}) =>
-      <option key={id} value={id}>
-        {name}
-      </option>
-    )}
-  </select>
-);

--- a/client/src/rpb/index.js
+++ b/client/src/rpb/index.js
@@ -42,18 +42,29 @@ import { SafeJSURL } from '../general_utils.js';
 const sub_app_name = "_rpb";
 
 
-const url_state_selector = createSelector(_.identity, str => {
-  let state = {};
-  if(_.nonEmpty(str)){
-    state = _.chain(str)
-      .pipe(str => SafeJSURL.parse(str) )
-      .pipe(naive=> naive_to_real_state(naive) )
-      .value();
-  } else {
-    state = naive_to_real_state({});
+const url_state_selector = createSelector(
+  _.identity, 
+  str => {
+    const state = (
+      () => {
+        if( _.isEmpty(str) ){
+          return naive_to_real_state({});
+        } else {
+          try {
+            return _.chain(str)
+              .pipe( str => SafeJSURL.parse(str) )
+              .pipe( naive=> naive_to_real_state(naive) )
+              .value();
+          } catch(e){
+            return naive_to_real_state();
+          }
+        }
+      }
+    )();
+
+    return state;
   }
-  return state;
-});
+);
 
 const RPBTitle = ({ table_name, subject_name }) => {
   const title_prefix = text_maker("report_builder_title"); 

--- a/client/src/rpb/index.js
+++ b/client/src/rpb/index.js
@@ -209,116 +209,107 @@ class RPB extends React.Component {
         subject_name={subject !== Gov && subject && subject.name}
         table_name={table && table.name}
       />
-      <LabeledBox
-        label={ <TextMaker text_key="blue_text_pick_data" /> }
-        content={
-          <div>
-            <div className="centerer">
-              <p 
-                id="picker-label"
-                className="md-half-width md-gutter-right"
-                style={{margin: 0}}
-              >
-                { table ? 
-                  <TextMaker text_key="table_picker_select_different_summary" args={{name: table.name}} /> :
-                  <TextMaker text_key="table_picker_none_selected_summary" /> 
-                } 
-              </p>
-              <div className="md-half-width md-gutter-left">
-                { 
-                  window.is_a11y_mode ?
-                    <AccessibleTablePicker
-                      onSelect={id => this.pickTable(id)}
-                      tables={_.reject(Table.get_all(), 'reference_table')}
-                      selected={_.get(table, 'id')}
-                      broken_url={broken_url}
-                    /> :
-                    <button 
-                      className="btn btn-ib-primary"
-                      style={{width: '100%'}}
-                      onClick={()=>{ this.setState({table_picking: true});}}
-                    >
-                      <TextMaker text_key={table ? 'select_another_table_button' : 'select_table_button'} /> 
-                    </button>
-                }
-              </div>
-            </div>
-            {!window.is_a11y_mode &&
-              <AriaModal
-                mounted={this.state.table_picking}
-                onExit={()=>{ 
-                  if( this.state.table_picking ){
-                    this.setState({ table_picking: false }); 
-                    setTimeout(()=>{
-                      slowScrollDown();
-                      const sub_app_node = document.querySelector('#'+sub_app_name);
-                      if(sub_app_node !== null){
-                        sub_app_node.focus();
-                      }
-                    },200);
-                  }
-                }}
-                titleId="tbp-title"
-                getApplicationNode={()=>document.getElementById('app')}
-                verticallyCenter={true}
-                underlayStyle={{
-                  paddingTop: "50px",
-                  paddingBottom: "50px",
-                }}
-                focusDialog={true}
-              >
-                <div 
-                  tabIndex={-1}
-                  id="modal-child"
-                  className="container app-font"
-                  style={{
-                    backgroundColor: 'white',
-                    overflow: 'auto',
-                    lineHeight: 1.5,
-                    padding: "0px 20px 0px 20px",
-                    borderRadius: "5px",
-                    fontWeight: 400,
-                  }}
-                >
-                  <TablePicker
-                    onSelect={id=> this.pickTable(id)} 
+      <LabeledBox label={ <TextMaker text_key="blue_text_pick_data" /> }>
+        <div>
+          <div className="centerer">
+            <p 
+              id="picker-label"
+              className="md-half-width md-gutter-right"
+              style={{margin: 0}}
+            >
+              { table ? 
+                <TextMaker text_key="table_picker_select_different_summary" args={{name: table.name}} /> :
+                <TextMaker text_key="table_picker_none_selected_summary" /> 
+              } 
+            </p>
+            <div className="md-half-width md-gutter-left">
+              { 
+                window.is_a11y_mode ?
+                  <AccessibleTablePicker
+                    onSelect={id => this.pickTable(id)}
+                    tables={_.reject(Table.get_all(), 'reference_table')}
+                    selected={_.get(table, 'id')}
                     broken_url={broken_url}
-                  />
-                </div>
-              </AriaModal>
-            }
+                  /> :
+                  <button 
+                    className="btn btn-ib-primary"
+                    style={{width: '100%'}}
+                    onClick={()=>{ this.setState({table_picking: true});}}
+                  >
+                    <TextMaker text_key={table ? 'select_another_table_button' : 'select_table_button'} /> 
+                  </button>
+              }
+            </div>
           </div>
-        }
-      />
+          {!window.is_a11y_mode &&
+            <AriaModal
+              mounted={this.state.table_picking}
+              onExit={()=>{ 
+                if( this.state.table_picking ){
+                  this.setState({ table_picking: false }); 
+                  setTimeout(()=>{
+                    slowScrollDown();
+                    const sub_app_node = document.querySelector('#'+sub_app_name);
+                    if(sub_app_node !== null){
+                      sub_app_node.focus();
+                    }
+                  },200);
+                }
+              }}
+              titleId="tbp-title"
+              getApplicationNode={()=>document.getElementById('app')}
+              verticallyCenter={true}
+              underlayStyle={{
+                paddingTop: "50px",
+                paddingBottom: "50px",
+              }}
+              focusDialog={true}
+            >
+              <div 
+                tabIndex={-1}
+                id="modal-child"
+                className="container app-font"
+                style={{
+                  backgroundColor: 'white',
+                  overflow: 'auto',
+                  lineHeight: 1.5,
+                  padding: "0px 20px 0px 20px",
+                  borderRadius: "5px",
+                  fontWeight: 400,
+                }}
+              >
+                <TablePicker
+                  onSelect={id=> this.pickTable(id)} 
+                  broken_url={broken_url}
+                />
+              </div>
+            </AriaModal>
+          }
+        </div>
+      </LabeledBox>
       {
         this.state.loading ? 
           <SpinnerWrapper config_name={"route"} /> :
           <Fragment>
-            <LabeledBox
-              label={ <TextMaker text_key="blue_text_pick_org" /> }
-              content={
-                <SubjectFilterPicker 
-                  subject={subject}  
-                  onSelect={ subj=> on_set_subject(subj) }
+            <LabeledBox label={<TextMaker text_key="blue_text_pick_org" />}>
+              <SubjectFilterPicker 
+                subject={subject}  
+                onSelect={ subj=> on_set_subject(subj) }
+              />
+            </LabeledBox>
+            <LabeledBox label={<TextMaker text_key="blue_text_select_mode" />}>
+              <div className="centerer">
+                <RadioButtons
+                  options = {[
+                    {id: 'simple', display: <TextMaker text_key="simple_view_title" />, active: mode==='simple'},
+                    {id: 'details', display: <TextMaker text_key="granular_view_title" />, active: mode==='details'}]}
+                  
+                  onChange={ id =>{
+                    on_switch_mode(id);} 
+                  }
                 />
-              }
-            />
-            <LabeledBox
-              label={ <TextMaker text_key="blue_text_select_mode" /> }
-              content={
-                <div className="centerer">
-                  <RadioButtons
-                    options = {[
-                      {id: 'simple', display: <TextMaker text_key="simple_view_title" />, active: mode==='simple'},
-                      {id: 'details', display: <TextMaker text_key="granular_view_title" />, active: mode==='details'}]}
-                    
-                    onChange={ id =>{
-                      on_switch_mode(id);} 
-                    }
-                  />
-                </div>
-              }
-            />
+              </div>
+            </LabeledBox>
             {
               table ? 
               (

--- a/client/src/rpb/index.js
+++ b/client/src/rpb/index.js
@@ -209,7 +209,7 @@ class RPB extends React.Component {
         subject_name={subject !== Gov && subject && subject.name}
         table_name={table && table.name}
       />
-      <LabeledBox label={ <TextMaker text_key="blue_text_pick_data" /> }>
+      <LabeledBox label={ <TextMaker text_key="rpb_pick_data" /> }>
         <div>
           <div className="centerer">
             <p 
@@ -291,13 +291,13 @@ class RPB extends React.Component {
         this.state.loading ? 
           <SpinnerWrapper config_name={"route"} /> :
           <Fragment>
-            <LabeledBox label={<TextMaker text_key="blue_text_pick_org" />}>
+            <LabeledBox label={<TextMaker text_key="rpb_pick_org" />}>
               <SubjectFilterPicker 
                 subject={subject}  
                 onSelect={ subj=> on_set_subject(subj) }
               />
             </LabeledBox>
-            <LabeledBox label={<TextMaker text_key="blue_text_select_mode" />}>
+            <LabeledBox label={<TextMaker text_key="rpb_select_mode" />}>
               <div className="centerer">
                 <RadioButtons
                   options = {[

--- a/client/src/rpb/rpb.scss
+++ b/client/src/rpb/rpb.scss
@@ -113,3 +113,17 @@ li.select-list-item {
 .rpb-separator {
   border-bottom: 1px solid $separatorColor;
 }
+
+.rpb-share-options {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-evenly;
+
+  & > button {
+    background-color: Transparent;
+    border: none;  
+    &:active {
+      transform: scale(1.15);
+    }
+  }
+}

--- a/client/src/rpb/rpb.yaml
+++ b/client/src/rpb/rpb.yaml
@@ -125,6 +125,10 @@ export:
   en: Export
   fr: Exporter
 
+share_report:
+  en: Share
+  fr: Partager
+
 ### Table Picker text
 
 select_table:

--- a/client/src/rpb/rpb.yaml
+++ b/client/src/rpb/rpb.yaml
@@ -15,11 +15,13 @@ blue_text_pick_org:
   fr: Sélectionnez une organisation
 
 
+table_picker_broken_link_warning:
+  en: TODO
+  fr: TODO
+
 table_picker_none_selected_summary:
-  en: |
-    To see data, select a table
-  fr: |
-    Pour voir des données, veuillez choisir un tableau 
+  en: To see data, select a table
+  fr: Pour voir des données, veuillez choisir un tableau 
 
 
 select_table_button:

--- a/client/src/rpb/rpb.yaml
+++ b/client/src/rpb/rpb.yaml
@@ -16,7 +16,7 @@ blue_text_pick_org:
 
 
 table_picker_broken_link_warning:
-  en: TODO
+  en: You were brought here by a report builder link which could not be properly parsed. If you know what data you were looking for, please select the appropriate table below.
   fr: TODO
 
 table_picker_none_selected_summary:

--- a/client/src/rpb/rpb.yaml
+++ b/client/src/rpb/rpb.yaml
@@ -6,11 +6,11 @@ report_builder_meta_desc:
   en: Create a customized and exportable report on the data you want to analyze
   fr: Créer un rapport adapté et exportable sur les données que vous voulez analyser
 
-blue_text_pick_data:
+rpb_pick_data:
   en: Select your data
   fr: Sélectionnez vos données
 
-blue_text_pick_org:
+rpb_pick_org:
   en: Select organization
   fr: Sélectionnez une organisation
 
@@ -39,7 +39,7 @@ table_picker_select_different_summary:
   fr: |
     Tableau présentement sélectionné: {{name}}
 
-blue_text_select_mode:
+rpb_select_mode:
   en: Select the type of report you want 
   fr: Sélectionner le type de rapport que vous voulez 
 
@@ -51,15 +51,15 @@ granular_view_title:
   en: Build a detailed report 
   fr: Créer un rapport détaillé
 
-blue_text_report_details:
+rpb_report_details:
   en: See your report details
   fr: Voir les détails de votre rapport
 
-blue_text_report_data_sources:
+rpb_report_data_sources:
  en: Datasets and data sources
  fr: Données et sources des données
 
-blue_text_table_controls:
+rpb_table_controls:
   en: Sort and filter your report
   fr: Trier et filtrer votre rapport
 

--- a/client/src/rpb/rpb_link.js
+++ b/client/src/rpb/rpb_link.js
@@ -25,19 +25,25 @@ const rpb_link = (naive_state, useRouterFormat) => _.chain(naive_state)
       ),
     };
   })
-  .pick([
-    'columns',
-    'subject',
-    'mode',
-    'dimension',
-    'table',
-    'preferDeptBreakout',
-    'preferTable',
-    'sort_col',
-    'descending',
-    'filter',
-  ])
-  .pipe(obj => SafeJSURL.stringify(obj))
+  .pickBy(
+    (value, key) => _.includes(
+      [
+        'columns',
+        'subject',
+        'mode',
+        'dimension',
+        'table',
+        'preferDeptBreakout',
+        'preferTable',
+        'sort_col',
+        'descending',
+        'filter',
+      ],
+      key
+    ) ||
+    key === "broken_url" && value // need to store broken_url in route state while true so it isn't lost, fine to drop it once it has been cleared (becomes false) to keep the URL clean
+  )
+  .pipe( obj => SafeJSURL.stringify(obj) )
   .pipe( str => base_url+str )
   .pipe(str => useRouterFormat ? str.replace("#","/") : str )
   .value();

--- a/client/src/rpb/shared.js
+++ b/client/src/rpb/shared.js
@@ -191,7 +191,7 @@ const ShareReport = () => (
 
 
 class ExportButton extends React.Component {
-  //note that though props may not have changed, this method doesn't get trigerred from this.setState 
+  //note that though props may not have changed, this method doesn't get triggered from this.setState 
   constructor(){
     super();
     this.state = { 
@@ -281,8 +281,7 @@ class ExportButton extends React.Component {
   }
 }
 
-//the parent flexbox styling screws stuff up and makes it impossible to center vertically,
-// a padding of 6px at the top seems to fix it ¯\_(ツ)_/¯
+//the parent flexbox styling screws stuff up and makes it impossible to center vertically, top padding tweaked to correct
 const SubjectFilterPicker = ({ subject, onSelect })=> <div style={{paddingTop: '10px'}}>
   <div className="md-half-width md-gutter-right">
     <button 

--- a/client/src/rpb/shared.js
+++ b/client/src/rpb/shared.js
@@ -1,9 +1,17 @@
 import { TextMaker, text_maker } from './rpb_text_provider.js';
 import { sources as all_sources } from '../metadata/data_sources.js';
 import { sanitized_dangerous_inner_html } from '../general_utils.js';
-import { DeptSearch, FancyUL } from '../components/index.js';
-import classNames from 'classnames';
 import { Subject } from '../models/subject';
+import {
+  DeptSearch,
+  FancyUL,
+  ShareButton,
+  WriteToClipboard,
+} from '../components/index.js';
+import { IconCopyLink } from '../icons/icons.js';
+
+import { Fragment } from 'react';
+import classNames from 'classnames';
 
 const { Gov } = Subject;
 
@@ -168,6 +176,19 @@ const ReportDatasets = ({
   );
 };
 
+const ShareReport = () => (
+  <Fragment>
+    <ShareButton
+      url={window.location}
+    />
+    <WriteToClipboard 
+      text_to_copy={window.location}
+      IconComponent={IconCopyLink}
+    />
+  </Fragment>
+);
+
+
 //the parent flexbox styling screws stuff up and makes it impossible to center vertically,
 // a padding of 6px at the top seems to fix it ¯\_(ツ)_/¯
 const SubjectFilterPicker = ({ subject, onSelect })=> <div style={{paddingTop: '10px'}}>
@@ -215,6 +236,7 @@ export {
   SelectList,
   ReportDetails,
   ReportDatasets,
+  ShareReport,
   SubjectFilterPicker,
   NoDataMessage,
 };

--- a/client/src/rpb/simple_view.js
+++ b/client/src/rpb/simple_view.js
@@ -1,9 +1,10 @@
 import { TextMaker, text_maker } from './rpb_text_provider.js';
 import { 
   SelectList,
-  ReportDetails, 
-  ReportDatasets, 
-  NoDataMessage, 
+  ReportDetails,
+  ReportDatasets,
+  ShareReport,
+  NoDataMessage,
 } from './shared.js';
 import { 
   Select, 
@@ -24,8 +25,7 @@ const granular_rpb_link_for_filter = (currentProps, filter) => rpb_link({ ...cur
 
 
 class SimpleView extends React.Component {
-
-  render() {
+  render(){
     const {
       subject,
       table,
@@ -44,6 +44,7 @@ class SimpleView extends React.Component {
       on_toggle_col_nick,
       on_toggle_deptBreakout,
     } = this.props;
+
     return (
       <div> 
         <LabeledBox label={<TextMaker text_key="blue_text_table_controls" />}>
@@ -137,6 +138,9 @@ class SimpleView extends React.Component {
         </LabeledBox>
         <LabeledBox label={<TextMaker text_key="blue_text_report_data_sources" args={{table_name: table.name}} />}>
           <ReportDatasets {...this.props} /> 
+        </LabeledBox>
+        <LabeledBox label={<TextMaker text_key="share_report"/>}>
+          <ShareReport /> 
         </LabeledBox>
         { table.rpb_banner && <AlertBanner>{table.rpb_banner}</AlertBanner> }
         <div id="rpb-main-content" >

--- a/client/src/rpb/simple_view.js
+++ b/client/src/rpb/simple_view.js
@@ -47,7 +47,7 @@ class SimpleView extends React.Component {
     } = this.props;
     return (
       <div> 
-        <LabeledBox label={<TextMaker text_key="blue_text_table_controls" />}>
+        <LabeledBox label={<TextMaker text_key="rpb_table_controls" />}>
           <div className="rpb-config rpb-simple row">
             <div className="col-md-6">
               <fieldset className="rpb-config-item col-selection simple">
@@ -125,7 +125,7 @@ class SimpleView extends React.Component {
             <div className="clearfix" />
           </div>
         </LabeledBox>
-        <LabeledBox label={<TextMaker text_key="blue_text_report_details" args={{table_name: table.name}} />}>
+        <LabeledBox label={<TextMaker text_key="rpb_report_details" args={{table_name: table.name}} />}>
           <Details
             summary_content={
               <div>
@@ -137,7 +137,7 @@ class SimpleView extends React.Component {
             }
           />
         </LabeledBox>
-        <LabeledBox label={<TextMaker text_key="blue_text_report_data_sources" args={{table_name: table.name}} />}>
+        <LabeledBox label={<TextMaker text_key="rpb_report_data_sources" args={{table_name: table.name}} />}>
           <ReportDatasets {...this.props} /> 
         </LabeledBox>
         { table.rpb_banner && <AlertBanner>{table.rpb_banner}</AlertBanner> }

--- a/client/src/rpb/simple_view.js
+++ b/client/src/rpb/simple_view.js
@@ -46,105 +46,98 @@ class SimpleView extends React.Component {
     } = this.props;
     return (
       <div> 
-        <LabeledBox
-          label={ <TextMaker text_key="blue_text_table_controls" /> }
-          content={
-            <div className="rpb-config rpb-simple row">
-              <div className="col-md-6">
-                <fieldset className="rpb-config-item col-selection simple">
-                  <legend className="rpb-config-header"> <TextMaker text_key="select_columns" /> </legend>
-                  <SelectList 
-                    items={_.map(all_data_columns, obj => ({id: obj.nick, display: obj.fully_qualified_name }) ) }
-                    selected={ _.map(columns,'nick') }
-                    is_multi_select={true}
-                    onSelect={id=> on_toggle_col_nick(id) }
-                  />
-                </fieldset>
-              </div>
-              <div className="col-md-6">
-                { subject === Gov && 
-                  <div className="rpb-config-item">
-                    <label 
-                      className="rpb-config-header" 
-                    > 
-                      <TextMaker text_key="show_dept_breakout" />
-                      <input 
-                        type="checkbox"
-                        disabled={subject!==Gov}
-                        checked={deptBreakoutMode}
-                        onChange={on_toggle_deptBreakout}
-                        style={{ marginLeft: '15px' }}
-                      />
+        <LabeledBox label={<TextMaker text_key="blue_text_table_controls" />}>
+          <div className="rpb-config rpb-simple row">
+            <div className="col-md-6">
+              <fieldset className="rpb-config-item col-selection simple">
+                <legend className="rpb-config-header"> <TextMaker text_key="select_columns" /> </legend>
+                <SelectList 
+                  items={_.map(all_data_columns, obj => ({id: obj.nick, display: obj.fully_qualified_name }) ) }
+                  selected={ _.map(columns,'nick') }
+                  is_multi_select={true}
+                  onSelect={id=> on_toggle_col_nick(id) }
+                />
+              </fieldset>
+            </div>
+            <div className="col-md-6">
+              { subject === Gov && 
+                <div className="rpb-config-item">
+                  <label 
+                    className="rpb-config-header" 
+                  > 
+                    <TextMaker text_key="show_dept_breakout" />
+                    <input 
+                      type="checkbox"
+                      disabled={subject!==Gov}
+                      checked={deptBreakoutMode}
+                      onChange={on_toggle_deptBreakout}
+                      style={{ marginLeft: '15px' }}
+                    />
+                  </label>
+                </div>
+              }
+              <div className="rpb-config-item">
+                <div className="row">
+                  <div className="col-md-2" style={{paddingLeft: "0px"}}>
+                    <label className="rpb-config-header" htmlFor="dim-select"> 
+                      <span className="nowrap">
+                        <TextMaker text_key="group_by" />
+                      </span>
                     </label>
                   </div>
-                }
+                  <div className="col-md-10">
+                    <Select
+                      id="dim_select"
+                      className="form-control form-control-ib rpb-simple-select"
+                      options={dimensions}
+                      selected={dimension}
+                      onSelect={id => on_set_dimension(id)}
+                    />
+                  </div>
+                  <div className="clearfix" />
+                </div>
+              </div>
+              { deptBreakoutMode &&
                 <div className="rpb-config-item">
                   <div className="row">
                     <div className="col-md-2" style={{paddingLeft: "0px"}}>
-                      <label className="rpb-config-header" htmlFor="dim-select"> 
-                        <span className="nowrap">
-                          <TextMaker text_key="group_by" />
-                        </span>
-                      </label>
+                      <label className="rpb-config-header" htmlFor="filt-select"> <TextMaker text_key="filter" /> </label>
                     </div>
                     <div className="col-md-10">
                       <Select
-                        id="dim_select"
+                        id="filt_select"
                         className="form-control form-control-ib rpb-simple-select"
-                        options={dimensions}
-                        selected={dimension}
-                        onSelect={id => on_set_dimension(id)}
+                        options={filters.sort().map( filter => ({ id: filter, display: filter }) )}
+                        selected={filter}
+                        onSelect={id => on_set_filter({
+                          dimension: dimension, 
+                          filter: id,
+                        })}
                       />
                     </div>
                     <div className="clearfix" />
                   </div>
                 </div>
-                { deptBreakoutMode &&
-                  <div className="rpb-config-item">
-                    <div className="row">
-                      <div className="col-md-2" style={{paddingLeft: "0px"}}>
-                        <label className="rpb-config-header" htmlFor="filt-select"> <TextMaker text_key="filter" /> </label>
-                      </div>
-                      <div className="col-md-10">
-                        <Select
-                          id="filt_select"
-                          className="form-control form-control-ib rpb-simple-select"
-                          options={filters.sort().map( filter => ({ id: filter, display: filter }) )}
-                          selected={filter}
-                          onSelect={id => on_set_filter({
-                            dimension: dimension, 
-                            filter: id,
-                          })}
-                        />
-                      </div>
-                      <div className="clearfix" />
-                    </div>
-                  </div>
-                }
-              </div>
-              <div className="clearfix" />
+              }
             </div>
-          }
-        />
-        <LabeledBox
-          label={ <TextMaker text_key="blue_text_report_details" args={{table_name: table.name}} /> }
-          content={
-            <Details
-              summary_content={
-                <div>
-                  { table.title } : {subject.name}  
-                </div>
-              }
-              content={
-                <ReportDetails {...this.props} />
-              }
-            />
-          }
-        />
-        <LabeledBox
-          label={ <TextMaker text_key="blue_text_report_data_sources" args={{table_name: table.name}} /> }
-          content={ <ReportDatasets {...this.props} /> }
-        />
+            <div className="clearfix" />
+          </div>
+        </LabeledBox>
+        <LabeledBox label={<TextMaker text_key="blue_text_report_details" args={{table_name: table.name}} />}>
+          <Details
+            summary_content={
+              <div>
+                { table.title } : {subject.name}  
+              </div>
+            }
+            content={
+              <ReportDetails {...this.props} />
+            }
+          />
+        </LabeledBox>
+        <LabeledBox label={<TextMaker text_key="blue_text_report_data_sources" args={{table_name: table.name}} />}>
+          <ReportDatasets {...this.props} /> 
+        </LabeledBox>
         { table.rpb_banner && <AlertBanner>{table.rpb_banner}</AlertBanner> }
         <div id="rpb-main-content" >
           { 

--- a/client/src/rpb/simple_view.js
+++ b/client/src/rpb/simple_view.js
@@ -25,7 +25,8 @@ const granular_rpb_link_for_filter = (currentProps, filter) => rpb_link({ ...cur
 
 
 class SimpleView extends React.Component {
-  render(){
+
+  render() {
     const {
       subject,
       table,
@@ -44,7 +45,6 @@ class SimpleView extends React.Component {
       on_toggle_col_nick,
       on_toggle_deptBreakout,
     } = this.props;
-
     return (
       <div> 
         <LabeledBox label={<TextMaker text_key="blue_text_table_controls" />}>
@@ -120,6 +120,7 @@ class SimpleView extends React.Component {
                   </div>
                 </div>
               }
+              <ShareReport/>
             </div>
             <div className="clearfix" />
           </div>
@@ -138,9 +139,6 @@ class SimpleView extends React.Component {
         </LabeledBox>
         <LabeledBox label={<TextMaker text_key="blue_text_report_data_sources" args={{table_name: table.name}} />}>
           <ReportDatasets {...this.props} /> 
-        </LabeledBox>
-        <LabeledBox label={<TextMaker text_key="share_report"/>}>
-          <ShareReport /> 
         </LabeledBox>
         { table.rpb_banner && <AlertBanner>{table.rpb_banner}</AlertBanner> }
         <div id="rpb-main-content" >

--- a/client/src/rpb/state_and_data.js
+++ b/client/src/rpb/state_and_data.js
@@ -47,6 +47,7 @@ function get_default_state_for_new_table(table_id){
     page_num: 0,
     sort_col: 'dept',
     descending: false,
+    broken_url: false,
   };
 }
 

--- a/client/src/rpb/state_and_data.js
+++ b/client/src/rpb/state_and_data.js
@@ -5,7 +5,6 @@ import { createSelector } from 'reselect';
 import { Subject } from '../models/subject.js';
 
 const {
-  Gov,
   Program,
   Dept,
 } = Subject;
@@ -329,28 +328,6 @@ function create_mapStateToProps(){
     )
   );
 
-  const get_canGraph = createSelector(
-    [get_table, get_subject, get_sorted_columns, _.property('preferDeptBreakout'), _.property('filter') ],
-    (table, subject, columns, preferDeptBreakout, filter ) => {
-      if(columns.length > 1){
-        return false;
-      } else {
-        // the only case we can't graph a single column is when we're trying to 
-        //  show a dept breakout with no filters on a non-linearly lined column 
-        //(e.g. lapse % column)
-        const col = _.first(columns);
-        return !(
-          preferDeptBreakout && 
-          subject === Gov && 
-          filter === text_maker('all') && 
-          ( !col.formula || !col.formula.default )
-        );
-      }
-    }
-  );
-
-  const get_shouldGraph = state => !window.is_a11y_mode && !state.preferTable && get_canGraph(state);
-
   const get_deptBreakoutMode = state => state.subject === 'gov_gov' && state.preferDeptBreakout;
 
   const reverse_array = arr => _.clone(arr).reverse();
@@ -519,8 +496,6 @@ function create_mapStateToProps(){
 
       //simple view props,
       deptBreakoutMode: get_deptBreakoutMode(state),
-      canGraph: !window.is_a11y_mode && state.table && get_canGraph(state),
-      shouldGraph: state.table && get_shouldGraph(state),
       graph_data: state.table && state.mode === 'simple' && get_graph_split_data(state),
       simple_table_rows: state.table && state.mode === 'simple' && get_simple_table_rows(state),
 

--- a/client/src/rpb/state_and_data.js
+++ b/client/src/rpb/state_and_data.js
@@ -47,7 +47,7 @@ function get_default_state_for_new_table(table_id){
     filter: text_maker('all'),
     page_num: 0,
     sort_col: 'dept',
-    descending: false, 
+    descending: false,
   };
 }
 
@@ -106,7 +106,8 @@ const reducer = (state=initial_state, action) => {
       if(state.sort_col === col_nick){
         return {...state, descending: !state.descending };
       } else {
-        return {...state,
+        return {
+          ...state,
           sort_col: col_nick,
           descending: true, 
           page_num: 0,
@@ -117,10 +118,11 @@ const reducer = (state=initial_state, action) => {
 
     case 'toggle_col_nick': {
       const col_nick = payload;
-      if(state.columns.length < 2 && _.includes(state.columns, col_nick ) ){ 
+      if( state.columns.length < 2 && _.includes(state.columns, col_nick) ){ 
         return state; 
       }
-      return {...state,
+      return {
+        ...state,
         columns: _.toggle_list(state.columns, col_nick),
         page_num: 0,
       };
@@ -134,7 +136,8 @@ const reducer = (state=initial_state, action) => {
 
     case 'set_filter': {
       const { dimension, filter} = payload;
-      return {...state,
+      return {
+        ...state,
         dimension,
         filter,
         page_num: 0,
@@ -142,7 +145,8 @@ const reducer = (state=initial_state, action) => {
     }
 
     case 'set_dimension': {
-      return {...state,
+      return {
+        ...state,
         dimension: payload,
         filter: text_maker('all'),
         page_num: 0,
@@ -152,7 +156,8 @@ const reducer = (state=initial_state, action) => {
 
     case 'set_subject': {
       const { guid } = payload;
-      return {...state,
+      return {
+        ...state,
         subject: guid,
         filter: text_maker('all'),
         page_num: 0,
@@ -160,7 +165,8 @@ const reducer = (state=initial_state, action) => {
     }
 
     case 'toggle_deptBreakout': {
-      return {...state,
+      return {
+        ...state,
         preferDeptBreakout: !state.preferDeptBreakout,
         filter: text_maker('all'),
         page_num: 0,
@@ -168,14 +174,16 @@ const reducer = (state=initial_state, action) => {
     }
 
     case 'toggle_preferTable': {
-      return {...state,
+      return {
+        ...state,
         preferTable: !state.preferTable,
         page_num: 0,
       };
     }
 
     case 'switch_mode': {
-      return {...state,
+      return {
+        ...state,
         mode: payload,
         page_num: 0,
       };
@@ -183,7 +191,8 @@ const reducer = (state=initial_state, action) => {
     }
 
     case 'set_page': {
-      return {...state,
+      return {
+        ...state,
         page_num: payload,
       };
 


### PR DESCRIPTION
Closes #250 

TODOs:
  - [x] catch when JSURL chokes on a bad URL, don't go full error page
  - [x] fall back to table picker and display a banner explaining the faulty link
    - [x] write the text for that
      - [ ] review and translate that text
  - [x] still log bad RPB URLs (as `{MISC1: 'BROKEN_RPB_URL', MISC2: <the broken url>}`)

STRETCH:
  - [x] ~should I try and recover parts of a bad URL? E.g., if the table name is still present I could parse it out with regex and at least default to the right table? I'm leaning away from this right now~ yeah, not going to do this, would be too confusing to explain to users and would still mean they aren't looking at what whoever shared the link wanted to show them (which is just room for further confusion)
  - [x] Add share and copy to clipboard utils to the report builder, since broken URLs LOOK to be mostly copy-paste errors. ~This could be a separate PR though.~ Should have been though
    - [x] ~double-stretch goal on this one, but if the share/copy to clipboard gave something like a shortened URL, this would be even more resilient to link mangling. This idea probably won't happen soon, but I might open an issue to store the thought in, in case the share utils don't do enough to solve the issue~ opened as issue #303 