### PR TITLE
Reinstate type for subjects

### DIFF
--- a/client/src/models/organizational_entities.js
+++ b/client/src/models/organizational_entities.js
@@ -172,6 +172,9 @@ const Dept = class Dept extends static_subject_store_with_API_data(){
   get minister(){
     return _.map(this.ministers, 'name');
   }
+  get type(){ // not a great variable name, but too hard to fix all the instances that could exist
+    return this.inst_form.name;
+  }
   get auditor(){
     return this.auditor_str;
   }

--- a/client/src/panels/igoc/igoc_panel.js
+++ b/client/src/panels/igoc/igoc_panel.js
@@ -35,7 +35,7 @@ export const declare_igoc_fields_panel = () => declare_panel({
           ["acronym", subject.abbr],
           ["previously_named", subject.old_name],
           ["incorp_yr", subject.incorp_yr],
-          ["type", subject.inst_form.name],
+          ["type", subject.type],
           ["website", !subject.is_dead && subject.website_url && <ExternalLink href={generate_href(subject.website_url)}>{subject.website_url}</ExternalLink>],
           ["eval_links", !subject.is_dead && subject.eval_url && <ExternalLink href={generate_href(subject.eval_url)}>{subject.eval_url}</ExternalLink>],
           ["minister", !_.isEmpty(subject.minister) && _.chain(subject.minister).flatMap( (minister, ix) => [minister, <br key={ix} />]).dropRight().value()],

--- a/client/src/panels/intro_graphs/hierarchy_component.js
+++ b/client/src/panels/intro_graphs/hierarchy_component.js
@@ -161,7 +161,6 @@ const _HierarchyPeek = ({root}) => (
 export const org_external_hierarchy = ({ subject, href_generator }) => {
 
   const is_subject = subj => subj === subject;
-
   return {
     name: Gov.name,
     href: href_generator(Gov),


### PR DESCRIPTION
I tried to get rid of `subject.type` in favour of `subject.inst_form.name`, but I missed at least one use of it in the hierarchy builder used for one of the about panels and I'm no longer confident I'd be able to track down all instances of `type` in the code. So, putting it back in.