### PR TITLE
Get rid of $000 format across the infobase

### DIFF
--- a/client/src/TreeMap/TreeMap.js
+++ b/client/src/TreeMap/TreeMap.js
@@ -29,8 +29,8 @@ const { TM, text_maker } = create_text_maker_component([treemap_text]);
 
 const format_display_number = (value, is_fte = false, raw = false) =>
   raw ?
-    is_fte ? `${formats.big_int_real_raw(Math.round(value))} ${text_maker("fte")}` : formats.compact1_raw(value) :
-    is_fte ? `${formats.big_int_real(Math.round(value))} ${text_maker("fte")}` : formats.compact1(value);
+    is_fte ? `${formats.big_int_raw(Math.round(value))} ${text_maker("fte")}` : formats.compact1_raw(value) :
+    is_fte ? `${formats.big_int(Math.round(value))} ${text_maker("fte")}` : formats.compact1(value);
 
 
 function generate_infograph_href(d, data_area) {

--- a/client/src/TreeMap/TreeMapLegend.js
+++ b/client/src/TreeMap/TreeMapLegend.js
@@ -22,10 +22,10 @@ const proportional_block = () =>
       <rect className="mutLegendBG" fill="white" stroke="black" strokeWidth="2" width="60" height="60" />
       <rect className="mutLegendBG" fill="white" stroke="black" strokeWidth="2" width="30" height="30" />
       <text className="breakLabels" x="25" y="25" style={{ textAnchor: "end", display: "block" }} >
-        {`${formats.big_int_real_raw(25)}`}
+        {`${formats.big_int_raw(25)}`}
       </text>
       <text className="breakLabels" x="55" y="55" style={{ textAnchor: "end", display: "block" }} >
-        {`${formats.big_int_real_raw(100)}`}
+        {`${formats.big_int_raw(100)}`}
       </text>
     </g>
   </svg>;

--- a/client/src/charts/NivoCharts.js
+++ b/client/src/charts/NivoCharts.js
@@ -12,7 +12,7 @@ const get_formatter = (is_money, formatter, raw = true) => (
   _.isUndefined(formatter) ?
     ( 
       !is_money ? 
-        (value) => formats.big_int_real(value, {raw}) :
+        (value) => formats.big_int(value, {raw}) :
         (
           raw ? 
             (value) => dollar_formats.compact2_raw(value) : 

--- a/client/src/common_css/site.scss
+++ b/client/src/common_css/site.scss
@@ -1,7 +1,7 @@
 @import "common-variables";
 
 div.int{width: 95px;text-align:center;}
-div.big_int_real,
+div.big_int,
 div.decimal, 
 div.short-str,
 div.decimal1 {

--- a/client/src/common_css/site.scss
+++ b/client/src/common_css/site.scss
@@ -1,7 +1,6 @@
 @import "common-variables";
 
 div.int{width: 95px;text-align:center;}
-div.big_int{width: 100px;text-align:right;}
 div.big_int_real,
 div.decimal, 
 div.short-str,

--- a/client/src/common_text/common_lang.yaml
+++ b/client/src/common_text/common_lang.yaml
@@ -756,10 +756,6 @@ results_overview:
   en: Results at a glance 
   fr: Aperçu sur les résultats
 
-in_thousands:
-  en: "($000)"
-  fr: "(en milliers de dollars)"
-
 difference:
   en: Difference
   fr: Différence

--- a/client/src/common_text/template_globals.csv
+++ b/client/src/common_text/template_globals.csv
@@ -30,7 +30,6 @@ planning_year_2,2020-21,2020-2021
 planning_year_3,2021-22,2021-2022
 Gov,Government of Canada,Gouvernement du Canada
 mar_31,March 31,31 mars
-short_thousand," <span class=""text-nowra"">($000)</span> "," <span class=""text-nowra"">(000$)</span>"
 mains_date,April 16th,16 avril
 p,P13,P13
 ppl_last_year,March 2019,mars 2019

--- a/client/src/core/TableClass.js
+++ b/client/src/core/TableClass.js
@@ -408,7 +408,7 @@ export class Table extends mix().with(staticStoreMixin){
         // need to handle special cases of '.', '', and '-'
         if ( _.includes(['percentage', 'decimal', 'decimal1', 'percentage1', 'percentage2'], type) && !_.isNaN(parseFloat(val)) ){
           row_obj[key]=parseFloat(val);
-        } else if ( (type === 'big_int' || type === "big_int" || type === 'int') && !_.isNaN(parseInt(val,10))){
+        } else if ( (type === 'big_int' || type === 'int') && !_.isNaN(parseInt(val,10))){
           row_obj[key]=parseInt(val,10);
         } else if (_.includes(['.','','-'], val) && _.includes(['percentage', 'decimal', 'decimal1', 'percentage1', 'percentage2', 'big_int', 'big_int', 'int'], type) ){
           row_obj[key]=0;

--- a/client/src/core/TableClass.js
+++ b/client/src/core/TableClass.js
@@ -408,9 +408,9 @@ export class Table extends mix().with(staticStoreMixin){
         // need to handle special cases of '.', '', and '-'
         if ( _.includes(['percentage', 'decimal', 'decimal1', 'percentage1', 'percentage2'], type) && !_.isNaN(parseFloat(val)) ){
           row_obj[key]=parseFloat(val);
-        } else if ( (type === 'big_int' || type === "big_int_real" || type === 'int') && !_.isNaN(parseInt(val,10))){
+        } else if ( (type === 'big_int' || type === "big_int" || type === 'int') && !_.isNaN(parseInt(val,10))){
           row_obj[key]=parseInt(val,10);
-        } else if (_.includes(['.','','-'], val) && _.includes(['percentage', 'decimal', 'decimal1', 'percentage1', 'percentage2', 'big_int', 'big_int_real', 'int'], type) ){
+        } else if (_.includes(['.','','-'], val) && _.includes(['percentage', 'decimal', 'decimal1', 'percentage1', 'percentage2', 'big_int', 'big_int', 'int'], type) ){
           row_obj[key]=0;
         }
       });

--- a/client/src/core/format.js
+++ b/client/src/core/format.js
@@ -143,11 +143,7 @@ const types_to_format = {
   "decimal2": (val, lang, options) => number_formatter[lang][2].format(val),
   "decimal": (val, lang, options) => number_formatter[lang][3].format(val),
   "big_int": (val, lang, options) => {
-    const value = _.isArray(val) ?
-      _.map(val, x => x/1000) :
-      val/1000;
-    
-    const rtn = number_formatter[lang][0].format(value);
+    const rtn = number_formatter[lang][0].format(val);
 
     if (options.raw){
       return rtn;
@@ -155,7 +151,6 @@ const types_to_format = {
       return `<span class='text-nowrap'>${rtn}</span>`;
     }
   },
-  "big_int_real": (val, lang, options) => types_to_format["big_int"](val*1000, lang, options),
   "int": (val) => val,
   "ordinal": (val) => val,
   "str": (val) => val,

--- a/client/src/diff/TextDiff.yaml
+++ b/client/src/diff/TextDiff.yaml
@@ -124,6 +124,6 @@ list_of_indicators:
 indicator_counts_text:
   transform: [handlebars,markdown]
   en: |
-    **{{fmt_big_int_real num_indicators}}** {{plural_branch num_indicators "indicator" "indicators"}} match the current filters.
+    **{{fmt_big_int num_indicators}}** {{plural_branch num_indicators "indicator" "indicators"}} match the current filters.
   fr: |
-    **{{fmt_big_int_real num_indicators}}** {{plural_branch num_indicators "indicateur" "indicateurs"}} correspondent aux paramètres de filtrages choisis.    
+    **{{fmt_big_int num_indicators}}** {{plural_branch num_indicators "indicateur" "indicateurs"}} correspondent aux paramètres de filtrages choisis.    

--- a/client/src/gen_expl/resource-explorer-common.js
+++ b/client/src/gen_expl/resource-explorer-common.js
@@ -44,7 +44,7 @@ export const get_col_defs = ({doc}) => [
       />
     ),
     get_val: node => _.get(node, "data.resources.ftes"),
-    val_display: val => _.isNumber(val) ? <Format type="big_int_real" content={val} /> : null,
+    val_display: val => _.isNumber(val) ? <Format type="big_int" content={val} /> : null,
   },
 ];
 

--- a/client/src/igoc_explorer/igoc_explorer.yaml
+++ b/client/src/igoc_explorer/igoc_explorer.yaml
@@ -46,7 +46,7 @@ show_orgs_without_data:
 displayed_orgs_count:
   transform: [handlebars,markdown]
   text: |
-    {{gt "inst_form_corp_int_filter"}}: **{{rawfmt_big_int_real org_count}}** 
+    {{gt "inst_form_corp_int_filter"}}: **{{rawfmt_big_int org_count}}** 
 
 by_pop_group:
   en: By population group

--- a/client/src/panels/drr_dp_resources/crso_by_prog.js
+++ b/client/src/panels/drr_dp_resources/crso_by_prog.js
@@ -115,7 +115,7 @@ class PlannedProgramResources extends React.Component {
             data={programs.map(({data, label}) => ({
               label,
               /* eslint-disable react/jsx-key */
-              data: data.map(amt => <Format type={is_fte? "big_int_real" : "compact1"} content={amt} /> ),
+              data: data.map(amt => <Format type={is_fte? "big_int" : "compact1"} content={amt} /> ),
             }))}
           />
         </div>

--- a/client/src/panels/drr_dp_resources/crso_by_prog.yaml
+++ b/client/src/panels/drr_dp_resources/crso_by_prog.yaml
@@ -15,8 +15,8 @@ crso_by_prog_exp_or_ftes:
    In {{planning_year_1}}, {{gl_tt (pluralize crso_prg_num "program")  "PROG"}}
    {{#isEqual crso_prg_num 1}}falls{{else}}fall{{/isEqual}} under this {{gt "core_resp"}}
    {{#if is_fte}}
-   with **{{crso_prg_top1}}** ({{fmt_big_int_real crso_prg_top1_amnt}} FTEs) being the largest in terms of employment,
-   {{#if crso_prg_top2_amnt}} followed by **{{crso_prg_top2}}** ({{fmt_big_int_real crso_prg_top2_amnt}} FTEs). {{else}}. {{/if}}
+   with **{{crso_prg_top1}}** ({{fmt_big_int crso_prg_top1_amnt}} FTEs) being the largest in terms of employment,
+   {{#if crso_prg_top2_amnt}} followed by **{{crso_prg_top2}}** ({{fmt_big_int crso_prg_top2_amnt}} FTEs). {{else}}. {{/if}}
    {{else}}
    with **{{fmt_compact1_written crso_prg_top1}}** ({{fmt_compact1_written crso_prg_top1_amnt}}) being the largest in terms of spending,
    {{#if crso_prg_top2_amnt}} followed by **{{crso_prg_top2}}** ({{fmt_compact1_written crso_prg_top2_amnt}}). {{else}}. {{/if}}
@@ -25,8 +25,8 @@ crso_by_prog_exp_or_ftes:
   fr: |
    En {{planning_year_1}}, cette responsabilité essentielle compte {{gl_tt (pluralize crso_prg_num "programme") "PROG"}}.
    {{#if is_fte}}
-   Le plus important en termes d'employés étant **{{crso_prg_top1}}** ({{fmt_big_int_real crso_prg_top1_amnt}} ETP)
-   {{#if crso_prg_top2_amnt}} suivi par **{{crso_prg_top2}}** ({{fmt_big_int_real crso_prg_top2_amnt}} ETP). {{else}}. {{/if}}
+   Le plus important en termes d'employés étant **{{crso_prg_top1}}** ({{fmt_big_int crso_prg_top1_amnt}} ETP)
+   {{#if crso_prg_top2_amnt}} suivi par **{{crso_prg_top2}}** ({{fmt_big_int crso_prg_top2_amnt}} ETP). {{else}}. {{/if}}
    {{else}}
    Le plus important en terme de dépenses étant **{{crso_prg_top1}}** ({{fmt_compact1_written crso_prg_top1_amnt}})
    {{#if crso_prg_top2_amnt}} suivi par **{{crso_prg_top2}}** ({{fmt_compact1_written crso_prg_top2_amnt}}). {{else}}. {{/if}}

--- a/client/src/panels/drr_dp_resources/drr_planned_actual.yaml
+++ b/client/src/panels/drr_dp_resources/drr_planned_actual.yaml
@@ -6,20 +6,20 @@ drr_planned_actual_title:
 dept_drr_planned_actual_text:
   transform: [handlebars, markdown]
   en: |
-    In {{pa_last_year}}, {{subj_name subject}} planned to spend **{{fmt_compact1_written planned_spend}}** and employ **{{fmt_big_int_real planned_ftes}}** {{gl_tt "full-time equivalents (FTE)" "FTE"}}. It actually spent {{fmt_compact1_written actual_spend}} and employed {{fmt_big_int_real actual_ftes}} FTEs.
+    In {{pa_last_year}}, {{subj_name subject}} planned to spend **{{fmt_compact1_written planned_spend}}** and employ **{{fmt_big_int planned_ftes}}** {{gl_tt "full-time equivalents (FTE)" "FTE"}}. It actually spent {{fmt_compact1_written actual_spend}} and employed {{fmt_big_int actual_ftes}} FTEs.
   fr: |
-    En {{pa_last_year}}, {{subj_name subject}} prévoyait dépenser **{{fmt_compact1_written planned_spend}}** et employer **{{fmt_big_int_real planned_ftes}}** {{gl_tt "équivalents temps plein (ETP)" "FTE"}}. En fait, l'organisation a dépensé **{{fmt_compact1_written actual_spend}}** et employé **{{fmt_big_int_real actual_ftes}}** ETP.
+    En {{pa_last_year}}, {{subj_name subject}} prévoyait dépenser **{{fmt_compact1_written planned_spend}}** et employer **{{fmt_big_int planned_ftes}}** {{gl_tt "équivalents temps plein (ETP)" "FTE"}}. En fait, l'organisation a dépensé **{{fmt_compact1_written actual_spend}}** et employé **{{fmt_big_int actual_ftes}}** ETP.
 
 program_drr_planned_actual_text:
   transform: [handlebars, markdown]
   en: |
-    In {{pa_last_year}}, the **{{subj_name subject}}** program planned to spend **{{fmt_compact1_written planned_spend}}** and employ **{{fmt_big_int_real planned_ftes}}** {{gl_tt "full-time equivalents (FTE)" "FTE"}}. It actually spent **{{fmt_compact1_written actual_spend}}** and employed **{{fmt_big_int_real actual_ftes}}** FTEs.
+    In {{pa_last_year}}, the **{{subj_name subject}}** program planned to spend **{{fmt_compact1_written planned_spend}}** and employ **{{fmt_big_int planned_ftes}}** {{gl_tt "full-time equivalents (FTE)" "FTE"}}. It actually spent **{{fmt_compact1_written actual_spend}}** and employed **{{fmt_big_int actual_ftes}}** FTEs.
   fr: |
-    En {{pa_last_year}}, le programme **«{{subj_name subject}}»** prévoyait dépenser **{{fmt_compact1_written planned_spend}}** et employer **{{fmt_big_int_real planned_ftes}}** {{gl_tt "équivalents temps plein (ETP)" "FTE"}}. En fait, le programme a dépensé **{{fmt_compact1_written actual_spend}}** et employé **{{fmt_big_int_real actual_ftes}}** ETP.
+    En {{pa_last_year}}, le programme **«{{subj_name subject}}»** prévoyait dépenser **{{fmt_compact1_written planned_spend}}** et employer **{{fmt_big_int planned_ftes}}** {{gl_tt "équivalents temps plein (ETP)" "FTE"}}. En fait, le programme a dépensé **{{fmt_compact1_written actual_spend}}** et employé **{{fmt_big_int actual_ftes}}** ETP.
 
 crso_drr_planned_actual_text:
   transform: [handlebars, markdown]
   en: |
-    In {{pa_last_year}}, the {{gl_tt (pluralize crso_prg_num "program")  "PROG"}} that fell under the **{{subj_name subject}}** {{gl_tt (gt "core_resp") "CR"}} planned to spend **{{fmt_compact1_written planned_spend}}** and employ **{{fmt_big_int_real planned_ftes}}** {{gl_tt "full-time equivalents (FTE)" "FTE"}}. They actually spent **{{fmt_compact1_written actual_spend}}** and employed **{{fmt_big_int_real actual_ftes}}** FTEs.
+    In {{pa_last_year}}, the {{gl_tt (pluralize crso_prg_num "program")  "PROG"}} that fell under the **{{subj_name subject}}** {{gl_tt (gt "core_resp") "CR"}} planned to spend **{{fmt_compact1_written planned_spend}}** and employ **{{fmt_big_int planned_ftes}}** {{gl_tt "full-time equivalents (FTE)" "FTE"}}. They actually spent **{{fmt_compact1_written actual_spend}}** and employed **{{fmt_big_int actual_ftes}}** FTEs.
   fr: |
-    En {{pa_last_year}}, le {{gl_tt (gt "core_resp") "CR"}} **{{subj_name subject}}** compte {{gl_tt (pluralize crso_prg_num "programme") "PROG"}}. Ces programme prévoyait dépenser **{{fmt_compact1_written planned_spend}}** et employer **{{fmt_big_int_real planned_ftes}}** {{gl_tt "équivalents temps plein (ETP)" "FTE"}}. En fait, le programme a dépensé **{{fmt_compact1_written actual_spend}}** et employé **{{fmt_big_int_real actual_ftes}}** ETP.
+    En {{pa_last_year}}, le {{gl_tt (gt "core_resp") "CR"}} **{{subj_name subject}}** compte {{gl_tt (pluralize crso_prg_num "programme") "PROG"}}. Ces programme prévoyait dépenser **{{fmt_compact1_written planned_spend}}** et employer **{{fmt_big_int planned_ftes}}** {{gl_tt "équivalents temps plein (ETP)" "FTE"}}. En fait, le programme a dépensé **{{fmt_compact1_written actual_spend}}** et employé **{{fmt_big_int actual_ftes}}** ETP.

--- a/client/src/panels/intro_graphs/simplographic.yaml
+++ b/client/src/panels/intro_graphs/simplographic.yaml
@@ -25,9 +25,9 @@ simplographic_people_title:
 simplographic_people_text:
   transform: [handlebars,markdown]
   en: |
-    As of **{{ppl_last_year_end_ticks}}** there were **<a href="{{org_employee_type_link}}">{{fmt_big_int_real empl_count_total}}</a>** employees in the {{gl_tt "Federal Public Service" "FPS"}}, with **<a href="{{org_employee_region_link}}">{{fmt_percentage1 empl_count_ncr_ratio}}</a>** located in the National Capital Region.
+    As of **{{ppl_last_year_end_ticks}}** there were **<a href="{{org_employee_type_link}}">{{fmt_big_int empl_count_total}}</a>** employees in the {{gl_tt "Federal Public Service" "FPS"}}, with **<a href="{{org_employee_region_link}}">{{fmt_percentage1 empl_count_ncr_ratio}}</a>** located in the National Capital Region.
   fr: |
-    Au **31 mars {{ppl_last_year_short_second}}**, il y avait **<a href="{{org_employee_type_link}}">{{fmt_big_int_real empl_count_total}}</a>** employés au sein de la {{gl_tt "fonction publique générale" "FPS"}}, dont **<a href="{{org_employee_region_link}}">{{fmt_percentage1 empl_count_ncr_ratio}}</a>** travaillaient dans la région de la capitale nationale.
+    Au **31 mars {{ppl_last_year_short_second}}**, il y avait **<a href="{{org_employee_type_link}}">{{fmt_big_int empl_count_total}}</a>** employés au sein de la {{gl_tt "fonction publique générale" "FPS"}}, dont **<a href="{{org_employee_region_link}}">{{fmt_percentage1 empl_count_ncr_ratio}}</a>** travaillaient dans la région de la capitale nationale.
 
 simplographic_struct_title:
   en: How we're structured
@@ -48,9 +48,9 @@ simplographic_results_title:
 simplographic_results_text:
   transform: [handlebars,markdown]
   en: |
-    In {{pa_last_year}}, the federal government sought to achieve **{{num_results}}** results. Progress towards meeting these results was measured using **{{fmt_big_int_real num_indicators}}** {{gl_tt "indicators" "IND_RESULT"}}. 
-    Of those indicators, **{{fmt_big_int_real num_met}}** (**{{fmt_percentage pct_met}}**) have {{gl_tt "met" "RESULTS_MET"}} their target.
+    In {{pa_last_year}}, the federal government sought to achieve **{{num_results}}** results. Progress towards meeting these results was measured using **{{fmt_big_int num_indicators}}** {{gl_tt "indicators" "IND_RESULT"}}. 
+    Of those indicators, **{{fmt_big_int num_met}}** (**{{fmt_percentage pct_met}}**) have {{gl_tt "met" "RESULTS_MET"}} their target.
   fr: |
-    En {{pa_last_year}}, le gouvernement fédéral a cherché à rencontrer **{{num_results}}** résultats. Les progrès accomplis dans l'atteinte de ces résultats ont été mesurés à l’aide de **{{fmt_big_int_real num_indicators}}** {{gl_tt "indicateurs" "IND_RESULT"}}. 
-    De ces indicateurs, **{{fmt_big_int_real num_met}}** (**{{fmt_percentage pct_met}}**) ont {{gl_tt "atteint" "RESULTS_MET"}} leur cible.
+    En {{pa_last_year}}, le gouvernement fédéral a cherché à rencontrer **{{num_results}}** résultats. Les progrès accomplis dans l'atteinte de ces résultats ont été mesurés à l’aide de **{{fmt_big_int num_indicators}}** {{gl_tt "indicateurs" "IND_RESULT"}}. 
+    De ces indicateurs, **{{fmt_big_int num_met}}** (**{{fmt_percentage pct_met}}**) ont {{gl_tt "atteint" "RESULTS_MET"}} leur cible.
 

--- a/client/src/panels/people/employee_age.js
+++ b/client/src/panels/people/employee_age.js
@@ -136,7 +136,7 @@ export const declare_employee_age_panel = () => declare_panel({
         graph_options: {
           ticks: ticks,
           y_axis: text_maker("employees"),
-          formatter: formats.big_int_real_raw,
+          formatter: formats.big_int_raw,
         },
         initial_graph_mode: "bar_grouped",
         data: graph_args.age_group,

--- a/client/src/panels/people/employee_age.yaml
+++ b/client/src/panels/people/employee_age.yaml
@@ -6,23 +6,23 @@ employee_age_title:
 gov_employee_age_text:
   transform: [handlebars,markdown]
   en: |
-   From **{{ppl_last_year_5}}** to **{{ppl_last_year}}**, people aged **{{fmt_big_int_real gov_head_count_age_top}}** accounted for the largest average share (**{{fmt_percentage1 gov_head_count_age_top_avg_percent}}**) of **Federal Public Service** employees.
+   From **{{ppl_last_year_5}}** to **{{ppl_last_year}}**, people aged **{{fmt_big_int gov_head_count_age_top}}** accounted for the largest average share (**{{fmt_percentage1 gov_head_count_age_top_avg_percent}}**) of **Federal Public Service** employees.
    
    Over this period, the **average age** of **Federal Public Service** employees **{{two_value_changed_to gov_avgage_last_year_5 gov_avgage_last_year "fmt_decimal1"}}**.
   fr: |
-   De **{{ppl_last_year_5}}** à **{{ppl_last_year}}**, les personnes âgées de **{{fmt_big_int_real gov_head_count_age_top}}** constituaient en moyenne le plus fort contingent (**{{fmt_percentage1 gov_head_count_age_top_avg_percent}}**) de l’effectif de la **fonction publique fédérale**.
+   De **{{ppl_last_year_5}}** à **{{ppl_last_year}}**, les personnes âgées de **{{fmt_big_int gov_head_count_age_top}}** constituaient en moyenne le plus fort contingent (**{{fmt_percentage1 gov_head_count_age_top_avg_percent}}**) de l’effectif de la **fonction publique fédérale**.
 
    Au cours de cette période, **l’âge moyen** des employés de la **fonction publique fédérale** **{{fr_two_value_changed_to gov_avgage_last_year_5 gov_avgage_last_year "m" "s" "fmt_decimal1"}}**.
 
 dept_employee_age_text:
   transform: [handlebars,markdown]
   en: |
-   From **{{fmt_big_int_real dept_head_count_age_first_active_year}}** to **{{fmt_big_int_real dept_head_count_age_last_active_year}}**, people aged **{{fmt_big_int_real dept_head_count_age_top}}** accounted for the largest average share (**{{fmt_percentage1 dept_head_count_age_top_avg_percent}}**) of **{{subj_name subject}}** employees.
+   From **{{fmt_big_int dept_head_count_age_first_active_year}}** to **{{fmt_big_int dept_head_count_age_last_active_year}}**, people aged **{{fmt_big_int dept_head_count_age_top}}** accounted for the largest average share (**{{fmt_percentage1 dept_head_count_age_top_avg_percent}}**) of **{{subj_name subject}}** employees.
 
    Over this period, the **average age** of **{{subj_name subject}}** employees **{{two_value_changed_to dept_avgage_first_active_value dept_avgage_last_active_value "fmt_decimal1"}}**.
    For comparison, the average age of all **Federal Public Service** employees **{{two_value_changed_to gov_avgage_last_year_5 gov_avgage_last_year "fmt_decimal1"}}**.
   fr: |
-   De **{{fmt_big_int_real dept_head_count_age_first_active_year}}** à **{{fmt_big_int_real dept_head_count_age_last_active_year}}**, les personnes âgées de **{{fmt_big_int_real dept_head_count_age_top}}** constituaient en moyenne le plus fort contingent (**{{fmt_percentage1 dept_head_count_age_top_avg_percent}}**) d’employés **{{de_dept dept}}**.
+   De **{{fmt_big_int dept_head_count_age_first_active_year}}** à **{{fmt_big_int dept_head_count_age_last_active_year}}**, les personnes âgées de **{{fmt_big_int dept_head_count_age_top}}** constituaient en moyenne le plus fort contingent (**{{fmt_percentage1 dept_head_count_age_top_avg_percent}}**) d’employés **{{de_dept dept}}**.
 
    Au cours de cette période, **l’âge moyen** des employés **{{de_dept dept}}** **{{fr_two_value_changed_to dept_avgage_first_active_value dept_avgage_last_active_value "m" "s" "fmt_decimal1"}}**.
    Aux fins de comparaison, l’âge moyen de tous les employés de la **fonction publique fédérale** **{{fr_two_value_changed_to gov_avgage_last_year_5 gov_avgage_last_year "m" "s" "fmt_decimal1"}}**.
@@ -30,15 +30,15 @@ dept_employee_age_text:
 gov_employee_age_text_temporary_no_avg_age:
   transform: [handlebars,markdown]
   en: |
-   From **{{ppl_last_year_5}}** to **{{ppl_last_year}}**, people aged **{{fmt_big_int_real gov_head_count_age_top}}** accounted for the largest average share (**{{fmt_percentage1 gov_head_count_age_top_avg_percent}}**) of **Federal Public Service** employees.
+   From **{{ppl_last_year_5}}** to **{{ppl_last_year}}**, people aged **{{fmt_big_int gov_head_count_age_top}}** accounted for the largest average share (**{{fmt_percentage1 gov_head_count_age_top_avg_percent}}**) of **Federal Public Service** employees.
    
   fr: |
-   De **{{ppl_last_year_5}}** à **{{ppl_last_year}}**, les personnes âgées de **{{fmt_big_int_real gov_head_count_age_top}}** constituaient en moyenne le plus fort contingent (**{{fmt_percentage1 gov_head_count_age_top_avg_percent}}**) de l’effectif de la **fonction publique fédérale**.
+   De **{{ppl_last_year_5}}** à **{{ppl_last_year}}**, les personnes âgées de **{{fmt_big_int gov_head_count_age_top}}** constituaient en moyenne le plus fort contingent (**{{fmt_percentage1 gov_head_count_age_top_avg_percent}}**) de l’effectif de la **fonction publique fédérale**.
 
 dept_employee_age_text_temporary_no_avg_age:
   transform: [handlebars,markdown]
   en: |
-   From **{{fmt_big_int_real dept_head_count_age_first_active_year}}** to **{{fmt_big_int_real dept_head_count_age_last_active_year}}**, people aged **{{fmt_big_int_real dept_head_count_age_top}}** accounted for the largest average share (**{{fmt_percentage1 dept_head_count_age_top_avg_percent}}**) of **{{subj_name subject}}** employees.
+   From **{{fmt_big_int dept_head_count_age_first_active_year}}** to **{{fmt_big_int dept_head_count_age_last_active_year}}**, people aged **{{fmt_big_int dept_head_count_age_top}}** accounted for the largest average share (**{{fmt_percentage1 dept_head_count_age_top_avg_percent}}**) of **{{subj_name subject}}** employees.
 
   fr: |
-   De **{{fmt_big_int_real dept_head_count_age_first_active_year}}** à **{{fmt_big_int_real dept_head_count_age_last_active_year}}**, les personnes âgées de **{{fmt_big_int_real dept_head_count_age_top}}** constituaient en moyenne le plus fort contingent (**{{fmt_percentage1 dept_head_count_age_top_avg_percent}}**) d’employés **{{de_dept dept}}**.
+   De **{{fmt_big_int dept_head_count_age_first_active_year}}** à **{{fmt_big_int dept_head_count_age_last_active_year}}**, les personnes âgées de **{{fmt_big_int dept_head_count_age_top}}** constituaient en moyenne le plus fort contingent (**{{fmt_percentage1 dept_head_count_age_top_avg_percent}}**) d’employés **{{de_dept dept}}**.

--- a/client/src/panels/people/employee_executive_level.js
+++ b/client/src/panels/people/employee_executive_level.js
@@ -98,7 +98,7 @@ export const declare_employee_executive_level_panel = () => declare_panel({
                   graph_options: {
                     y_axis: text_maker("employees"),
                     ticks: ticks,
-                    formatter: formats.big_int_real_raw,
+                    formatter: formats.big_int_raw,
                   },
                   initial_graph_mode: "bar_stacked",
                   data: graph_args,

--- a/client/src/panels/people/employee_executive_level.yaml
+++ b/client/src/panels/people/employee_executive_level.yaml
@@ -6,34 +6,34 @@ employee_executive_level_title:
 gov_employee_executive_level_text:
   transform: [handlebars,markdown]
   en: |
-   From **{{ppl_last_year_5}}** to **{{ppl_last_year}}**, an average of **{{fmt_big_int_real gov_head_count_ex_level_avg_ex}}** **Federal Public Service** employees occupied a position at the executive level, representing an average of **{{fmt_percentage1 gov_head_count_ex_avg_share}}** of the total **Federal Public Service** population.
+   From **{{ppl_last_year_5}}** to **{{ppl_last_year}}**, an average of **{{fmt_big_int gov_head_count_ex_level_avg_ex}}** **Federal Public Service** employees occupied a position at the executive level, representing an average of **{{fmt_percentage1 gov_head_count_ex_avg_share}}** of the total **Federal Public Service** population.
    
-   Over this period, employees at the **{{fmt_big_int_real gov_head_count_ex_level_top}}** level accounted for the largest executive group with an average share of **{{fmt_percentage1 gov_head_count_ex_level_top_avg_percent}}** of the total executive population.
-   The smallest executive group was the **{{fmt_big_int_real gov_head_count_ex_level_bottom}}** level, with an average share of **{{fmt_percentage1 gov_head_count_ex_level_bottom_avg_percent}}** of the total executive population.
+   Over this period, employees at the **{{fmt_big_int gov_head_count_ex_level_top}}** level accounted for the largest executive group with an average share of **{{fmt_percentage1 gov_head_count_ex_level_top_avg_percent}}** of the total executive population.
+   The smallest executive group was the **{{fmt_big_int gov_head_count_ex_level_bottom}}** level, with an average share of **{{fmt_percentage1 gov_head_count_ex_level_bottom_avg_percent}}** of the total executive population.
   fr: |
-   De **{{ppl_last_year_5}}** à **{{ppl_last_year}}**, en moyenne, **{{fmt_big_int_real gov_head_count_ex_level_avg_ex}}** employés de la **fonction publique fédérale** occupaient un poste de direction, soit **{{fmt_percentage1 gov_head_count_ex_avg_share}}** de l’effectif moyen. 
+   De **{{ppl_last_year_5}}** à **{{ppl_last_year}}**, en moyenne, **{{fmt_big_int gov_head_count_ex_level_avg_ex}}** employés de la **fonction publique fédérale** occupaient un poste de direction, soit **{{fmt_percentage1 gov_head_count_ex_avg_share}}** de l’effectif moyen. 
    
-   Au cours de cette période, les employés de niveau **{{fmt_big_int_real gov_head_count_ex_level_top}}** constituaient le plus fort contingent, avec une moyenne de **{{fmt_percentage1 gov_head_count_ex_level_top_avg_percent}}** du nombre total de cadres de direction. 
-   Le niveau **{{fmt_big_int_real gov_head_count_ex_level_bottom}}** formait le plus petit contingent, avec une moyenne de **{{fmt_percentage1 gov_head_count_ex_level_bottom_avg_percent}}** du numbre total de cadres de direction.
+   Au cours de cette période, les employés de niveau **{{fmt_big_int gov_head_count_ex_level_top}}** constituaient le plus fort contingent, avec une moyenne de **{{fmt_percentage1 gov_head_count_ex_level_top_avg_percent}}** du nombre total de cadres de direction. 
+   Le niveau **{{fmt_big_int gov_head_count_ex_level_bottom}}** formait le plus petit contingent, avec une moyenne de **{{fmt_percentage1 gov_head_count_ex_level_bottom_avg_percent}}** du numbre total de cadres de direction.
 
 
 dept_employee_executive_level_text:
   transform: [handlebars,markdown]
   en: |
-   From **{{fmt_big_int_real dept_head_count_ex_level_years_first_active_year}}** to **{{fmt_big_int_real dept_head_count_ex_level_years_last_active_year}}**, an average of **{{fmt_big_int_real dept_head_count_ex_level_avg_ex}}** **{{subj_name subject}}** employees occupied a position at the executive level, representing an average share of **{{fmt_percentage1 dept_head_count_ex_avg_share}}** of its total population.
+   From **{{fmt_big_int dept_head_count_ex_level_years_first_active_year}}** to **{{fmt_big_int dept_head_count_ex_level_years_last_active_year}}**, an average of **{{fmt_big_int dept_head_count_ex_level_avg_ex}}** **{{subj_name subject}}** employees occupied a position at the executive level, representing an average share of **{{fmt_percentage1 dept_head_count_ex_avg_share}}** of its total population.
    
-   Over this period, employees at the **{{fmt_big_int_real dept_head_count_ex_level_top}}** level accounted for the largest executive group with an average share of **{{fmt_percentage1 dept_head_count_ex_level_top_avg_percent}}** of **{{subj_name subject}}'s** executive population.
+   Over this period, employees at the **{{fmt_big_int dept_head_count_ex_level_top}}** level accounted for the largest executive group with an average share of **{{fmt_percentage1 dept_head_count_ex_level_top_avg_percent}}** of **{{subj_name subject}}'s** executive population.
    {{#isEqual dept_head_count_ex_level_bottom null}}
      
    {{else}}
-     The smallest executive group was the **{{fmt_big_int_real dept_head_count_ex_level_bottom}}** level, with an average share of **{{fmt_percentage1 dept_head_count_ex_level_bottom_avg_percent}}** of **{{subj_name subject}}'s** executive population.
+     The smallest executive group was the **{{fmt_big_int dept_head_count_ex_level_bottom}}** level, with an average share of **{{fmt_percentage1 dept_head_count_ex_level_bottom_avg_percent}}** of **{{subj_name subject}}'s** executive population.
    {{/isEqual}}
   fr: |
-   De **{{fmt_big_int_real dept_head_count_ex_level_years_first_active_year}}** à **{{fmt_big_int_real dept_head_count_ex_level_years_last_active_year}}**, en moyenne, **{{fmt_big_int_real dept_head_count_ex_level_avg_ex}}** employés **{{de_dept dept}}** occupaient un poste de direction, soit **{{fmt_percentage1 dept_head_count_ex_avg_share}}** de l’effectif moyen.
+   De **{{fmt_big_int dept_head_count_ex_level_years_first_active_year}}** à **{{fmt_big_int dept_head_count_ex_level_years_last_active_year}}**, en moyenne, **{{fmt_big_int dept_head_count_ex_level_avg_ex}}** employés **{{de_dept dept}}** occupaient un poste de direction, soit **{{fmt_percentage1 dept_head_count_ex_avg_share}}** de l’effectif moyen.
    
-   Au cours de cette période, les employés de niveau **{{fmt_big_int_real dept_head_count_ex_level_top}}** constituaient le plus fort contingent, avec une moyenne de **{{fmt_percentage1 dept_head_count_ex_level_top_avg_percent}}** du nombre total de cadres de direction **{{de_dept dept}}**. 
+   Au cours de cette période, les employés de niveau **{{fmt_big_int dept_head_count_ex_level_top}}** constituaient le plus fort contingent, avec une moyenne de **{{fmt_percentage1 dept_head_count_ex_level_top_avg_percent}}** du nombre total de cadres de direction **{{de_dept dept}}**. 
    {{#isEqual dept_head_count_ex_level_bottom null}}
      
    {{else}}
-     Le niveau **{{fmt_big_int_real dept_head_count_ex_level_bottom}}** formait le plus petit contingent, avec une moyenne de **{{fmt_percentage1 dept_head_count_ex_level_bottom_avg_percent}}** du numbre total de cadres de direction.
+     Le niveau **{{fmt_big_int dept_head_count_ex_level_bottom}}** formait le plus petit contingent, avec une moyenne de **{{fmt_percentage1 dept_head_count_ex_level_bottom_avg_percent}}** du numbre total de cadres de direction.
    {{/isEqual}}

--- a/client/src/panels/people/employee_fol.js
+++ b/client/src/panels/people/employee_fol.js
@@ -119,7 +119,7 @@ export const declare_employee_fol_panel = () => declare_panel({
                     graph_options: {
                       y_axis: text_maker("employees"),
                       ticks: ticks,
-                      formatter: formats.big_int_real_raw,
+                      formatter: formats.big_int_raw,
                     },
                     initial_graph_mode: "bar_grouped",
                     data: graph_args,

--- a/client/src/panels/people/employee_gender.js
+++ b/client/src/panels/people/employee_gender.js
@@ -119,7 +119,7 @@ export const declare_employee_gender_panel = () => declare_panel({
                     graph_options: {
                       y_axis: text_maker("employees"),
                       ticks: ticks,
-                      formatter: formats.big_int_real_raw,
+                      formatter: formats.big_int_raw,
                     },
                     initial_graph_mode: "bar_grouped",
                     data: graph_args,

--- a/client/src/panels/people/employee_last_year_totals.yaml
+++ b/client/src/panels/people/employee_last_year_totals.yaml
@@ -6,8 +6,8 @@ dept_employee_last_year_totals_title:
 dept_employee_last_year_totals_text:
   transform: [handlebars,markdown]
   en: |
-    In **{{ppl_last_year}}**, **{{fmt_big_int_real dept_head_count_ppl_last_year}}** people were employed by **{{subj_name subject}}**, 
+    In **{{ppl_last_year}}**, **{{fmt_big_int dept_head_count_ppl_last_year}}** people were employed by **{{subj_name subject}}**, 
     representing **{{fmt_percentage1 dept_head_count_dept_share_last_year}}** of the total {{gl_tt "Federal Public Service" "FPS"}} population. 
 
   fr: |
-    En **{{ppl_last_year}}**, **{{fmt_big_int_real dept_head_count_ppl_last_year}}** personnes étaient à l’emploi **{{de_dept dept}}**, soit **{{fmt_percentage1 dept_head_count_dept_share_last_year}}** de l’effectif de la {{gl_tt "fonction publique fédérale" "FPS"}}.
+    En **{{ppl_last_year}}**, **{{fmt_big_int dept_head_count_ppl_last_year}}** personnes étaient à l’emploi **{{de_dept dept}}**, soit **{{fmt_percentage1 dept_head_count_dept_share_last_year}}** de l’effectif de la {{gl_tt "fonction publique fédérale" "FPS"}}.

--- a/client/src/panels/people/employee_prov.js
+++ b/client/src/panels/people/employee_prov.js
@@ -60,7 +60,7 @@ class CanadaGraphBarLegend extends React.Component {
     };
 
     const formatted_data = format_prov_data(prov,years_by_province);
-    const formatter = formats["big_int_real_raw"];
+    const formatter = formats["big_int_raw"];
     return (
       <Fragment>
         <p className="mrgn-bttm-0 mrgn-tp-0 nav-header centerer">
@@ -122,7 +122,7 @@ class CanadaGraph extends React.Component {
 
     const graph_area_sel = d3.select( ReactDOM.findDOMNode(this.graph_area.current) );
 
-    const formatter = formats["big_int_real_raw"];
+    const formatter = formats["big_int_raw"];
     const ticks = _.map(people_years, y => `${run_template(y)}`);
     
     const canada_graph = new Canada(graph_area_sel.node(), {
@@ -215,7 +215,7 @@ class ProvPanel extends React.Component {
     };
 
     const legend_items = _.map( color_scale.ticks(5).reverse(), (tick) => ({
-      label: `${formats["big_int_real_raw"](tick)}+`,
+      label: `${formats["big_int_raw"](tick)}+`,
       active: true,
       id: tick,
       color: get_graph_color( color_scale(tick) ),

--- a/client/src/panels/people/employee_prov.yaml
+++ b/client/src/panels/people/employee_prov.yaml
@@ -1,7 +1,7 @@
 gov_employee_prov_text:
   transform: [handlebars,markdown]
   en: |
-   From **{{ppl_last_year_5}}** to **{{ppl_last_year}}**, the largest average share of **Federal Public Service** employees (**{{fmt_percentage1 gov_head_count_region_top_avg_percent}}**) worked in **{{fmt_big_int_real gov_head_count_region_top}}**.
+   From **{{ppl_last_year_5}}** to **{{ppl_last_year}}**, the largest average share of **Federal Public Service** employees (**{{fmt_percentage1 gov_head_count_region_top_avg_percent}}**) worked in **{{fmt_big_int gov_head_count_region_top}}**.
    
    
    * The National Capital Region (NCR) includes employees working in both Ottawa (Ontario) and Gatineau (Quebec).
@@ -11,7 +11,7 @@ gov_employee_prov_text:
    
 
   fr: |
-   De **{{ppl_last_year_5}}** à **{{ppl_last_year}}**, le plus fort contingent d’employés de la **fonction publique fédérale** (**{{fmt_percentage1 gov_head_count_region_top_avg_percent}}**) travaillait dans **{{fmt_big_int_real gov_head_count_region_top}}**.
+   De **{{ppl_last_year_5}}** à **{{ppl_last_year}}**, le plus fort contingent d’employés de la **fonction publique fédérale** (**{{fmt_percentage1 gov_head_count_region_top_avg_percent}}**) travaillait dans **{{fmt_big_int gov_head_count_region_top}}**.
    
    
    * La région de la capitale nationale (RCN) inclut à la fois les employés qui travaillent à Ottawa (Ontario) et ceux qui travaillent à Gatineau (Québec).
@@ -28,7 +28,7 @@ employee_prov_title:
 dept_employee_prov_text:
   transform: [handlebars,markdown]
   en: |
-   From **{{fmt_big_int_real dept_head_count_region_first_active_year}}** to **{{fmt_big_int_real dept_head_count_region_last_active_year}}**, the largest average share of **{{subj_name subject}}** employees (**{{fmt_percentage1 dept_head_count_region_top_avg_percent}}**) worked in **{{fmt_big_int_real dept_head_count_region_top}}**.
+   From **{{fmt_big_int dept_head_count_region_first_active_year}}** to **{{fmt_big_int dept_head_count_region_last_active_year}}**, the largest average share of **{{subj_name subject}}** employees (**{{fmt_percentage1 dept_head_count_region_top_avg_percent}}**) worked in **{{fmt_big_int dept_head_count_region_top}}**.
 
 
    * The **National Capital Region (NCR)** includes employees working in both Ottawa (Ontario) and Gatineau (Quebec).
@@ -38,7 +38,7 @@ dept_employee_prov_text:
    
 
   fr: |
-   De **{{fmt_big_int_real dept_head_count_region_first_active_year}}** à **{{fmt_big_int_real dept_head_count_region_last_active_year}}**, le plus fort contingent d’employés **{{de_dept dept}}** (**{{fmt_percentage1 dept_head_count_region_top_avg_percent}}**) travaillait dans **{{fmt_big_int_real dept_head_count_region_top}}**.  
+   De **{{fmt_big_int dept_head_count_region_first_active_year}}** à **{{fmt_big_int dept_head_count_region_last_active_year}}**, le plus fort contingent d’employés **{{de_dept dept}}** (**{{fmt_percentage1 dept_head_count_region_top_avg_percent}}**) travaillait dans **{{fmt_big_int dept_head_count_region_top}}**.  
 
    
    * La **région de la capitale nationale (RCN)** inclut à la fois les employés qui travaillent à Ottawa (Ontario) et ceux qui travaillent à Gatineau (Québec).

--- a/client/src/panels/people/employee_totals.js
+++ b/client/src/panels/people/employee_totals.js
@@ -92,7 +92,7 @@ export const declare_employee_totals_panel = () => declare_panel({
                                  </td>
                                  <td style={{padding: '3px 5px'}}> {tooltip_item.serie.id} </td>
                                  <td style = {{padding: '3px 5px'}}> {tooltip_item.data.x}</td>
-                                 <td style={{padding: '3px 5px'}} dangerouslySetInnerHTML={{__html: formats.big_int_real(tooltip_item.data.y)}} />
+                                 <td style={{padding: '3px 5px'}} dangerouslySetInnerHTML={{__html: formats.big_int(tooltip_item.data.y)}} />
                                </tr>
                              )
                            )}

--- a/client/src/panels/people/employee_totals.yaml
+++ b/client/src/panels/people/employee_totals.yaml
@@ -11,17 +11,17 @@ dept_employee_totals_title:
 gov_employee_totals_text:
   transform: [handlebars, markdown]
   en: |
-   In **{{ppl_last_year}}**, there were **{{fmt_big_int_real gov_head_count_ppl_last_year}}** employees in the 
+   In **{{ppl_last_year}}**, there were **{{fmt_big_int gov_head_count_ppl_last_year}}** employees in the 
    **{{gl_tt "Federal Public Service" "FPS"}}**. 
-   From **{{ppl_last_year_5}}** to **{{ppl_last_year}}**, the **Federal Public Service** employed an average of **{{fmt_big_int_real gov_head_count_avg}}** people.
+   From **{{ppl_last_year_5}}** to **{{ppl_last_year}}**, the **Federal Public Service** employed an average of **{{fmt_big_int gov_head_count_avg}}** people.
   fr: |
-   En **{{ppl_last_year}}**, la {{gl_tt "fonction publique fédérale" "FPS"}} comptait **{{fmt_big_int_real gov_head_count_ppl_last_year}}** employés.
-   L’effectif moyen de la **fonction publique fédérale** de **{{ppl_last_year_5}}** à **{{ppl_last_year}}** est de **{{fmt_big_int_real gov_head_count_avg}}** employés.
+   En **{{ppl_last_year}}**, la {{gl_tt "fonction publique fédérale" "FPS"}} comptait **{{fmt_big_int gov_head_count_ppl_last_year}}** employés.
+   L’effectif moyen de la **fonction publique fédérale** de **{{ppl_last_year_5}}** à **{{ppl_last_year}}** est de **{{fmt_big_int gov_head_count_avg}}** employés.
 
 dept_employee_totals_text:
   transform: [handlebars,markdown]
   en: |
-   From **{{fmt_big_int_real dept_head_count_type_first_active_year}}** to **{{fmt_big_int_real dept_head_count_type_last_active_year}}**, **{{subj_name subject}}** employed an average of 
-   **{{fmt_big_int_real dept_head_count_avg}}** people.
+   From **{{fmt_big_int dept_head_count_type_first_active_year}}** to **{{fmt_big_int dept_head_count_type_last_active_year}}**, **{{subj_name subject}}** employed an average of 
+   **{{fmt_big_int dept_head_count_avg}}** people.
   fr: |
-   De **{{fmt_big_int_real dept_head_count_type_first_active_year}}** à **{{fmt_big_int_real dept_head_count_type_last_active_year}}**, **{{le_dept dept}}** comptait en moyenne **{{fmt_big_int_real dept_head_count_avg}}** employés. 
+   De **{{fmt_big_int dept_head_count_type_first_active_year}}** à **{{fmt_big_int dept_head_count_type_last_active_year}}**, **{{le_dept dept}}** comptait en moyenne **{{fmt_big_int dept_head_count_avg}}** employés. 

--- a/client/src/panels/people/employee_type.js
+++ b/client/src/panels/people/employee_type.js
@@ -105,7 +105,7 @@ export const declare_employee_type_panel = () => declare_panel({
                     graph_options: {
                       ticks: ticks,
                       y_axis: text_maker("employees"),
-                      formatter: formats.big_int_real_raw,
+                      formatter: formats.big_int_raw,
                     },
                     initial_graph_mode: "bar_stacked",
                     data: graph_args,

--- a/client/src/panels/people/employee_type.yaml
+++ b/client/src/panels/people/employee_type.yaml
@@ -6,21 +6,21 @@ employee_type_title:
 gov_employee_type_text:
   transform: [handlebars,markdown]
   en: |
-   From **{{ppl_last_year_5}}** to **{{ppl_last_year}}**, the **{{fmt_big_int_real gov_head_count_type_top}}** workforce accounted for the largest average share (**{{fmt_percentage1 gov_head_count_type_top_avg_percent}}**) of the **Federal Public Service** population. 
+   From **{{ppl_last_year_5}}** to **{{ppl_last_year}}**, the **{{fmt_big_int gov_head_count_type_top}}** workforce accounted for the largest average share (**{{fmt_percentage1 gov_head_count_type_top_avg_percent}}**) of the **Federal Public Service** population. 
    
    Over this period, the proportion of **Students** in the **Federal Public Service** **{{two_value_changed_to gov_student_share_last_year_five gov_student_share_last_year "fmt_percentage1"}}**.
   fr: |
-   De **{{ppl_last_year_5}}** à  **{{ppl_last_year}}**, les employés nommés pour une «**{{fmt_big_int_real gov_head_count_type_top}}**» constituaient en moyenne le plus fort contingent (**{{fmt_percentage1 gov_head_count_type_top_avg_percent}}**) de l’effectif de la **fonction publique fédérale**.
+   De **{{ppl_last_year_5}}** à  **{{ppl_last_year}}**, les employés nommés pour une «**{{fmt_big_int gov_head_count_type_top}}**» constituaient en moyenne le plus fort contingent (**{{fmt_percentage1 gov_head_count_type_top_avg_percent}}**) de l’effectif de la **fonction publique fédérale**.
    
    Au cours de cette période, l’effectif **« d’étudiants »** dans la **fonction publique fédérale** **{{fr_two_value_changed_to gov_student_share_last_year_five gov_student_share_last_year "m" "s" "fmt_percentage1"}}**.
 
 dept_employee_type_text:
   transform: [handlebars,markdown] 
   en: |
-   From **{{fmt_big_int_real dept_head_count_type_first_active_year}}** to **{{fmt_big_int_real dept_head_count_type_last_active_year}}**, the **{{fmt_big_int_real dept_head_count_type_top}}** workforce accounted for the largest average share (**{{fmt_percentage1 dept_head_count_type_top_avg_percent}}**) of **{{subj_name subject}}'s** total population.
+   From **{{fmt_big_int dept_head_count_type_first_active_year}}** to **{{fmt_big_int dept_head_count_type_last_active_year}}**, the **{{fmt_big_int dept_head_count_type_top}}** workforce accounted for the largest average share (**{{fmt_percentage1 dept_head_count_type_top_avg_percent}}**) of **{{subj_name subject}}'s** total population.
    
    Over this period, the proportion of **Students** in **{{subj_name subject}}'s** workforce **{{two_value_changed_to dept_student_share_first_active_year dept_student_share_last_active_year "fmt_percentage1"}}**.
   fr: |
-   De **{{fmt_big_int_real dept_head_count_type_first_active_year}}** à **{{fmt_big_int_real dept_head_count_type_last_active_year}}**, les employés nommés pour une «**{{fmt_big_int_real dept_head_count_type_top}}**» constituaient en moyenne le plus fort contingent (**{{fmt_percentage1 dept_head_count_type_top_avg_percent}}**) de l’effectif **{{de_dept dept}}**.
+   De **{{fmt_big_int dept_head_count_type_first_active_year}}** à **{{fmt_big_int dept_head_count_type_last_active_year}}**, les employés nommés pour une «**{{fmt_big_int dept_head_count_type_top}}**» constituaient en moyenne le plus fort contingent (**{{fmt_percentage1 dept_head_count_type_top_avg_percent}}**) de l’effectif **{{de_dept dept}}**.
    
    Au cours de cette période, l’effectif **« d’étudiants »** **{{de_dept dept}}** **{{fr_two_value_changed_to dept_student_share_first_active_year dept_student_share_last_active_year "m" "s" "fmt_percentage1"}}**.

--- a/client/src/panels/result_graphs/drr_summary_text.yaml
+++ b/client/src/panels/result_graphs/drr_summary_text.yaml
@@ -11,39 +11,39 @@ drr_summary_text_intro:
   transform: [handlebars,markdown]
   en: |
     {{#if is_gov}}
-      In {{pa_last_year}}, **{{num_depts}}** organizations sought to achieve **{{fmt_big_int_real drr_results}}** results.
+      In {{pa_last_year}}, **{{num_depts}}** organizations sought to achieve **{{fmt_big_int drr_results}}** results.
     {{else}}
-      In {{pa_last_year}}, {{subj_name subject}} sought to achieve **{{fmt_big_int_real drr_results}}** results.
+      In {{pa_last_year}}, {{subj_name subject}} sought to achieve **{{fmt_big_int drr_results}}** results.
     {{/if}}
-    Progress towards meeting these results was measured using **{{fmt_big_int_real drr_total}}** {{gl_tt "indicators" "IND_RESULT"}}, {{#if drr_past_total}} **{{fmt_big_int_real drr_past_total}}**
+    Progress towards meeting these results was measured using **{{fmt_big_int drr_total}}** {{gl_tt "indicators" "IND_RESULT"}}, {{#if drr_past_total}} **{{fmt_big_int drr_past_total}}**
     of which were seeking to achieve their target **by** March 31, {{pa_last_year_short_second}}{{#if drr_future_total}} and{{else}}.{{/if}}
-    {{/if}}{{#if drr_future_total}} **{{fmt_big_int_real drr_future_total}}** of which are seeking to achieve their target **after** March 31, {{pa_last_year_short_second}}
+    {{/if}}{{#if drr_future_total}} **{{fmt_big_int drr_future_total}}** of which are seeking to achieve their target **after** March 31, {{pa_last_year_short_second}}
     or on an **ongoing** basis.{{/if}}
   fr: |
     {{#if is_gov}}
-      En {{pa_last_year}}, **{{num_depts}}** organisations ont cherché à obtenir **{{fmt_big_int_real drr_results}}** résultats.
+      En {{pa_last_year}}, **{{num_depts}}** organisations ont cherché à obtenir **{{fmt_big_int drr_results}}** résultats.
     {{else}}
-      En {{pa_last_year}}, {{subj_name subject}} a cherché à atteindre **{{fmt_big_int_real drr_results}}** résultats.
+      En {{pa_last_year}}, {{subj_name subject}} a cherché à atteindre **{{fmt_big_int drr_results}}** résultats.
     {{/if}}
-    Les progrès accomplis dans l'atteinte de ces résultats ont été mesurés à l’aide de **{{fmt_big_int_real drr_total}}** {{gl_tt "indicateurs" "IND_RESULT"}}, {{#if drr_past_total}} dont
-    **{{fmt_big_int_real drr_past_total}}** avaient des cibles à **atteindre au plus tard** le 31 mars {{pa_last_year_short_second}}{{#if drr_future_total}} et{{else}}.{{/if}}
-    {{/if}}{{#if drr_future_total}} dont **{{fmt_big_int_real drr_future_total}}** visaient à atteindre leurs cibles **continuellement** ou **après** mars 31
+    Les progrès accomplis dans l'atteinte de ces résultats ont été mesurés à l’aide de **{{fmt_big_int drr_total}}** {{gl_tt "indicateurs" "IND_RESULT"}}, {{#if drr_past_total}} dont
+    **{{fmt_big_int drr_past_total}}** avaient des cibles à **atteindre au plus tard** le 31 mars {{pa_last_year_short_second}}{{#if drr_future_total}} et{{else}}.{{/if}}
+    {{/if}}{{#if drr_future_total}} dont **{{fmt_big_int drr_future_total}}** visaient à atteindre leurs cibles **continuellement** ou **après** mars 31
     {{pa_last_year_short_second}}.{{/if}}
 drr_summary_text_summary_left:
   transform: [handlebars,markdown]
   en: |
     {{#if drr_past_total}}
-    Of the **{{fmt_big_int_real drr_past_total}}** indicators that sought to achieve their target by March 31, {{pa_last_year_short_second}}:
-      {{#if drr_indicators_met}}* **{{fmt_big_int_real drr_indicators_met}}** (**{{fmt_percentage1 (divide drr_indicators_met drr_past_total)}}**) {{gl_tt "met" "RESULTS_MET"}} their target{{/if}}
-      {{#if drr_indicators_not_met}}* **{{fmt_big_int_real drr_indicators_not_met}}** (**{{fmt_percentage1 (divide drr_indicators_not_met drr_past_total)}}**) did {{gl_tt "not meet" "RESULTS_NOT_MET"}} their target{{/if}}
-      {{#if drr_indicators_not_available}}* **{{fmt_big_int_real drr_indicators_not_available}}** (**{{fmt_percentage1 (divide drr_indicators_not_available drr_past_total)}}**) have {{gl_tt "no result available" "RESULTS_NOT_AVAILABLE"}}{{/if}}
+    Of the **{{fmt_big_int drr_past_total}}** indicators that sought to achieve their target by March 31, {{pa_last_year_short_second}}:
+      {{#if drr_indicators_met}}* **{{fmt_big_int drr_indicators_met}}** (**{{fmt_percentage1 (divide drr_indicators_met drr_past_total)}}**) {{gl_tt "met" "RESULTS_MET"}} their target{{/if}}
+      {{#if drr_indicators_not_met}}* **{{fmt_big_int drr_indicators_not_met}}** (**{{fmt_percentage1 (divide drr_indicators_not_met drr_past_total)}}**) did {{gl_tt "not meet" "RESULTS_NOT_MET"}} their target{{/if}}
+      {{#if drr_indicators_not_available}}* **{{fmt_big_int drr_indicators_not_available}}** (**{{fmt_percentage1 (divide drr_indicators_not_available drr_past_total)}}**) have {{gl_tt "no result available" "RESULTS_NOT_AVAILABLE"}}{{/if}}
     {{/if}}
   fr: |
     {{#if drr_past_total}}
-    De ces **{{fmt_big_int_real drr_past_total}}** indicateurs qui devaient atteindre leur cible au plus tard le 31 mars {{pa_last_year_short_second}}:
-      {{#if drr_indicators_met}}* **{{fmt_big_int_real drr_indicators_met}}** (**{{fmt_percentage1 (divide drr_indicators_met drr_past_total)}}**) {{gl_tt "ont atteint" "RESULTS_MET"}} leur cible{{/if}}
-      {{#if drr_indicators_not_met}}* **{{fmt_big_int_real drr_indicators_not_met}}** (**{{fmt_percentage1 (divide drr_indicators_not_met drr_past_total)}}**) {{gl_tt "n’ont pas atteint" "RESULTS_NOT_MET"}} leur cible{{/if}}
-      {{#if drr_indicators_not_available}}* **{{fmt_big_int_real drr_indicators_not_available}}** (**{{fmt_percentage1 (divide drr_indicators_not_available drr_past_total)}}**) {{gl_tt "n’ont pas de résultat disponible" "RESULTS_NOT_AVAILABLE"}}{{/if}}
+    De ces **{{fmt_big_int drr_past_total}}** indicateurs qui devaient atteindre leur cible au plus tard le 31 mars {{pa_last_year_short_second}}:
+      {{#if drr_indicators_met}}* **{{fmt_big_int drr_indicators_met}}** (**{{fmt_percentage1 (divide drr_indicators_met drr_past_total)}}**) {{gl_tt "ont atteint" "RESULTS_MET"}} leur cible{{/if}}
+      {{#if drr_indicators_not_met}}* **{{fmt_big_int drr_indicators_not_met}}** (**{{fmt_percentage1 (divide drr_indicators_not_met drr_past_total)}}**) {{gl_tt "n’ont pas atteint" "RESULTS_NOT_MET"}} leur cible{{/if}}
+      {{#if drr_indicators_not_available}}* **{{fmt_big_int drr_indicators_not_available}}** (**{{fmt_percentage1 (divide drr_indicators_not_available drr_past_total)}}**) {{gl_tt "n’ont pas de résultat disponible" "RESULTS_NOT_AVAILABLE"}}{{/if}}
     {{/if}}
 
 gov_drr_summary_org_table_text:

--- a/client/src/panels/result_graphs/gov_dp_text.yaml
+++ b/client/src/panels/result_graphs/gov_dp_text.yaml
@@ -12,13 +12,13 @@ gov_dp_text:
     
     Organizations group their {{gl_tt "programs" "PROG"}} and {{gl_tt "departmental results" "DR"}} by their {{gl_tt "Core Responsibilities" "CR"}}. In addition, programs also have {{gl_tt "results" "PO"}}. Progress for each result is measured by {{gl_tt "indicator targets" "IND_RESULT"}}. 
 
-    In **{{planning_year_1}}**, **{{fmt_big_int_real depts_with_dps}}** organizations are seeking to achieve **{{fmt_big_int_real dp_results}}** results, measured by **{{fmt_big_int_real dp_indicators}}** indicators. Assessed performance against these indicators will be reported in **fall {{planning_year_1_short_second}}**.
+    In **{{planning_year_1}}**, **{{fmt_big_int depts_with_dps}}** organizations are seeking to achieve **{{fmt_big_int dp_results}}** results, measured by **{{fmt_big_int dp_indicators}}** indicators. Assessed performance against these indicators will be reported in **fall {{planning_year_1_short_second}}**.
   fr: |
     En avril 2018, les organisations de l’administration publique ont adopté une {{gl_tt "nouvelle structure redditionnelle" "DRF"}} fondée sur les résultats.
 
     Les organisations groupent leurs {{gl_tt "programmes" "PROG"}} et {{gl_tt "résultats ministériels" "DR"}} en fonction de leurs {{gl_tt "responsabilités essentielles" "CR"}}. De plus, les programmes doivent aussi obtenir des {{gl_tt "résultats" "PO"}} et chaque résultat est mesuré à l’aide des cibles figurant aux {{gl_tt "indicateurs" "IND_RESULT"}}.
 
-    En **{{planning_year_1}}**, **{{fmt_big_int_real depts_with_dps}}** organisations comptent atteindre **{{fmt_big_int_real dp_results}}** résultats, mesurés par **{{fmt_big_int_real dp_indicators}}** indicateurs. L'évaluation du rendement par rapport à ces indicateurs fera l’objet d’un rapport à **l’automne {{planning_year_1_short_second}}**.
+    En **{{planning_year_1}}**, **{{fmt_big_int depts_with_dps}}** organisations comptent atteindre **{{fmt_big_int dp_results}}** résultats, mesurés par **{{fmt_big_int dp_indicators}}** indicateurs. L'évaluation du rendement par rapport à ces indicateurs fera l’objet d’un rapport à **l’automne {{planning_year_1_short_second}}**.
 
 
 gov_dp_above_search_bar_text:

--- a/client/src/panels/result_graphs/result_drilldown.js
+++ b/client/src/panels/result_graphs/result_drilldown.js
@@ -80,7 +80,7 @@ const get_non_col_content_func = createSelector(
           <DlItem
             key={2}
             term={<span className="nowrap">{fte_header(doc) }</span>}
-            def={<Format type="big_int_real" content={resources ? resources.ftes : 0} />}
+            def={<Format type="big_int" content={resources ? resources.ftes : 0} />}
           />
         ),
         _.nonEmpty(subject.old_name) && (

--- a/client/src/panels/result_graphs/result_drilldown.yaml
+++ b/client/src/panels/result_graphs/result_drilldown.yaml
@@ -22,74 +22,74 @@ result_drilldown_title:
 result_counts_drr_dept_first_wave:
   transform: [handlebars,markdown]
   en: |
-    In {{doc_year}}, **{{subj_name subject}}** sought to achieve **{{fmt_big_int_real num_results}}** results through **{{fmt_big_int_real num_crs}}** {{gl_tt (plural_branch num_crs "Core Responsibility" "Core Responsibilities") "CR"}} and **{{fmt_big_int_real num_programs}}** {{gl_tt (plural_branch num_programs "Program" "Programs") "PROG"}}.. Progress towards meeting these results was {{gl_tt "measured" "RESULTS_STATUS"}} using **{{fmt_big_int_real num_indicators}}** {{gl_tt "indicators" "IND_RESULT"}}.
+    In {{doc_year}}, **{{subj_name subject}}** sought to achieve **{{fmt_big_int num_results}}** results through **{{fmt_big_int num_crs}}** {{gl_tt (plural_branch num_crs "Core Responsibility" "Core Responsibilities") "CR"}} and **{{fmt_big_int num_programs}}** {{gl_tt (plural_branch num_programs "Program" "Programs") "PROG"}}.. Progress towards meeting these results was {{gl_tt "measured" "RESULTS_STATUS"}} using **{{fmt_big_int num_indicators}}** {{gl_tt "indicators" "IND_RESULT"}}.
   fr: |
-    En {{doc_year}}, **{{subj_name subject}}** a cherché à rencontrer **{{fmt_big_int_real num_results}} résultats** à l’aide de **{{fmt_big_int_real num_crs}}** {{gl_tt (plural_branch num_crs "responsabilité essentielle" "responsabilités essentielles") "CR"}} et **{{fmt_big_int_real num_programs}}** {{gl_tt (plural_branch num_programs "programme" "programmes") "PROG"}}. Les progrès accomplis dans l’atteinte de ces résultats ont été {{gl_tt "mesurés" "RESULTS_STATUS"}} au moyen de **{{fmt_big_int_real num_indicators}}** {{gl_tt "indicateurs" "IND_RESULT"}}.
+    En {{doc_year}}, **{{subj_name subject}}** a cherché à rencontrer **{{fmt_big_int num_results}} résultats** à l’aide de **{{fmt_big_int num_crs}}** {{gl_tt (plural_branch num_crs "responsabilité essentielle" "responsabilités essentielles") "CR"}} et **{{fmt_big_int num_programs}}** {{gl_tt (plural_branch num_programs "programme" "programmes") "PROG"}}. Les progrès accomplis dans l’atteinte de ces résultats ont été {{gl_tt "mesurés" "RESULTS_STATUS"}} au moyen de **{{fmt_big_int num_indicators}}** {{gl_tt "indicateurs" "IND_RESULT"}}.
 
 result_counts_drr_dept_sub:
   transform: [handlebars,markdown]
   en: |
-    In {{doc_year}}, **{{subj_name subject}}** sought to achieve **{{fmt_big_int_real num_results}}** results through **{{fmt_big_int_real num_programs}}** {{gl_tt "Programs" "PROG"}} and **{{fmt_big_int_real num_subs}}** {{gl_tt "Sub-Programs" "SSP"}}. Progress towards meeting these results was {{gl_tt "measured" "RESULTS_STATUS"}} using **{{fmt_big_int_real num_indicators}}** {{gl_tt "indicators" "IND_RESULT"}}.
+    In {{doc_year}}, **{{subj_name subject}}** sought to achieve **{{fmt_big_int num_results}}** results through **{{fmt_big_int num_programs}}** {{gl_tt "Programs" "PROG"}} and **{{fmt_big_int num_subs}}** {{gl_tt "Sub-Programs" "SSP"}}. Progress towards meeting these results was {{gl_tt "measured" "RESULTS_STATUS"}} using **{{fmt_big_int num_indicators}}** {{gl_tt "indicators" "IND_RESULT"}}.
   fr: |
-    En {{doc_year}}, **{{subj_name subject}}** a cherché à obtenir **{{fmt_big_int_real num_results}} résultats** à l’aide de **{{fmt_big_int_real num_programs}}** {{gl_tt "programmes" "PROG"}} et **{{fmt_big_int_real num_subs}}** {{gl_tt "sous-programmes" "SSP"}}. Les progrès vers l’atteinte de ces résultats ont été {{gl_tt "mesurés" "RESULTS_STATUS"}} à l’aide de **{{fmt_big_int_real num_indicators}}** {{gl_tt "indicateurs" "IND_RESULT"}}.
+    En {{doc_year}}, **{{subj_name subject}}** a cherché à obtenir **{{fmt_big_int num_results}} résultats** à l’aide de **{{fmt_big_int num_programs}}** {{gl_tt "programmes" "PROG"}} et **{{fmt_big_int num_subs}}** {{gl_tt "sous-programmes" "SSP"}}. Les progrès vers l’atteinte de ces résultats ont été {{gl_tt "mesurés" "RESULTS_STATUS"}} à l’aide de **{{fmt_big_int num_indicators}}** {{gl_tt "indicateurs" "IND_RESULT"}}.
 
 result_counts_drr_dept_no_subs:
   transform: [handlebars,markdown]
   en: |
-    In {{doc_year}}, **{{subj_name subject}}** sought to achieve **{{fmt_big_int_real num_results}}** results through **{{fmt_big_int_real num_programs}}** {{gl_tt "Programs" "PROG"}}. Progress towards meeting these results was {{gl_tt "measured" "RESULTS_STATUS"}} using **{{fmt_big_int_real num_indicators}}** {{gl_tt "indicators" "IND_RESULT"}}.
+    In {{doc_year}}, **{{subj_name subject}}** sought to achieve **{{fmt_big_int num_results}}** results through **{{fmt_big_int num_programs}}** {{gl_tt "Programs" "PROG"}}. Progress towards meeting these results was {{gl_tt "measured" "RESULTS_STATUS"}} using **{{fmt_big_int num_indicators}}** {{gl_tt "indicators" "IND_RESULT"}}.
   fr: |
-    En {{doc_year}}, **{{subj_name subject}}** a cherché à obtenir **{{fmt_big_int_real num_results}}** résultats à l’aide de **{{fmt_big_int_real num_programs}}** {{gl_tt "programmes" "PROG"}}. Les progrès vers l’atteinte de ces résultats ont été {{gl_tt "mesurés" "RESULTS_STATUS"}} à l’aide de **{{fmt_big_int_real num_indicators}}** {{gl_tt "indicateurs" "IND_RESULT"}} 
+    En {{doc_year}}, **{{subj_name subject}}** a cherché à obtenir **{{fmt_big_int num_results}}** résultats à l’aide de **{{fmt_big_int num_programs}}** {{gl_tt "programmes" "PROG"}}. Les progrès vers l’atteinte de ces résultats ont été {{gl_tt "mesurés" "RESULTS_STATUS"}} à l’aide de **{{fmt_big_int num_indicators}}** {{gl_tt "indicateurs" "IND_RESULT"}} 
 
 result_counts_drr_dept_sub_sub:
   transform: [handlebars,markdown]
   en: |
-    In {{doc_year}}, **{{subj_name subject}}** sought to achieve **{{fmt_big_int_real num_results}}** results through **{{fmt_big_int_real num_programs}}** {{gl_tt "Programs" "PROG"}}, **{{fmt_big_int_real num_subs}}** {{gl_tt "Sub-Programs" "SSP"}} and **{{fmt_big_int_real num_sub_subs}}** Sub-Sub Programs. Progress towards meeting these results was {{gl_tt "measured" "RESULTS_STATUS"}} using **{{fmt_big_int_real num_indicators}}** {{gl_tt "indicators" "IND_RESULT"}}.
+    In {{doc_year}}, **{{subj_name subject}}** sought to achieve **{{fmt_big_int num_results}}** results through **{{fmt_big_int num_programs}}** {{gl_tt "Programs" "PROG"}}, **{{fmt_big_int num_subs}}** {{gl_tt "Sub-Programs" "SSP"}} and **{{fmt_big_int num_sub_subs}}** Sub-Sub Programs. Progress towards meeting these results was {{gl_tt "measured" "RESULTS_STATUS"}} using **{{fmt_big_int num_indicators}}** {{gl_tt "indicators" "IND_RESULT"}}.
   fr: |
-    En {{doc_year}}, **{{subj_name subject}}** a cherché à atteindre **{{fmt_big_int_real num_results}}** résultats à l’aide de **{{fmt_big_int_real num_programs}}** {{gl_tt "programmes" "PROG"}}, **{{fmt_big_int_real num_subs}}** {{gl_tt "sous-programmes" "SSP"}} et **{{fmt_big_int_real num_sub_subs}}** sous-sous-programmes. Les progrès vers l’atteinte de ces résultats ont été {{gl_tt "mesurés" "RESULTS_STATUS"}} à l’aide de **{{fmt_big_int_real num_indicators}}** {{gl_tt "indicateurs" "IND_RESULT"}}. 
+    En {{doc_year}}, **{{subj_name subject}}** a cherché à atteindre **{{fmt_big_int num_results}}** résultats à l’aide de **{{fmt_big_int num_programs}}** {{gl_tt "programmes" "PROG"}}, **{{fmt_big_int num_subs}}** {{gl_tt "sous-programmes" "SSP"}} et **{{fmt_big_int num_sub_subs}}** sous-sous-programmes. Les progrès vers l’atteinte de ces résultats ont été {{gl_tt "mesurés" "RESULTS_STATUS"}} à l’aide de **{{fmt_big_int num_indicators}}** {{gl_tt "indicateurs" "IND_RESULT"}}. 
 
 result_counts_drr_prog_paa_sub_sub:
   transform: [handlebars,markdown]
   en: |
-    In {{doc_year}}, **{{subj_name subject}}** sought to achieve **{{fmt_big_int_real num_results}}** results. Progress towards meeting these results was {{gl_tt "measured" "RESULTS_STATUS"}} using **{{fmt_big_int_real num_indicators}}** {{gl_tt "indicators" "IND_RESULT"}}. During that fiscal year, the program was comprised of **{{fmt_big_int_real num_subs}}** {{gl_tt "sub-Programs" "SSP"}} and **{{fmt_big_int_real num_sub_subs}}** sub-sub programs.
+    In {{doc_year}}, **{{subj_name subject}}** sought to achieve **{{fmt_big_int num_results}}** results. Progress towards meeting these results was {{gl_tt "measured" "RESULTS_STATUS"}} using **{{fmt_big_int num_indicators}}** {{gl_tt "indicators" "IND_RESULT"}}. During that fiscal year, the program was comprised of **{{fmt_big_int num_subs}}** {{gl_tt "sub-Programs" "SSP"}} and **{{fmt_big_int num_sub_subs}}** sub-sub programs.
   fr: |
-    En {{doc_year}}, **{{subj_name subject}}** a cherché à obtenir **{{fmt_big_int_real num_results}}** résultats. Les progrès vers l’atteinte de ces résultats ont été {{gl_tt "mesurés" "RESULTS_STATUS"}} à l’aide de **{{fmt_big_int_real num_indicators}}** {{gl_tt "indicateurs" "IND_RESULT"}}. Au cours de cet exercice, le programme comprenait **{{fmt_big_int_real num_subs}}** {{gl_tt "sous-programmes" "SSP"}} et **{{fmt_big_int_real num_sub_subs}}** sous-sous programmes.
+    En {{doc_year}}, **{{subj_name subject}}** a cherché à obtenir **{{fmt_big_int num_results}}** résultats. Les progrès vers l’atteinte de ces résultats ont été {{gl_tt "mesurés" "RESULTS_STATUS"}} à l’aide de **{{fmt_big_int num_indicators}}** {{gl_tt "indicateurs" "IND_RESULT"}}. Au cours de cet exercice, le programme comprenait **{{fmt_big_int num_subs}}** {{gl_tt "sous-programmes" "SSP"}} et **{{fmt_big_int num_sub_subs}}** sous-sous programmes.
   
 
 result_counts_drr_prog_paa_sub:
   transform: [handlebars,markdown]
   en: |
-    In {{doc_year}}, **{{subj_name subject}}** sought to achieve **{{fmt_big_int_real num_results}}** results. Progress towards meeting these results was {{gl_tt "measured" "RESULTS_STATUS"}} using **{{fmt_big_int_real num_indicators}}** {{gl_tt "indicators" "IND_RESULT"}}. During that fiscal year, the program was comprised of **{{fmt_big_int_real num_subs}}** {{gl_tt "sub-Programs" "SSP"}}.
+    In {{doc_year}}, **{{subj_name subject}}** sought to achieve **{{fmt_big_int num_results}}** results. Progress towards meeting these results was {{gl_tt "measured" "RESULTS_STATUS"}} using **{{fmt_big_int num_indicators}}** {{gl_tt "indicators" "IND_RESULT"}}. During that fiscal year, the program was comprised of **{{fmt_big_int num_subs}}** {{gl_tt "sub-Programs" "SSP"}}.
   fr: |
-    En {{doc_year}}, **{{subj_name subject}}** a cherché à obtenir **{{fmt_big_int_real num_results}}** résultats. Les progrès vers l’atteinte de ces résultats ont été {{gl_tt "mesurés" "RESULTS_STATUS"}} à l’aide de **{{fmt_big_int_real num_indicators}}** {{gl_tt "indicateurs" "IND_RESULT"}}. Au cours de cet exercice, le programme comprenait **{{fmt_big_int_real num_subs}}** {{gl_tt "sous-programmes" "SSP"}}.
+    En {{doc_year}}, **{{subj_name subject}}** a cherché à obtenir **{{fmt_big_int num_results}}** résultats. Les progrès vers l’atteinte de ces résultats ont été {{gl_tt "mesurés" "RESULTS_STATUS"}} à l’aide de **{{fmt_big_int num_indicators}}** {{gl_tt "indicateurs" "IND_RESULT"}}. Au cours de cet exercice, le programme comprenait **{{fmt_big_int num_subs}}** {{gl_tt "sous-programmes" "SSP"}}.
 
 result_counts_drr_prog_paa_no_subs:
   transform: [handlebars,markdown]
   en: |
-    In {{doc_year}}, **{{subj_name subject}}** sought to achieve **{{fmt_big_int_real num_results}}** results. Progress towards meeting these results was {{gl_tt "measured" "RESULTS_STATUS"}} using **{{fmt_big_int_real num_indicators}} {{gl_tt "indicators" "IND_RESULT"}}**.
+    In {{doc_year}}, **{{subj_name subject}}** sought to achieve **{{fmt_big_int num_results}}** results. Progress towards meeting these results was {{gl_tt "measured" "RESULTS_STATUS"}} using **{{fmt_big_int num_indicators}} {{gl_tt "indicators" "IND_RESULT"}}**.
   fr: |
-    En {{doc_year}}, **{{subj_name subject}}** a cherché à obtenir **{{fmt_big_int_real num_results}}** résultats. Les progrès vers l’atteinte de ces résultats ont été {{gl_tt "mesurés" "RESULTS_STATUS"}} à l’aide de **{{fmt_big_int_real num_indicators}}** {{gl_tt "indicateurs" "IND_RESULT"}}.
+    En {{doc_year}}, **{{subj_name subject}}** a cherché à obtenir **{{fmt_big_int num_results}}** résultats. Les progrès vers l’atteinte de ces résultats ont été {{gl_tt "mesurés" "RESULTS_STATUS"}} à l’aide de **{{fmt_big_int num_indicators}}** {{gl_tt "indicateurs" "IND_RESULT"}}.
 
 
 result_counts_dp_dept:
   transform: [handlebars,markdown]
   en: |
-    In {{doc_year}}, **{{subj_name subject}}** seeks to achieve **{{fmt_big_int_real num_results}}** results through **{{fmt_big_int_real num_crs}}** {{gl_tt (plural_branch num_crs "Core Responsibility" "Core Responsibilities") "CR"}} and **{{fmt_big_int_real num_programs}}** {{gl_tt (plural_branch num_programs "Program" "Programs") "PROG"}}. Progress towards meeting these results will be {{gl_tt "measured" "RESULTS_STATUS"}} using **{{fmt_big_int_real num_indicators}}** {{gl_tt "indicators" "IND_RESULT"}}.
+    In {{doc_year}}, **{{subj_name subject}}** seeks to achieve **{{fmt_big_int num_results}}** results through **{{fmt_big_int num_crs}}** {{gl_tt (plural_branch num_crs "Core Responsibility" "Core Responsibilities") "CR"}} and **{{fmt_big_int num_programs}}** {{gl_tt (plural_branch num_programs "Program" "Programs") "PROG"}}. Progress towards meeting these results will be {{gl_tt "measured" "RESULTS_STATUS"}} using **{{fmt_big_int num_indicators}}** {{gl_tt "indicators" "IND_RESULT"}}.
   fr: |
-    En {{doc_year}}, **{{subj_name subject}}** cherche à rencontrer **{{fmt_big_int_real num_results}}** résultats à l’aide de **{{fmt_big_int_real num_crs}}** {{gl_tt (plural_branch num_crs "responsabilité essentielle" "responsabilités essentielles") "CR"}} et **{{fmt_big_int_real num_programs}}** {{gl_tt (plural_branch num_programs "programme" "programmes") "PROG"}}. Les progrès accomplis dans l’atteinte de ces résultats seront {{gl_tt "mesurés" "RESULTS_STATUS"}} au moyen de **{{fmt_big_int_real num_indicators}}** {{gl_tt "indicateurs" "IND_RESULT"}}.
+    En {{doc_year}}, **{{subj_name subject}}** cherche à rencontrer **{{fmt_big_int num_results}}** résultats à l’aide de **{{fmt_big_int num_crs}}** {{gl_tt (plural_branch num_crs "responsabilité essentielle" "responsabilités essentielles") "CR"}} et **{{fmt_big_int num_programs}}** {{gl_tt (plural_branch num_programs "programme" "programmes") "PROG"}}. Les progrès accomplis dans l’atteinte de ces résultats seront {{gl_tt "mesurés" "RESULTS_STATUS"}} au moyen de **{{fmt_big_int num_indicators}}** {{gl_tt "indicateurs" "IND_RESULT"}}.
 
 result_counts_dp_prog:
   transform: [handlebars,markdown]
   en: |
-    **{{subj_name subject}}** is seeking to achieve **{{fmt_big_int_real num_results}}** {{plural_branch num_results "result" "results"}} in {{doc_year}}. Progress towards meeting these results will be {{gl_tt "measured" "RESULTS_STATUS"}} using **{{fmt_big_int_real num_indicators}}** {{gl_tt "indicators" "IND_RESULT"}}.
+    **{{subj_name subject}}** is seeking to achieve **{{fmt_big_int num_results}}** {{plural_branch num_results "result" "results"}} in {{doc_year}}. Progress towards meeting these results will be {{gl_tt "measured" "RESULTS_STATUS"}} using **{{fmt_big_int num_indicators}}** {{gl_tt "indicators" "IND_RESULT"}}.
   fr: |
-    **{{subj_name subject}}** cherche à rencontrer **{{fmt_big_int_real num_results}}** {{plural_branch num_results "résultat" "résultats"}} en {{doc_year}}. Les progrès accomplis dans l’atteinte de ces résultats seront {{gl_tt "mesurés" "RESULTS_STATUS"}} à l’aide de **{{fmt_big_int_real num_indicators}}** {{gl_tt "indicateurs" "IND_RESULT"}}.
+    **{{subj_name subject}}** cherche à rencontrer **{{fmt_big_int num_results}}** {{plural_branch num_results "résultat" "résultats"}} en {{doc_year}}. Les progrès accomplis dans l’atteinte de ces résultats seront {{gl_tt "mesurés" "RESULTS_STATUS"}} à l’aide de **{{fmt_big_int num_indicators}}** {{gl_tt "indicateurs" "IND_RESULT"}}.
 
 result_counts_dp_cr:
   transform: [handlebars,markdown]
   en: |
-    In {{doc_year}}, **{{subj_name subject.dept}}** is seeking to achieve **{{fmt_big_int_real num_results}}** {{plural_branch num_results "result" "results"}} under the {{gl_tt "Core Responsibility" "CR"}} **"{{subj_name subject}}"** comprised of **{{fmt_big_int_real num_programs}}** {{plural_branch num_programs "program" "programs"}}.
+    In {{doc_year}}, **{{subj_name subject.dept}}** is seeking to achieve **{{fmt_big_int num_results}}** {{plural_branch num_results "result" "results"}} under the {{gl_tt "Core Responsibility" "CR"}} **"{{subj_name subject}}"** comprised of **{{fmt_big_int num_programs}}** {{plural_branch num_programs "program" "programs"}}.
   fr: |
-    En {{doc_year}}, **{{subj_name subject.dept}}** cherche à rencontrer **{{fmt_big_int_real num_results}}** {{plural_branch num_results "résultat" "résultats"}} sous la {{gl_tt "responsabilité essentielle" "CR"}} **«{{subj_name subject}}»** appuyé par **{{fmt_big_int_real num_programs}}** {{plural_branch num_programs "programme" "programmes"}}.
+    En {{doc_year}}, **{{subj_name subject.dept}}** cherche à rencontrer **{{fmt_big_int num_results}}** {{plural_branch num_results "résultat" "résultats"}} sous la {{gl_tt "responsabilité essentielle" "CR"}} **«{{subj_name subject}}»** appuyé par **{{fmt_big_int num_programs}}** {{plural_branch num_programs "programme" "programmes"}}.
     
 
 

--- a/client/src/panels/result_graphs/result_table_text.yaml
+++ b/client/src/panels/result_graphs/result_table_text.yaml
@@ -17,12 +17,12 @@ result_flat_table_title:
 result_flat_table_text:
   transform: [handlebars,markdown]
   en: |
-    In **{{pa_last_year}}**, {{subj_name subject}} measured **{{fmt_big_int_real drr_total}}** {{gl_tt "indicators" "IND_RESULT"}}.
+    In **{{pa_last_year}}**, {{subj_name subject}} measured **{{fmt_big_int drr_total}}** {{gl_tt "indicators" "IND_RESULT"}}.
 
     You can filter the data by selecting the result status you want to explore (you may select multiple statuses). 
     To find all data about an indicator (such as explanations), click on the indicator name.
   fr: |
-    En **{{pa_last_year}}**, {{subj_name subject}} a mesuré **{{fmt_big_int_real drr_total}}** {{gl_tt "indicateurs" "IND_RESULT"}}.
+    En **{{pa_last_year}}**, {{subj_name subject}} a mesuré **{{fmt_big_int drr_total}}** {{gl_tt "indicateurs" "IND_RESULT"}}.
 
     Vous pouvez filtrer les données en sélectionnant l'état du résultat à analyser (plusieurs états peuvent être sélectionnés).
     Pour trouver les données sur un indicateur (tel que  les explications), cliquez sur le nom de l'indicateur.

--- a/client/src/panels/shared.js
+++ b/client/src/panels/shared.js
@@ -502,9 +502,9 @@ export const PlannedActualTable = ({
       </tr>
       <tr>
         <th scope="row"> <TM k="ftes"/> </th>
-        <td> <Format type="big_int_real" content={planned_ftes} /> </td>
-        <td> <Format type="big_int_real" content={actual_ftes} /> </td>
-        <td> <Format type="big_int_real" content={diff_ftes} /> </td>
+        <td> <Format type="big_int" content={planned_ftes} /> </td>
+        <td> <Format type="big_int" content={actual_ftes} /> </td>
+        <td> <Format type="big_int" content={diff_ftes} /> </td>
       </tr>
     </tbody> 
   </table>

--- a/client/src/panels/tag_panels/goco.js
+++ b/client/src/panels/tag_panels/goco.js
@@ -96,7 +96,7 @@ class Goco extends React.Component {
       const a11y_data = _.map(graph_data, row => {
         return {
           label: row.label,
-          data: [formats.compact1_raw(row.actual_Spending), formats.big_int_real_raw(row.actual_FTEs)],
+          data: [formats.compact1_raw(row.actual_Spending), formats.big_int_raw(row.actual_FTEs)],
         };
       });
       
@@ -107,7 +107,7 @@ class Goco extends React.Component {
             child_data: _.map(row.children, (child) => {
               return {
                 label: child.label,
-                data: [formats.compact1_raw(child.actual_Spending), formats.big_int_real_raw(child.actual_FTEs)],
+                data: [formats.compact1_raw(child.actual_Spending), formats.big_int_raw(child.actual_FTEs)],
               };
             }),
           }

--- a/client/src/panels/tag_panels/goco.yaml
+++ b/client/src/panels/tag_panels/goco.yaml
@@ -6,13 +6,13 @@ gocographic_title:
 goco_intro_text:
   transform: [handlebars, markdown]
   en: |
-   In {{pa_last_year}}, the federal government spent **{{fmt_compact1_written total_spending}}** and employed **{{fmt_big_int_real total_ftes}}** {{gl_tt "full-time equivalents" "FTE"}}. 
+   In {{pa_last_year}}, the federal government spent **{{fmt_compact1_written total_spending}}** and employed **{{fmt_big_int total_ftes}}** {{gl_tt "full-time equivalents" "FTE"}}. 
    The largest spending area was **{{max_sa}}** and accounted for **{{fmt_percentage1 max_sa_share}}** of the government total spending. 
 
 
    To further explore a particular spending area, click on its name to expand the graph and discover what {{gl_tt "Government of Canada Activities" "GOCO"}} are included.
   fr: |
-   En {{pa_last_year}}, le gouvernement fédéral a dépensé **{{fmt_compact1_written total_spending}}** et employé **{{fmt_big_int_real total_ftes}}** {{gl_tt "équivalents temps plein" "FTE"}}. 
+   En {{pa_last_year}}, le gouvernement fédéral a dépensé **{{fmt_compact1_written total_spending}}** et employé **{{fmt_big_int total_ftes}}** {{gl_tt "équivalents temps plein" "FTE"}}. 
    Le secteur de dépenses le plus important était celui des **{{max_sa}}** qui représentait **{{fmt_percentage1 max_sa_share}}** des dépenses totales du gouvernement. 
 
 

--- a/client/src/panels/welcome_mat/welcome_mat.js
+++ b/client/src/panels/welcome_mat/welcome_mat.js
@@ -27,7 +27,7 @@ const actual_history_years = _.map(std_years, run_template);
 const { text_maker, TM } = create_text_maker_component(text);
 
 const SpendFormat = ({amt}) => <Format type="compact1" content={amt} />;
-const FteFormat = ({amt}) => <Format type="big_int_real" content={amt} />;
+const FteFormat = ({amt}) => <Format type="big_int" content={amt} />;
 
 const get_estimates_source_link = subject => {
   const table = Table.lookup('orgVoteStatEstimates');

--- a/client/src/panels/welcome_mat/welcome_mat.yaml
+++ b/client/src/panels/welcome_mat/welcome_mat.yaml
@@ -68,10 +68,10 @@ spending_will_be_1:
 fte_will_be_1:
   transform: [handlebars]
   en: |
-    <div class="mat-grid__inner-panel mat-grid__inner-panel--large">{{fmt_big_int_real will_be_1}}</div>
+    <div class="mat-grid__inner-panel mat-grid__inner-panel--large">{{fmt_big_int will_be_1}}</div>
     <div class="mat-grid__inner-panel mat-grid__inner-panel--small">FTEs will be employed</div>
   fr: |
-    <div class="mat-grid__inner-panel mat-grid__inner-panel--large">{{fmt_big_int_real will_be_1}}</div>
+    <div class="mat-grid__inner-panel mat-grid__inner-panel--large">{{fmt_big_int will_be_1}}</div>
     <div class="mat-grid__inner-panel mat-grid__inner-panel--small">ETP seront employés</div>
 
 spending_will_be_3:
@@ -86,10 +86,10 @@ fte_will_be_3:
   transform: [handlebars]
   en: |
     <div class="mat-grid__inner-panel mat-grid__inner-panel--small">number of FTEs is {{will_change_to plan_change ""}}</div>
-    <div class="mat-grid__inner-panel mat-grid__inner-panel--large">{{fmt_big_int_real will_be}}</div>
+    <div class="mat-grid__inner-panel mat-grid__inner-panel--large">{{fmt_big_int will_be}}</div>
   fr: |
     <div class="mat-grid__inner-panel mat-grid__inner-panel--small">le nombre d'ETP prévus {{fr_will_change_to plan_change "m" "s" ""}}</div>
-    <div class="mat-grid__inner-panel mat-grid__inner-panel--large">{{fmt_big_int_real will_be}}</div>
+    <div class="mat-grid__inner-panel mat-grid__inner-panel--large">{{fmt_big_int will_be}}</div>
 
 spending_was:
   transform: [handlebars]
@@ -169,10 +169,10 @@ fte_will_be_1__new:
 fte_was:
   transform: [handlebars]
   en: |
-    <div class="mat-grid__inner-panel mat-grid__inner-panel--large">{{fmt_big_int_real was}}</div>
+    <div class="mat-grid__inner-panel mat-grid__inner-panel--large">{{fmt_big_int was}}</div>
     <div class="mat-grid__inner-panel mat-grid__inner-panel--small">FTEs were employed</div>
   fr: |
-    <div class="mat-grid__inner-panel mat-grid__inner-panel--large">{{fmt_big_int_real was}}</div>
+    <div class="mat-grid__inner-panel mat-grid__inner-panel--large">{{fmt_big_int was}}</div>
     <div class="mat-grid__inner-panel mat-grid__inner-panel--small">ETP étaient employés</div>
 spending_change_was:
   transform: [handlebars]
@@ -186,10 +186,10 @@ fte_change_was:
   transform: [handlebars]
   en: | 
     <div class="mat-grid__inner-panel mat-grid__inner-panel--small">number of FTEs {{changed_to hist_change ""}}</div>
-    <div class="mat-grid__inner-panel mat-grid__inner-panel--large">{{fmt_big_int_real changed_to}}</div>
+    <div class="mat-grid__inner-panel mat-grid__inner-panel--large">{{fmt_big_int changed_to}}</div>
   fr: | 
     <div class="mat-grid__inner-panel mat-grid__inner-panel--small">le nombre d'ETP {{fr_changed_to hist_change "m" "s" ""}}</div>
-    <div class="mat-grid__inner-panel mat-grid__inner-panel--large">{{fmt_big_int_real changed_to}}</div>
+    <div class="mat-grid__inner-panel mat-grid__inner-panel--large">{{fmt_big_int changed_to}}</div>
 spending_change_will:
   transform: [handlebars]
   en: | 
@@ -202,10 +202,10 @@ fte_change_will:
   transform: [handlebars]
   en: | 
     <div class="mat-grid__inner-panel mat-grid__inner-panel--small">number of FTEs is {{will_change_to plan_change ""}}</div>
-    <div class="mat-grid__inner-panel mat-grid__inner-panel--large">{{fmt_big_int_real will_be}}</div>
+    <div class="mat-grid__inner-panel mat-grid__inner-panel--large">{{fmt_big_int will_be}}</div>
   fr: | 
     <div class="mat-grid__inner-panel mat-grid__inner-panel--small">le nombre d'ETP prévus {{fr_will_change_to plan_change "m" "s" ""}}</div>
-    <div class="mat-grid__inner-panel mat-grid__inner-panel--large">{{fmt_big_int_real will_be}}</div>
+    <div class="mat-grid__inner-panel mat-grid__inner-panel--large">{{fmt_big_int will_be}}</div>
 spending_authority_this_year:
   transform: [handlebars]
   en: | 

--- a/client/src/panels/welcome_mat/welcome_mat_fte.js
+++ b/client/src/panels/welcome_mat/welcome_mat_fte.js
@@ -69,7 +69,7 @@ export const format_and_get_fte = (type, info, subject) => {
           })
           .flatten()
           .value();
-        const formatted_data = formatter("big_int_real", filtered_data, {raw: true});
+        const formatted_data = formatter("big_int", filtered_data, {raw: true});
         formatted_data.length > 0 ? formatted_data.splice(null_index, 0, null) : null;
         return {
           label: raw_row.label,

--- a/client/src/partition/partition_subapp/perspectives/perspective_content.yaml
+++ b/client/src/partition/partition_subapp/perspectives/perspective_content.yaml
@@ -83,7 +83,7 @@ partition_popup_fte_value_split:
         {{gt "employed"}}
       {{/if}}
       </br> 
-      {{fmt_big_int_real fte}} {{gt "ftes"}}
+      {{fmt_big_int fte}} {{gt "ftes"}}
     </span>
 partition_popup_name:
   handlebars_partial: true
@@ -141,7 +141,7 @@ partition_popup_org_info_child_org_count:
   text: |
     <div class='mrgn-bttm-md popup-row-bottom-border popup-font-m'>
         {{gt "contains"}}
-        {{fmt_big_int_real org_info}}
+        {{fmt_big_int org_info}}
         {{#if plural_child_orgs}}
           {{gt "orgs"}}
         {{else}}
@@ -314,31 +314,31 @@ partition_org_info_was:
   transform: [handlebars]
   en: |
     We have
-    <p class='amount'><a class='partition-link-out' href='#igoc'>{{rawfmt_big_int_real x}}</a></p>
+    <p class='amount'><a class='partition-link-out' href='#igoc'>{{rawfmt_big_int x}}</a></p>
     Federal Organizations and Interests
   fr: |
     Nous avons
-    <p class='amount'><a class='partition-link-out' href='#igoc'>{{rawfmt_big_int_real x}}</a></p>
+    <p class='amount'><a class='partition-link-out' href='#igoc'>{{rawfmt_big_int x}}</a></p>
     organisations et intérêts fédéraux
 partition_org_info_federal_orgs_by_inst_form_was:
   transform: [handlebars]
   en: |
     We have
-    <p class='amount'><a class='partition-link-out' href='#igoc'>{{rawfmt_big_int_real x}}</a></p>
+    <p class='amount'><a class='partition-link-out' href='#igoc'>{{rawfmt_big_int x}}</a></p>
     Federal Organizations
   fr: |
     Nous avons
-    <p class='amount'><a class='partition-link-out' href='#igoc'>{{rawfmt_big_int_real x}}</a></p>
+    <p class='amount'><a class='partition-link-out' href='#igoc'>{{rawfmt_big_int x}}</a></p>
     organisations fédérales
 partition_org_info_interests_by_inst_form_was:
   transform: [handlebars]
   en: |
     We have
-    <p class='amount'><a class='partition-link-out' href='#igoc'>{{rawfmt_big_int_real x}}</a></p>
+    <p class='amount'><a class='partition-link-out' href='#igoc'>{{rawfmt_big_int x}}</a></p>
     Interests
   fr: |
     Nous avons
-    <p class='amount'><a class='partition-link-out' href='#igoc'>{{rawfmt_big_int_real x}}</a></p>
+    <p class='amount'><a class='partition-link-out' href='#igoc'>{{rawfmt_big_int x}}</a></p>
     intérêts
 partition_spending_was:
   transform: [handlebars]
@@ -356,12 +356,12 @@ partition_fte_was:
   transform: [handlebars]
   en: |
     We employed  
-    <p class='amount'><a class='partition-link-out' href='#orgs/gov/gov/infograph/financial'>{{rawfmt_big_int_real x}}</a></p>
+    <p class='amount'><a class='partition-link-out' href='#orgs/gov/gov/infograph/financial'>{{rawfmt_big_int x}}</a></p>
     FTEs in
     <span class='text-nowrap'>{{pa_last_year}}</span> 
   fr: |
     Nous avons employé  
-    <p class='amount'><a class='partition-link-out' href='#orgs/gov/gov/infograph/financial'>{{rawfmt_big_int_real x}}</a></p>
+    <p class='amount'><a class='partition-link-out' href='#orgs/gov/gov/infograph/financial'>{{rawfmt_big_int x}}</a></p>
     ETP en
     <span class='text-nowrap'>{{pa_last_year}}</span>
 partiton_default_was_root:
@@ -371,12 +371,12 @@ partition_fte_will_be:
   transform: [handlebars]
   en: |
     We will be employing   
-    <p class='amount'><a class='partition-link-out' href='#orgs/gov/gov/infograph/financial'>{{rawfmt_big_int_real x}}</a></p>
+    <p class='amount'><a class='partition-link-out' href='#orgs/gov/gov/infograph/financial'>{{rawfmt_big_int x}}</a></p>
     in
     <span class='text-nowrap'>{{planning_year_1}}</span> 
   fr: |
     Nous emploieront   
-    <p class='amount'><a class='partition-link-out' href='#orgs/gov/gov/infograph/financial'>{{rawfmt_big_int_real x}}</a></p>
+    <p class='amount'><a class='partition-link-out' href='#orgs/gov/gov/infograph/financial'>{{rawfmt_big_int x}}</a></p>
     ETP en
     <span class='text-nowrap'>{{planning_year_1}}</span>
 

--- a/client/src/partition/partition_subapp/perspectives/perspective_utils.js
+++ b/client/src/partition/partition_subapp/perspectives/perspective_utils.js
@@ -22,13 +22,13 @@ const get_common_popup_options = d => {
 
 const wrap_in_brackets = (text) => " (" + text + ")";
 
-const { compact1, big_int_real } = formats; 
+const { compact1, big_int } = formats; 
 
 const formats_by_data_type = {
   "exp": compact1,
-  "fte": big_int_real,
+  "fte": big_int,
   "estimates": compact1,
-  "org_info": big_int_real,
+  "org_info": big_int,
 };
 
 const data_types = [

--- a/client/src/tables/orgActivityEstimates.js
+++ b/client/src/tables/orgActivityEstimates.js
@@ -79,7 +79,7 @@ export default {
     _.each(cr_estimates_years, (yr, ix) => { 
       this.add_col({
         "simple_default": ix === 1,
-        type: "big_int_real",
+        type: "big_int",
         nick: yr+"_estimates",
         description: {
           en: "Tabled Amounts for "+yr,

--- a/client/src/tables/orgActivityEstimates.js
+++ b/client/src/tables/orgActivityEstimates.js
@@ -35,7 +35,7 @@ export default {
   },
 
   "title": {
-    "en": "Tabled Estimates by Core Responsibility ($000)",
+    "en": "Tabled Estimates by Core Responsibility",
     "fr": "Budgets déposés par responsabilité essentielle (en milliers de dollars)",
   },
 

--- a/client/src/tables/orgActivityEstimates.js
+++ b/client/src/tables/orgActivityEstimates.js
@@ -79,7 +79,7 @@ export default {
     _.each(cr_estimates_years, (yr, ix) => { 
       this.add_col({
         "simple_default": ix === 1,
-        type: "big_int",
+        type: "big_int_real",
         nick: yr+"_estimates",
         description: {
           en: "Tabled Amounts for "+yr,

--- a/client/src/tables/orgEmployeeAgeGroup.js
+++ b/client/src/tables/orgEmployeeAgeGroup.js
@@ -69,7 +69,7 @@ export default {
     _.each(people_years,(header,ix)=>{
       this.add_col({
         "simple_default": ix === 4,
-        "type": "big_int_real",
+        "type": "big_int",
         "nick": header,
         "header": m("{{mar_31}}") + ", " + people_years_short_second[ix],
         "description": {
@@ -129,7 +129,7 @@ export default {
       });
     },
     "high_level_rows_with_percentage": function(year) {
-      var fm1 = formats["big_int_real"];
+      var fm1 = formats["big_int"];
       var fm2 = formats.percentage;
       var column = _.map(this.data, year);
       var dept_total = d3.sum(column);

--- a/client/src/tables/orgEmployeeExLvl.js
+++ b/client/src/tables/orgEmployeeExLvl.js
@@ -64,7 +64,7 @@ export default {
     _.each(people_years, (header,ix)=>{
       this.add_col({
         "simple_default": ix === 4,
-        "type": "big_int_real",
+        "type": "big_int",
         "nick": header,
         "header": m("{{mar_31}}") + ", " + people_years_short_second[ix],
         "description": {

--- a/client/src/tables/orgEmployeeFol.js
+++ b/client/src/tables/orgEmployeeFol.js
@@ -61,7 +61,7 @@ export default {
     _.each(people_years,(header,ix)=>{
       this.add_col({
         "simple_default": ix === 4,
-        "type": "big_int_real",
+        "type": "big_int",
         "nick": header,
         "header": m("{{mar_31}}") + ", " + people_years_short_second[ix],
         "description": {

--- a/client/src/tables/orgEmployeeGender.js
+++ b/client/src/tables/orgEmployeeGender.js
@@ -61,7 +61,7 @@ export default {
     _.each(people_years,(header,ix)=>{
       this.add_col({
         "simple_default": ix === 4,
-        "type": "big_int_real",
+        "type": "big_int",
         "nick": header,
         "header": m("{{mar_31}}") + ", " + people_years_short_second[ix],
         "description": {

--- a/client/src/tables/orgEmployeeRegion.js
+++ b/client/src/tables/orgEmployeeRegion.js
@@ -73,7 +73,7 @@ export default {
     _.each(people_years, (header,ix)=>{
       this.add_col({
         "simple_default": ix === 4,
-        "type": "big_int_real",
+        "type": "big_int",
         "nick": header,
         "header": m("{{mar_31}}") + ", " + people_years_short_second[ix],
         "description": {
@@ -127,7 +127,7 @@ export default {
       options = options || {};
       var lk = provinces,
         format = options.format || false,
-        fm1 = formats["big_int_real"],
+        fm1 = formats["big_int"],
         fm2 = formats.percentage,
         ncr = this.lang === 'en' ? "NCR" : "RCN",
         non_ncr = "Non-"+ncr,

--- a/client/src/tables/orgEmployeeType.js
+++ b/client/src/tables/orgEmployeeType.js
@@ -62,7 +62,7 @@ export default {
     });
     _.each(people_years, (header, ix)=>{
       this.add_col({
-        "type": "big_int_real",
+        "type": "big_int",
         "simple_default": ix === 4,
         "nick": header,
         "header": m("{{mar_31}}") + ", " + people_years_short_second[ix],

--- a/client/src/tables/orgSobjs.js
+++ b/client/src/tables/orgSobjs.js
@@ -32,8 +32,8 @@ export default {
   },
 
   "title": { 
-    "en": "Expenditures by Standard Object from {{pa_last_year_5}} to {{pa_last_year}} ($000)",
-    "fr": "Dépenses par article courant de {{pa_last_year_5}} à {{pa_last_year}} (en milliers de dollars)",
+    "en": "Expenditures by Standard Object from {{pa_last_year_5}} to {{pa_last_year}} ($)",
+    "fr": "Dépenses par article courant de {{pa_last_year_5}} à {{pa_last_year}} (en dollars)",
   },
 
 
@@ -66,7 +66,7 @@ export default {
     });
     _.each(std_years, (header, i) => {
       this.add_col({ 
-        "type": "big_int_real",
+        "type": "big_int",
         "simple_default": i === 4,
         "nick": header,
         "header": header,

--- a/client/src/tables/orgSobjs.js
+++ b/client/src/tables/orgSobjs.js
@@ -66,7 +66,7 @@ export default {
     });
     _.each(std_years, (header, i) => {
       this.add_col({ 
-        "type": "big_int",
+        "type": "big_int_real",
         "simple_default": i === 4,
         "nick": header,
         "header": header,

--- a/client/src/tables/orgSobjsQfr.js
+++ b/client/src/tables/orgSobjsQfr.js
@@ -29,8 +29,8 @@ export default {
   },
 
   "title": { 
-    "en": "Expenditures by Standard Object (QFR) ($000)",
-    "fr": "Dépenses par article courant (RFT) (en milliers de dollars)",
+    "en": "Expenditures by Standard Object (QFR) ($)",
+    "fr": "Dépenses par article courant (RFT) (en dollars)",
   },
 
   rpb_banner: trivial_text_maker("temp_qfr_late_depts_note"),

--- a/client/src/tables/orgSobjsQfr.js
+++ b/client/src/tables/orgSobjsQfr.js
@@ -68,7 +68,7 @@ export default {
     this.add_col("{{qfr_in_year}}")
       .add_child([
         {
-          "type": "big_int_real",
+          "type": "big_int",
           "nick": "plannedexp",
           "header": {
             "en": "Planned expenditures for the year ending {{qfr_in_year_end}}",
@@ -80,7 +80,7 @@ export default {
           },
         },
         {
-          "type": "big_int_real",
+          "type": "big_int",
           "nick": 'thisyear_quarterexpenditures',
           "header": {
             "en": "Expended during the quarter ended {{qfr_month_name}}, {{qfr_in_year_short_first}}",
@@ -92,7 +92,7 @@ export default {
           },
         },
         {
-          "type": "big_int_real",
+          "type": "big_int",
           "simple_default": true,
           "nick": "in_year_ytd-exp",
           "header": {
@@ -108,7 +108,7 @@ export default {
     this.add_col("{{qfr_last_year}}")
       .add_child([
         {
-          "type": "big_int_real",
+          "type": "big_int",
           "nick": "last_year_plannedexp",
           "header": {
             "en": "Planned expenditures for the year ending {{qfr_last_year_end}}",
@@ -120,7 +120,7 @@ export default {
           },
         },
         {
-          "type": "big_int_real",
+          "type": "big_int",
           "nick": 'lastyear_quarterexpenditures',
           "header": {
             "en": "Expended during the quarter ended {{qfr_month_name}}, {{qfr_last_year_short_first}}",
@@ -132,7 +132,7 @@ export default {
           },
         },
         {
-          "type": "big_int_real",
+          "type": "big_int",
           "nick": "last_year_ytd-exp",
           "header": {
             "en": "Year to date used at quarter-end",

--- a/client/src/tables/orgSobjsQfr.js
+++ b/client/src/tables/orgSobjsQfr.js
@@ -68,7 +68,7 @@ export default {
     this.add_col("{{qfr_in_year}}")
       .add_child([
         {
-          "type": "big_int",
+          "type": "big_int_real",
           "nick": "plannedexp",
           "header": {
             "en": "Planned expenditures for the year ending {{qfr_in_year_end}}",
@@ -80,7 +80,7 @@ export default {
           },
         },
         {
-          "type": "big_int",
+          "type": "big_int_real",
           "nick": 'thisyear_quarterexpenditures',
           "header": {
             "en": "Expended during the quarter ended {{qfr_month_name}}, {{qfr_in_year_short_first}}",
@@ -92,7 +92,7 @@ export default {
           },
         },
         {
-          "type": "big_int",
+          "type": "big_int_real",
           "simple_default": true,
           "nick": "in_year_ytd-exp",
           "header": {
@@ -108,7 +108,7 @@ export default {
     this.add_col("{{qfr_last_year}}")
       .add_child([
         {
-          "type": "big_int",
+          "type": "big_int_real",
           "nick": "last_year_plannedexp",
           "header": {
             "en": "Planned expenditures for the year ending {{qfr_last_year_end}}",
@@ -120,7 +120,7 @@ export default {
           },
         },
         {
-          "type": "big_int",
+          "type": "big_int_real",
           "nick": 'lastyear_quarterexpenditures',
           "header": {
             "en": "Expended during the quarter ended {{qfr_month_name}}, {{qfr_last_year_short_first}}",
@@ -132,7 +132,7 @@ export default {
           },
         },
         {
-          "type": "big_int",
+          "type": "big_int_real",
           "nick": "last_year_ytd-exp",
           "header": {
             "en": "Year to date used at quarter-end",

--- a/client/src/tables/orgTransferPayments.js
+++ b/client/src/tables/orgTransferPayments.js
@@ -76,7 +76,7 @@ export default {
       this.add_col(header).add_child(
         [
           {
-            "type": "big_int",
+            "type": "big_int_real",
             "nick": header+'auth',
             "header": {
               "en": "Total budgetary authority available for use",
@@ -88,7 +88,7 @@ export default {
             },
           },
           {
-            "type": "big_int",
+            "type": "big_int_real",
             "simple_default": i===4,
             "nick": header+'exp',
             "header": {

--- a/client/src/tables/orgTransferPayments.js
+++ b/client/src/tables/orgTransferPayments.js
@@ -76,7 +76,7 @@ export default {
       this.add_col(header).add_child(
         [
           {
-            "type": "big_int_real",
+            "type": "big_int",
             "nick": header+'auth',
             "header": {
               "en": "Total budgetary authority available for use",
@@ -88,7 +88,7 @@ export default {
             },
           },
           {
-            "type": "big_int_real",
+            "type": "big_int",
             "simple_default": i===4,
             "nick": header+'exp',
             "header": {

--- a/client/src/tables/orgTransferPayments.js
+++ b/client/src/tables/orgTransferPayments.js
@@ -28,8 +28,8 @@ export default {
   },
 
   "title": {
-    "en": "Transfer Payments from {{pa_last_year_5}} to {{pa_last_year}} ($000)",
-    "fr": "Paiements de transfert de {{pa_last_year_5}} à {{pa_last_year}} (en milliers de dollars)",
+    "en": "Transfer Payments from {{pa_last_year_5}} to {{pa_last_year}} ($)",
+    "fr": "Paiements de transfert de {{pa_last_year_5}} à {{pa_last_year}} (en dollars)",
   },
 
   "add_cols": function(){

--- a/client/src/tables/orgVoteStatEstimates.js
+++ b/client/src/tables/orgVoteStatEstimates.js
@@ -114,7 +114,7 @@ export default {
     _.each(estimates_years, (yr, ix) => { 
       this.add_col({
         "simple_default": ix === 4,
-        type: "big_int_real",
+        type: "big_int",
         nick: yr+"_estimates",
         description: {
           en: "Tabled Amounts for "+yr,

--- a/client/src/tables/orgVoteStatEstimates.js
+++ b/client/src/tables/orgVoteStatEstimates.js
@@ -114,7 +114,7 @@ export default {
     _.each(estimates_years, (yr, ix) => { 
       this.add_col({
         "simple_default": ix === 4,
-        type: "big_int",
+        type: "big_int_real",
         nick: yr+"_estimates",
         description: {
           en: "Tabled Amounts for "+yr,

--- a/client/src/tables/orgVoteStatEstimates.js
+++ b/client/src/tables/orgVoteStatEstimates.js
@@ -49,8 +49,8 @@ export default {
   },
 
   "title": {
-    "en": "Tabled Estimates ($000)",
-    "fr": "Budgets déposés (en milliers de dollars)",
+    "en": "Tabled Estimates ($)",
+    "fr": "Budgets déposés (en dollars)",
   },
 
   "footnote-topics": {

--- a/client/src/tables/orgVoteStatPa.js
+++ b/client/src/tables/orgVoteStatPa.js
@@ -103,7 +103,7 @@ export default {
       this.add_col(header)
         .add_child([
           {
-            "type": "big_int_real",
+            "type": "big_int",
             "nick": header + "auth",
             "header": {
               "en": "Total budgetary authority available for use",
@@ -115,7 +115,7 @@ export default {
             },
           },{
             "simple_default": i === 4,
-            "type": "big_int_real",
+            "type": "big_int",
             "nick": header + "exp",
             "header": {
               "en": "Expenditures",

--- a/client/src/tables/orgVoteStatPa.js
+++ b/client/src/tables/orgVoteStatPa.js
@@ -103,7 +103,7 @@ export default {
       this.add_col(header)
         .add_child([
           {
-            "type": "big_int",
+            "type": "big_int_real",
             "nick": header + "auth",
             "header": {
               "en": "Total budgetary authority available for use",
@@ -115,7 +115,7 @@ export default {
             },
           },{
             "simple_default": i === 4,
-            "type": "big_int",
+            "type": "big_int_real",
             "nick": header + "exp",
             "header": {
               "en": "Expenditures",

--- a/client/src/tables/orgVoteStatPa.js
+++ b/client/src/tables/orgVoteStatPa.js
@@ -53,8 +53,8 @@ export default {
   },
 
   title: { 
-    en: "Authorities and Actual Expenditures from {{pa_last_year_5}} to {{pa_last_year}} ($000)",
-    fr: "Autorisations et dépenses réelles {{pa_last_year_5}} à {{pa_last_year}} (en milliers de dollars)",
+    en: "Authorities and Actual Expenditures from {{pa_last_year_5}} to {{pa_last_year}} ($)",
+    fr: "Autorisations et dépenses réelles {{pa_last_year_5}} à {{pa_last_year}} (en dollars)",
   },
 
 

--- a/client/src/tables/orgVoteStatQfr.js
+++ b/client/src/tables/orgVoteStatQfr.js
@@ -32,8 +32,8 @@ export default {
   },
 
   title: { 
-    en: "Authorities and Expenditures (QFR) ($000)",
-    fr: "Autorisations et dépenses (RFT) (en milliers de dollars)",
+    en: "Authorities and Expenditures (QFR) ($)",
+    fr: "Autorisations et dépenses (RFT) (en dollars)",
   },
 
   rpb_banner: trivial_text_maker("temp_qfr_late_depts_note"),

--- a/client/src/tables/orgVoteStatQfr.js
+++ b/client/src/tables/orgVoteStatQfr.js
@@ -83,7 +83,7 @@ export default {
     this.add_col("{{qfr_in_year}}")
       .add_child([
         {
-          "type": "big_int",
+          "type": "big_int_real",
           "nick": 'thisyearauthorities',
           "header": {
             "en": "Total available for use for the year ending {{qfr_in_year_end}}",
@@ -94,7 +94,7 @@ export default {
             "fr": "Correspondent aux autorisations accordées par le Parlement, y compris les virements d'autres organisations, les crédits centraux ou les rajustements disponibles pour emploi à la fin du trimestre. Ceci ne comprend que les autorisations disponibles et octroyées par le Parlement à la fin du trimestre.",
           },
         }, {
-          "type": "big_int",
+          "type": "big_int_real",
           "nick": 'thisyear_quarterexpenditures',
           "header": {
             "en": "Used during the quarter ended {{qfr_month_name}}, {{qfr_in_year_short_first}}",
@@ -105,7 +105,7 @@ export default {
             "fr": "Correspondent aux dépenses faites à partir des autorisations disponibles pour le trimestre sélectionné.",
           },
         }, {
-          "type": "big_int",
+          "type": "big_int_real",
           "simple_default": true,
           "nick": 'thisyearexpenditures',
           "header": {
@@ -120,7 +120,7 @@ export default {
       ]);
     this.add_col("{{qfr_last_year}}")
       .add_child([{
-        "type": "big_int",
+        "type": "big_int_real",
         "nick": 'lastyearauthorities',
         "header": {
           "en": "Total available for use for the year ending {{qfr_last_year_end}}",
@@ -132,7 +132,7 @@ export default {
         },
       },
       {
-        "type": "big_int",
+        "type": "big_int_real",
         "nick": 'lastyear_quarterexpenditures',
         "header": {
           "en": "Used during the quarter ended {{qfr_month_name}}, {{qfr_last_year_short_first}} ",
@@ -144,7 +144,7 @@ export default {
         },
       },
       {
-        "type": "big_int",
+        "type": "big_int_real",
         "nick": 'lastyearexpenditures',
         "header": {
           "en": "Year to date used at quarter-end",
@@ -168,7 +168,7 @@ export default {
       if (!format){
         return data;
       }
-      return FORMAT.list_formatter(['big_int','big_int',"percentage"], data);
+      return FORMAT.list_formatter(['big_int_real','big_int_real',"percentage"], data);
     },
     "exp_change": function(format) {
       // returns last year, this year, and change
@@ -180,7 +180,7 @@ export default {
       if (!format){
         return data;
       }
-      return FORMAT.list_formatter(['big_int','big_int',"percentage"], data);
+      return FORMAT.list_formatter(['big_int_real','big_int_real',"percentage"], data);
     },
   },
 

--- a/client/src/tables/orgVoteStatQfr.js
+++ b/client/src/tables/orgVoteStatQfr.js
@@ -83,7 +83,7 @@ export default {
     this.add_col("{{qfr_in_year}}")
       .add_child([
         {
-          "type": "big_int_real",
+          "type": "big_int",
           "nick": 'thisyearauthorities',
           "header": {
             "en": "Total available for use for the year ending {{qfr_in_year_end}}",
@@ -94,7 +94,7 @@ export default {
             "fr": "Correspondent aux autorisations accordées par le Parlement, y compris les virements d'autres organisations, les crédits centraux ou les rajustements disponibles pour emploi à la fin du trimestre. Ceci ne comprend que les autorisations disponibles et octroyées par le Parlement à la fin du trimestre.",
           },
         }, {
-          "type": "big_int_real",
+          "type": "big_int",
           "nick": 'thisyear_quarterexpenditures',
           "header": {
             "en": "Used during the quarter ended {{qfr_month_name}}, {{qfr_in_year_short_first}}",
@@ -105,7 +105,7 @@ export default {
             "fr": "Correspondent aux dépenses faites à partir des autorisations disponibles pour le trimestre sélectionné.",
           },
         }, {
-          "type": "big_int_real",
+          "type": "big_int",
           "simple_default": true,
           "nick": 'thisyearexpenditures',
           "header": {
@@ -120,7 +120,7 @@ export default {
       ]);
     this.add_col("{{qfr_last_year}}")
       .add_child([{
-        "type": "big_int_real",
+        "type": "big_int",
         "nick": 'lastyearauthorities',
         "header": {
           "en": "Total available for use for the year ending {{qfr_last_year_end}}",
@@ -132,7 +132,7 @@ export default {
         },
       },
       {
-        "type": "big_int_real",
+        "type": "big_int",
         "nick": 'lastyear_quarterexpenditures',
         "header": {
           "en": "Used during the quarter ended {{qfr_month_name}}, {{qfr_last_year_short_first}} ",
@@ -144,7 +144,7 @@ export default {
         },
       },
       {
-        "type": "big_int_real",
+        "type": "big_int",
         "nick": 'lastyearexpenditures',
         "header": {
           "en": "Year to date used at quarter-end",
@@ -168,7 +168,7 @@ export default {
       if (!format){
         return data;
       }
-      return FORMAT.list_formatter(['big_int_real','big_int_real',"percentage"], data);
+      return FORMAT.list_formatter(['big_int','big_int',"percentage"], data);
     },
     "exp_change": function(format) {
       // returns last year, this year, and change
@@ -180,7 +180,7 @@ export default {
       if (!format){
         return data;
       }
-      return FORMAT.list_formatter(['big_int_real','big_int_real',"percentage"], data);
+      return FORMAT.list_formatter(['big_int','big_int',"percentage"], data);
     },
   },
 

--- a/client/src/tables/programFtes.js
+++ b/client/src/tables/programFtes.js
@@ -74,7 +74,7 @@ export default {
     });
     _.each(std_years, (header, ix) => {
       this.add_col(
-        { "type": "big_int_real",
+        { "type": "big_int",
           "simple_default": ix===4,
           "nick": header,
           "header": {
@@ -89,7 +89,7 @@ export default {
     });
 
     this.add_col({ 
-      "type": "big_int_real",
+      "type": "big_int",
       "nick": "drr_last_year" ,
       "hidden": true,
       "header": {
@@ -103,7 +103,7 @@ export default {
     });
     _.each(planning_years, (header)=>{
       this.add_col({ 
-        "type": "big_int_real",
+        "type": "big_int",
         "nick": header,
         "header": {
           "en": header + "  " + m("Planned FTEs"),

--- a/client/src/tables/programSobjs.js
+++ b/client/src/tables/programSobjs.js
@@ -83,7 +83,7 @@ export default {
     const years = _.takeRight(std_years, 3);
     years.forEach(yr=> {
       this.add_col({ 
-        "type": "big_int",
+        "type": "big_int_real",
         "nick": yr,
         "simple_default": true,
         "header": yr,

--- a/client/src/tables/programSobjs.js
+++ b/client/src/tables/programSobjs.js
@@ -83,7 +83,7 @@ export default {
     const years = _.takeRight(std_years, 3);
     years.forEach(yr=> {
       this.add_col({ 
-        "type": "big_int_real",
+        "type": "big_int",
         "nick": yr,
         "simple_default": true,
         "header": yr,

--- a/client/src/tables/programSobjs.js
+++ b/client/src/tables/programSobjs.js
@@ -39,8 +39,8 @@ export default {
     "fr": "Dépenses de programmes par article courant",
   },
   "title": { 
-    "en": "Program Expenditures by Standard Object {{pa_last_year}} ($000)",
-    "fr": "Dépenses de programmes par article courant {{pa_last_year}} (en milliers de dollars)",
+    "en": "Program Expenditures by Standard Object {{pa_last_year}} ($)",
+    "fr": "Dépenses de programmes par article courant {{pa_last_year}} (en dollars)",
   },
   add_cols () {
     this.add_col( {

--- a/client/src/tables/programSpending.js
+++ b/client/src/tables/programSpending.js
@@ -34,8 +34,8 @@ export default {
   },
 
   "title": { 
-    "en": "Expenditures and Planned Spending by Program from {{pa_last_year_5}} to {{planning_year_3}} ($000)",
-    "fr": "Dépenses réelles et prévues par programme de {{pa_last_year_5}} à {{planning_year_3}} (en milliers de dollars)",
+    "en": "Expenditures and Planned Spending by Program from {{pa_last_year_5}} to {{planning_year_3}} ($)",
+    "fr": "Dépenses réelles et prévues par programme de {{pa_last_year_5}} à {{planning_year_3}} (en dollars)",
   },
 
 

--- a/client/src/tables/programSpending.js
+++ b/client/src/tables/programSpending.js
@@ -77,7 +77,7 @@ export default {
       this.add_col(header)
         .add_child([
           {
-            "type": "big_int_real",
+            "type": "big_int",
             "simple_default": ix === 4,
             "nick": `${header}exp`,
             "header": {
@@ -92,7 +92,7 @@ export default {
         ]);
     });
     this.add_col({
-      "type": "big_int_real",
+      "type": "big_int",
       "nick": "drr_last_year",
       "hidden": true,
       "header": {
@@ -108,7 +108,7 @@ export default {
       this.add_col(header)
         .add_child([
           {
-            "type": "big_int_real",
+            "type": "big_int",
             "nick": header,
             "header": {
               "en": "Planned Spending",
@@ -120,17 +120,17 @@ export default {
             },
           },
           {
-            "type": "big_int_real",
+            "type": "big_int",
             "nick": `${header}_rev`,
             hidden: true,
           },
           {
-            "type": "big_int_real",
+            "type": "big_int",
             "nick": `${header}_spa`,
             hidden: true,
           },
           {
-            "type": "big_int_real",
+            "type": "big_int",
             "nick": `${header}_gross`,
             hidden: true,
           },

--- a/client/src/tables/programSpending.js
+++ b/client/src/tables/programSpending.js
@@ -77,7 +77,7 @@ export default {
       this.add_col(header)
         .add_child([
           {
-            "type": "big_int",
+            "type": "big_int_real",
             "simple_default": ix === 4,
             "nick": `${header}exp`,
             "header": {
@@ -92,7 +92,7 @@ export default {
         ]);
     });
     this.add_col({
-      "type": "big_int",
+      "type": "big_int_real",
       "nick": "drr_last_year",
       "hidden": true,
       "header": {
@@ -108,7 +108,7 @@ export default {
       this.add_col(header)
         .add_child([
           {
-            "type": "big_int",
+            "type": "big_int_real",
             "nick": header,
             "header": {
               "en": "Planned Spending",
@@ -120,17 +120,17 @@ export default {
             },
           },
           {
-            "type": "big_int",
+            "type": "big_int_real",
             "nick": `${header}_rev`,
             hidden: true,
           },
           {
-            "type": "big_int",
+            "type": "big_int_real",
             "nick": `${header}_spa`,
             hidden: true,
           },
           {
-            "type": "big_int",
+            "type": "big_int_real",
             "nick": `${header}_gross`,
             hidden: true,
           },

--- a/client/src/tables/programVoteStat.js
+++ b/client/src/tables/programVoteStat.js
@@ -65,7 +65,7 @@ export default {
     const years = _.takeRight(std_years, 3);
     years.forEach(yr=> {
       this.add_col({
-        "type": "big_int_real",
+        "type": "big_int",
         "simple_default": true,
         "nick": yr,
         "header": yr,

--- a/client/src/tables/programVoteStat.js
+++ b/client/src/tables/programVoteStat.js
@@ -65,7 +65,7 @@ export default {
     const years = _.takeRight(std_years, 3);
     years.forEach(yr=> {
       this.add_col({
-        "type": "big_int",
+        "type": "big_int_real",
         "simple_default": true,
         "nick": yr,
         "header": yr,

--- a/client/src/tables/programVoteStat.js
+++ b/client/src/tables/programVoteStat.js
@@ -26,8 +26,8 @@ export default {
     fr: "Dépenses de programme par type d'autorisation",
   },
   title: { 
-    en: "Program Expenditures by Authority Type {{pa_last_year}} ($000)",
-    fr: "Dépenses de programme par type d'autorisation {{last_year}} (en milliers de dollars)",
+    en: "Program Expenditures by Authority Type {{pa_last_year}} ($)",
+    fr: "Dépenses de programme par type d'autorisation {{last_year}} (en dollars)",
   },
   add_cols: function(){
     this.add_col( {


### PR DESCRIPTION
Mostly only used in the report builder, but major cleanup to the formats as the `big_int` format now doesn't divide by $1000 by default.

Fixes #46