### PR TITLE
Remove average avg age year to year change stats

### DIFF
--- a/client/src/panels/people/employee_age.yaml
+++ b/client/src/panels/people/employee_age.yaml
@@ -25,7 +25,7 @@ dept_employee_age_text:
    De **{{fmt_big_int_real dept_head_count_age_first_active_year}}** à **{{fmt_big_int_real dept_head_count_age_last_active_year}}**, les personnes âgées de **{{fmt_big_int_real dept_head_count_age_top}}** constituaient en moyenne le plus fort contingent (**{{fmt_percentage1 dept_head_count_age_top_avg_percent}}**) d’employés **{{de_dept dept}}**.
 
    Au cours de cette période, **l’âge moyen** des employés **{{de_dept dept}}** **{{fr_two_value_changed_to dept_avgage_first_active_value dept_avgage_last_active_value "m" "s" "fmt_decimal1"}}**.
-   Aux fins de comparaison, l’âge moyen des employés de la **fonction publique fédérale** **{{fr_two_value_changed_to gov_avgage_last_year_5 gov_avgage_last_year "m" "s" "fmt_decimal1"}}**.
+   Aux fins de comparaison, l’âge moyen de tous les employés de la **fonction publique fédérale** **{{fr_two_value_changed_to gov_avgage_last_year_5 gov_avgage_last_year "m" "s" "fmt_decimal1"}}**.
 
 gov_employee_age_text_temporary_no_avg_age:
   transform: [handlebars,markdown]

--- a/client/src/panels/people/employee_age.yaml
+++ b/client/src/panels/people/employee_age.yaml
@@ -8,24 +8,24 @@ gov_employee_age_text:
   en: |
    From **{{ppl_last_year_5}}** to **{{ppl_last_year}}**, people aged **{{fmt_big_int_real gov_head_count_age_top}}** accounted for the largest average share (**{{fmt_percentage1 gov_head_count_age_top_avg_percent}}**) of **Federal Public Service** employees.
    
-   Over this period, the **average age** of **Federal Public Service** employees **{{two_value_changed_to gov_avgage_last_year_5 gov_avgage_last_year "fmt_decimal1"}}**, with an average March-to-March change of **{{plus_or_minus_val gov_avgage_avg_change "fmt_decimal"}}** years.
+   Over this period, the **average age** of **Federal Public Service** employees **{{two_value_changed_to gov_avgage_last_year_5 gov_avgage_last_year "fmt_decimal1"}}**.
   fr: |
    De **{{ppl_last_year_5}}** à **{{ppl_last_year}}**, les personnes âgées de **{{fmt_big_int_real gov_head_count_age_top}}** constituaient en moyenne le plus fort contingent (**{{fmt_percentage1 gov_head_count_age_top_avg_percent}}**) de l’effectif de la **fonction publique fédérale**.
 
-   Au cours de cette période, **l’âge moyen** des employés de la **fonction publique fédérale** **{{fr_two_value_changed_to gov_avgage_last_year_5 gov_avgage_last_year "m" "s" "fmt_decimal1"}}**, l’écart moyen de mars à mars étant **{{plus_or_minus_val gov_avgage_avg_change "fmt_decimal"}}** année.
+   Au cours de cette période, **l’âge moyen** des employés de la **fonction publique fédérale** **{{fr_two_value_changed_to gov_avgage_last_year_5 gov_avgage_last_year "m" "s" "fmt_decimal1"}}**.
 
 dept_employee_age_text:
   transform: [handlebars,markdown]
   en: |
    From **{{fmt_big_int_real dept_head_count_age_first_active_year}}** to **{{fmt_big_int_real dept_head_count_age_last_active_year}}**, people aged **{{fmt_big_int_real dept_head_count_age_top}}** accounted for the largest average share (**{{fmt_percentage1 dept_head_count_age_top_avg_percent}}**) of **{{subj_name subject}}** employees.
 
