### PR TITLE
Tooltip a11y review

### DIFF
--- a/client/src/components/GlossaryIcon.js
+++ b/client/src/components/GlossaryIcon.js
@@ -1,6 +1,6 @@
 import { IconQuestion } from '../icons/icons.js';
 import { GlossaryEntry } from '../models/glossary.js';
-import { glossary_href } from '../link_utils.js'
+import { glossary_href } from '../link_utils.js';
 
 export const GlossaryIcon = ({id, alternate_text, arrow_selector, inner_selector, icon_color, icon_alt_color}) => (
   ( window.is_a11y_mode || window.feature_detection.is_mobile() ) ?

--- a/client/src/components/GlossaryIcon.js
+++ b/client/src/components/GlossaryIcon.js
@@ -1,0 +1,28 @@
+import { IconQuestion } from '../icons/icons.js';
+import { GlossaryEntry } from '../models/glossary.js';
+import { glossary_href } from '../link_utils.js'
+
+export const GlossaryIcon = ({id, alternate_text, arrow_selector, inner_selector, icon_color, icon_alt_color}) => (
+  ( window.is_a11y_mode || window.feature_detection.is_mobile() ) ?
+  <a href={glossary_href(id)}>{alternate_text || GlossaryEntry.lookup(id).title}</a> :
+  <span
+    className="tag-glossary-item"
+    aria-hidden="true"
+    tabIndex="0"
+    data-toggle="tooltip"
+    data-ibtt-glossary-key={id}
+    data-ibtt-html="true"
+    data-ibtt-arrowselector={arrow_selector ? arrow_selector : null}
+    data-ibtt-innerselector={inner_selector ? inner_selector : null}
+  >
+    <IconQuestion
+      color={icon_color ? icon_color : window.infobase_color_constants.backgroundColor}
+      width={"1.2em"}
+      alternate_color={icon_alt_color ? icon_alt_color : window.infobase_color_constants.primaryColor}
+      vertical_align={"-0.3em"}
+    />
+  </span>
+);
+
+
+

--- a/client/src/components/index.js
+++ b/client/src/components/index.js
@@ -27,6 +27,7 @@ export { PDFGenerator } from './PDFGenerator.js';
 export { CountdownCircle } from './CountdownCircle.js';
 export { Countdown } from './Countdown.js';
 export { LogInteractionEvents } from './LogInteractionEvents.js';
+export { GlossaryIcon } from './GlossaryIcon.js';
 
 export { StatelessModal, FixedPopover } from './modals_and_popovers';
 

--- a/client/src/panels/result_graphs/result_components.js
+++ b/client/src/panels/result_graphs/result_components.js
@@ -321,7 +321,7 @@ const StatusIconTable = ({ icon_counts, onIconClick, onClearClick, active_list }
             key: status_key,
             active: active_list.length === 0 || _.indexOf(active_list, status_key) !== -1,
             count: icon_counts[status_key] || 0,
-            text: !window.is_a11y ? 
+            text: !window.is_a11y_mode ? 
               (
                 <span
                   className="link-unstyled"

--- a/client/src/resource_explorer/resource-explorer.js
+++ b/client/src/resource_explorer/resource-explorer.js
@@ -6,11 +6,11 @@ import classNames from 'classnames';
 
 import { 
   infograph_href_template,
-  glossary_href,
 } from '../link_utils.js';
 import { StandardRouteContainer } from '../core/NavComponents';
 import { get_col_defs } from '../gen_expl/resource-explorer-common.js';
 import { Subject } from '../models/subject.js';
+import { GlossaryEntry } from '../models/glossary.js';
 import { current_drr_key, current_dp_key } from '../models/results.js';
 import { 
   create_text_maker_component,
@@ -19,6 +19,7 @@ import {
   TabbedControls,
   Details,
   AlertBanner,
+  GlossaryIcon,
 } from '../components/index.js';
 
 
@@ -39,44 +40,11 @@ import {
 } from '../gen_expl/state_and_memoizing';
 import { ensure_loaded } from '../core/lazy_loader.js';
 import { Explorer } from '../components/ExplorerComponents.js';
-import { IconQuestion } from '../icons/icons';
 
 const INCLUDE_OTHER_TAGS = true;
 const { text_maker, TM } = create_text_maker_component(explorer_text);
 
 const dp_only_schemes = ["MLT"];
-
-
-
-const get_image_glossary_tooltip = (id) => {
-  const glossary_link = glossary_href(id);
-
-  const img = <span
-    style={{marginLeft: "10px"}}
-    aria-hidden="true"
-    tabIndex="0"
-    data-toggle="tooltip"
-    data-ibtt-glossary-key={id}
-    data-ibtt-html="true"
-  >
-    <IconQuestion
-      inline={true}
-      color={window.infobase_color_constants.tertiaryColor}
-      alternate_color={window.infobase_color_constants.primaryColor}
-    />
-  </span>;
-
-  return glossary_link && (
-    window.feature_detection.is_mobile() ? 
-      img :
-      <a 
-        href={glossary_link} 
-        style={{lineHeight: 1.5}}
-      >
-        {img}
-      </a>
-  );
-};
 
 const children_grouper = (node, children) => {
   if(node.root){
@@ -292,7 +260,6 @@ class ExplorerPage extends React.Component {
     // DRR_TODO: all refine the check for including other tags, drr18 has all the tags dp19 does
     const all_category_props = [ min_props, dept_props, goco_props, hwh_props, ...(doc === "dp19" && INCLUDE_OTHER_TAGS ? [wwh_props, hi_props] : []) ];
     const current_category = _.find(all_category_props, props => props.active);
-
     return <div>
       <div style={{marginBottom: '35px'}}>
         <TM k="tag_nav_intro_text" el="div" />
@@ -338,7 +305,13 @@ class ExplorerPage extends React.Component {
           </div>
           <h2 style={{marginBottom: "10px"}}>
             { current_category && current_category.text }
-            { current_category && get_image_glossary_tooltip(current_category.id) }
+            { current_category && GlossaryEntry.lookup(current_category.id) && 
+              <GlossaryIcon
+                id={current_category.id}
+                icon_color={window.infobase_color_constants.tertiaryColor}
+                icon_alt_color={window.infobase_color_constants.primaryColor}
+              />
+            }
           </h2>
           { is_m2m &&
             <AlertBanner banner_class="danger">

--- a/client/src/rpb/TablePicker.js
+++ b/client/src/rpb/TablePicker.js
@@ -5,8 +5,7 @@ import { GlossaryEntry } from '../models/glossary.js';
 import { Fragment } from 'react';
 import { TransitionGroup, CSSTransition } from 'react-transition-group';
 import classNames from 'classnames';
-import { IconQuestion } from '../icons/icons.js';
-import { AlertBanner } from '../components';
+import { AlertBanner, GlossaryIcon } from '../components';
 
 import { 
   categories,
@@ -262,25 +261,6 @@ class TaggedItemCloud extends React.Component {
         .map(c => _.filter(tags,{ "id": c }))
         .flatten()
         .value()]));
-    
-    const generate_glossary_tooltip = (concept_id, container) => (
-      <div
-        className="tag-glossary-item"
-        aria-hidden="true"
-        tabIndex="0"
-        data-toggle="tooltip"
-        data-ibtt-glossary-key={concept_id}
-        data-ibtt-html="true"
-        data-ibtt-arrowselector="TablePicker__tooltip-arrow"
-        data-ibtt-innerselector="TablePicker__tooltip-inner"
-      >
-        <IconQuestion
-          color={window.infobase_color_constants.backgroundColor}
-          alternate_color={window.infobase_color_constants.primaryColor}
-          vertical_align={"-0.6em"}
-        />
-      </div>
-    );
 
     return <div>
       <div style={{padding: '0px'}}>
@@ -307,7 +287,11 @@ class TaggedItemCloud extends React.Component {
                     </button>
                     { GlossaryEntry.lookup(id) &&
                       <span className="tag-button-helper" tabIndex="0" >
-                        {generate_glossary_tooltip(id, document.getElementById("tbp-main"))}
+                        <GlossaryIcon
+                          id={id}
+                          inner_selector={"TablePicker__tooltip-inner"}
+                          arrow_selector={"TablePicker__tooltip-arrow"}
+                        />
                       </span>
                     }
                   </li>


### PR DESCRIPTION
Closes #200

I checked all the non-handlebars invocations of the tooltip activator, and they mostly had alternate link forms for mobile/a11y, but two places (tag explorer and table picker) used the question mark icon for glossary tooltips, so I componentized it.