### PR TITLE
Tweak name of text based version to text-only version

### DIFF
--- a/client/src/InfoBase/index.hbs.html
+++ b/client/src/InfoBase/index.hbs.html
@@ -35,7 +35,7 @@
         <div class="container">
           {{#unless is_a11y_mode}}
             <div style='margin:0 auto; text-align: center'>
-              <a class="a11y-version-link" href={{a11y_version_url}}>{{a11y_version_text}}</a>
+              <a class="a11y-version-link" href={{a11y_version_url}}>{{a11y_version_title}}, {{a11y_version_text}}</a>
             </div>
           {{/unless}}
           <div class="row">

--- a/client/src/InfoBase/index_data.js
+++ b/client/src/InfoBase/index_data.js
@@ -136,15 +136,19 @@ const index_lang_lookups = {
     en: "index-basic-eng.html",
     fr: "index-basic-fra.html",
   },
+  a11y_version_title: {
+    en: "Text-only version",
+    fr: "Version texte seulement",
+  },
   a11y_version_text: {
-    en: "Text based version",
-    fr: "Version basé en texte",
+    en: "recommended for screen reader users",
+    fr: "TODO",
   },
   standard_version_url: {
     en: "index-eng.html",
     fr: "index-fra.html",
   },
-  standard_version_text: {
+  standard_version_titile: {
     en: "Graphical version",
     fr: "Version graphique",
   },

--- a/client/src/InfoBase/index_data.js
+++ b/client/src/InfoBase/index_data.js
@@ -142,7 +142,7 @@ const index_lang_lookups = {
   },
   a11y_version_text: {
     en: "recommended for screen reader users",
-    fr: "TODO",
+    fr: "recommandé pour les utilisateurs de lecteur d'écran",
   },
   standard_version_url: {
     en: "index-eng.html",

--- a/client/src/InfoBase/index_data.js
+++ b/client/src/InfoBase/index_data.js
@@ -138,11 +138,11 @@ const index_lang_lookups = {
   },
   a11y_version_title: {
     en: "Text-only version",
-    fr: "Version texte seulement",
+    fr: "Version texte",
   },
   a11y_version_text: {
     en: "recommended for screen reader users",
-    fr: "recommandé pour les utilisateurs de lecteur d'écran",
+    fr: "recommandée pour les utilisateurs de lecteur d'écran",
   },
   standard_version_url: {
     en: "index-eng.html",

--- a/client/src/core/InsertRuntimeFooterLinks.js
+++ b/client/src/core/InsertRuntimeFooterLinks.js
@@ -9,12 +9,12 @@ const footer_link_items = _.compact([
   !window.is_a11y_mode && {
     id: "footer-a11y-link",
     href: index_lang_lookups.a11y_version_url[window.lang],
-    text: index_lang_lookups.a11y_version_text[window.lang],
+    text: index_lang_lookups.a11y_version_title[window.lang],
   },
   window.is_a11y_mode && {
     id: "footer-standard-link",
     href: index_lang_lookups.standard_version_url[window.lang],
-    text: index_lang_lookups.standard_version_text[window.lang],
+    text: index_lang_lookups.standard_version_titile[window.lang],
   },
 ]);
 

--- a/client/src/home/a11y-home.yaml
+++ b/client/src/home/a11y-home.yaml
@@ -29,14 +29,14 @@ home_a11y_subject_section_title:
 home_a11y_non_a11y_redirect_warning:
   transform: [markdown]
   en: |
-    You have been redirect to the text based InfoBase from a page with no text-only equivalent. 
+    You have been redirect to the text-only InfoBase from a page with no text-only equivalent. 
     Pages with no text-only equivalent are purely for visualization purposes and are not the sole presentation of any data in the InfoBase.
     Any information which was presented on the page you were redirected from can be found in the [report builder](#rpb).
   fr: |
-    Vous avez été redirigé vers une version d'InfoBase textuel à partir d'une page sans équivalent textuel.
+    Vous avez été redirigé vers une version d'InfoBase texte seulement à partir d'une page sans équivalent texte seulement.
     Les pages sans équivalent textuel servent à visualiser des donées et ne constituent pas la seule présentation de ces données dans l'InfoBase.
     Toute information présentée sur la page à partir de laquelle vous avez été redirigé se trouve dans le [générateur de rapports](#rpb).
 
 home_a11y_desc:
-  en: Text based Infobase home for improved accessibility
-  fr: Version texte de l’Infobase pour meilleure accessibilité
+  en: Text-only Infobase home, for improved accessibility
+  fr: Version texte seulement de l’Infobase, pour meilleure accessibilité

--- a/client/src/home/a11y-home.yaml
+++ b/client/src/home/a11y-home.yaml
@@ -29,14 +29,14 @@ home_a11y_subject_section_title:
 home_a11y_non_a11y_redirect_warning:
   transform: [markdown]
   en: |
-    You have been redirect to the text-only InfoBase from a page with no text-only equivalent. 
+    You have been redirected to the text-only InfoBase from a page with no text-only equivalent. 
     Pages with no text-only equivalent are purely for visualization purposes and are not the sole presentation of any data in the InfoBase.
     Any information which was presented on the page you were redirected from can be found in the [report builder](#rpb).
   fr: |
-    Vous avez été redirigé vers une version d'InfoBase texte seulement à partir d'une page sans équivalent texte seulement.
+    Vous avez été redirigé vers une version d'InfoBase textuel à partir d'une page sans équivalent textuel.
     Les pages sans équivalent textuel servent à visualiser des donées et ne constituent pas la seule présentation de ces données dans l'InfoBase.
     Toute information présentée sur la page à partir de laquelle vous avez été redirigé se trouve dans le [générateur de rapports](#rpb).
 
 home_a11y_desc:
-  en: Text-only Infobase home, for improved accessibility
-  fr: Version texte seulement de l’Infobase, pour meilleure accessibilité
+  en: Text-only Infobase home for improved accessibility
+  fr: Version texte de l’Infobase pour meilleure accessibilité


### PR DESCRIPTION
"text-only" seems to be the common phrase. Definitely a little more accurate than "text based".

Could someone take a second look at the french? There's also a short (partial sentence) untranslated, if anyone things they know what it should be. If not, I'll get it translated proper.