-   Over this period, the **average age** of **{{subj_name subject}}** employees **{{two_value_changed_to dept_avgage_first_active_value dept_avgage_last_active_value "fmt_decimal1"}}**, with an average March-to-March change of **{{plus_or_minus_val dept_avgage_avg_change "fmt_decimal"}}** years.
-   For comparison, from **{{dept_avgage_first_active_year}}** to **{{dept_avgage_last_active_year}}**, the average March-to-March change for the overall **Federal Public Service** was **{{plus_or_minus_val dept_gov_avgage_avg_change "fmt_decimal"}}** years.
+   Over this period, the **average age** of **{{subj_name subject}}** employees **{{two_value_changed_to dept_avgage_first_active_value dept_avgage_last_active_value "fmt_decimal1"}}**.
+   For comparison, the average age of all **Federal Public Service** employees **{{two_value_changed_to gov_avgage_last_year_5 gov_avgage_last_year "fmt_decimal1"}}**.
   fr: |
    De **{{fmt_big_int_real dept_head_count_age_first_active_year}}** à **{{fmt_big_int_real dept_head_count_age_last_active_year}}**, les personnes âgées de **{{fmt_big_int_real dept_head_count_age_top}}** constituaient en moyenne le plus fort contingent (**{{fmt_percentage1 dept_head_count_age_top_avg_percent}}**) d’employés **{{de_dept dept}}**.
 
-   Au cours de cette période, **l’âge moyen** des employés **{{de_dept dept}}** **{{fr_two_value_changed_to dept_avgage_first_active_value dept_avgage_last_active_value "m" "s" "fmt_decimal1"}}**, l’écart moyen de mars à mars étant **{{plus_or_minus_val dept_avgage_avg_change "fmt_decimal"}}** année.
-   Aux fins de comparaison, de **{{dept_avgage_first_active_year}}** à **{{dept_avgage_last_active_year}}**, l’écart moyen de mars à mars pour l’ensemble de la **fonction publique fédérale** était **{{plus_or_minus_val dept_gov_avgage_avg_change "fmt_decimal"}}** année.
+   Au cours de cette période, **l’âge moyen** des employés **{{de_dept dept}}** **{{fr_two_value_changed_to dept_avgage_first_active_value dept_avgage_last_active_value "m" "s" "fmt_decimal1"}}**.
+   Aux fins de comparaison, l’âge moyen des employés de la **fonction publique fédérale** **{{fr_two_value_changed_to gov_avgage_last_year_5 gov_avgage_last_year "m" "s" "fmt_decimal1"}}**.
 
 gov_employee_age_text_temporary_no_avg_age:
   transform: [handlebars,markdown]

--- a/client/src/tables/orgEmployeeAvgAge.js
+++ b/client/src/tables/orgEmployeeAvgAge.js
@@ -144,33 +144,6 @@ Statistics.create_and_register({
     add("avgage_first_active_value",dept_data[first_active]);
     add("avgage_last_active_year",m(people_years[last_active]));
     add("avgage_last_active_value",dept_data[last_active]);
-    
-    const dept_avg_change = _.chain(dept_data)
-      .filter((d,i) => ((i>= first_active) && (i <= last_active)))
-      .reduce((memo, val, i, dept_data) => {
-        if ((i+1) < dept_data.length) {
-          return (memo*i + (dept_data[i+1]-val))/(i+1);
-        } else {
-          return memo;
-        }
-      },0)
-      .value();
-    
-    add("avgage_avg_change",dept_avg_change);
-    
-    const gov_avg_change = _.chain(people_years)
-      .filter((d,i) => ((i>= first_active) && (i <= last_active)))
-      .map(y => table.GOC[0][y])
-      .reduce((memo, val, i, dept_data) => {
-        if ((i+1) < dept_data.length) {
-          return (memo*i + (dept_data[i+1]-val))/(i+1);
-        } else {
-          return memo;
-        }
-      },0)
-      .value();
-    
-    add("gov_avgage_avg_change",gov_avg_change);
   },
 });
 


### PR DESCRIPTION
The French text for dept_employee_age_text could use a look. I added an 'all' before Federal Public Service in English to make it read better, don't know if the French needs anything too.

Closes #52 