### PR TITLE
Fix React warning about href=`false` in ResultsTable

### DIFF
--- a/client/src/panels/result_graphs/result_flat_table.js
+++ b/client/src/panels/result_graphs/result_flat_table.js
@@ -70,7 +70,7 @@ const subject_link = (node) => {
         {node.data.name}
         {` (${text_maker("a_masc")} `}
         <a
-          href={window.is_a11y_mode && glossary_href("SSP")}
+          href={window.is_a11y_mode ? glossary_href("SSP") : undefined}
           className="nowrap glossary-tooltip-link"
           tabIndex={0}
           aria-hidden="true"


### PR DESCRIPTION
> Warning: Received `false` for a non-boolean attribute `href`.