### PR TITLE
Disable RPB broken link banner

### DIFF
--- a/client/src/rpb/TablePicker.js
+++ b/client/src/rpb/TablePicker.js
@@ -25,7 +25,7 @@ const BrokenLinkBanner = () => (
 
 export const AccessibleTablePicker = ({ tables, onSelect, selected, broken_url }) => (
   <Fragment>
-    {broken_url && <BrokenLinkBanner />}
+    {false && broken_url && <BrokenLinkBanner /> /* disabled while table_picker_broken_link_warning is translated*/}
     <select
       aria-labelledby="picker-label"
       className="form-control form-control-ib rpb-simple-select"

--- a/client/src/rpb/rpb.yaml
+++ b/client/src/rpb/rpb.yaml
@@ -16,7 +16,7 @@ rpb_pick_org:
 
 
 table_picker_broken_link_warning:
-  en: You were brought here by a report builder link which could not be properly parsed. If you know what data you were looking for, please select the appropriate table below.
+  en: The link that brought you here contained errors and your report could not be generated. If you know what data you were looking for, please select it from the tables below."
   fr: TODO
 
 table_picker_none_selected_summary:


### PR DESCRIPTION
Oops, forgot to finalize and translate the banner text in #301. Tweaked the text here and, more importantly, disabled the banner for now. Can't turn it on in production until that text is translated.