### PR TITLE
fix nivo legend alignment for IE

### DIFF
--- a/client/src/charts/NivoCharts.js
+++ b/client/src/charts/NivoCharts.js
@@ -78,13 +78,13 @@ const percent_value_tooltip = (tooltip_items, formatter, total) => (
   </div>
 );
 
-const IESymbolShape = ({
+const fixedSymbolShape = ({
   x, y, size, fill, borderWidth, borderColor,
 }) => (
   <rect
     x={x}
     y={y}
-    transform={`translate(0 -4)`}
+    transform={window.feature_detection.is_IE() ? `translate(0 -4)` : ''}
     fill={fill}
     strokeWidth={borderWidth}
     stroke={borderColor}
@@ -145,7 +145,8 @@ export class NivoResponsivePie extends React.Component{
       startAngle,
       is_money,
     } = this.props;
-
+    legends && (legends[0].symbolShape = fixedSymbolShape);
+    
     return (
       <ResponsivePie
         {...{data,
@@ -224,6 +225,7 @@ export class NivoResponsiveBar extends React.Component{
       labelTextColor,
       borderWidth,
     } = this.props;
+    legends && (legends[0].symbolShape = fixedSymbolShape);
 
     return (
       //have to have an empty string in key to make sure
@@ -322,7 +324,7 @@ export class NivoResponsiveHBar extends React.Component{
       labelSkipWidth,
       markers,
     } = this.props;
-    legends && window.feature_detection.is_IE() ? legends[0].symbolShape = IESymbolShape : null;
+    legends && (legends[0].symbolShape = fixedSymbolShape);
 
     return (
       //have to have an empty string in key to make sure
@@ -443,8 +445,8 @@ export class NivoResponsiveLine extends React.Component {
     const {
       y_scale_zoomed,
     } = this.state;
-    
-    legends && window.feature_detection.is_IE() ? legends[0].symbolShape = IESymbolShape : null;
+
+    legends && (legends[0].symbolShape = fixedSymbolShape);
     return (
       <Fragment>
         {show_yaxis_zoom && !enableArea &&

--- a/client/src/charts/NivoCharts.js
+++ b/client/src/charts/NivoCharts.js
@@ -78,6 +78,22 @@ const percent_value_tooltip = (tooltip_items, formatter, total) => (
   </div>
 );
 
+const IESymbolShape = ({
+  x, y, size, fill, borderWidth, borderColor,
+}) => (
+  <rect
+    x={x}
+    y={y}
+    transform={`translate(0 -4)`}
+    fill={fill}
+    strokeWidth={borderWidth}
+    stroke={borderColor}
+    width={size}
+    height={size}
+    style={{ pointerEvents: 'none' }}
+  />
+);
+
 const general_default_props = {
   tooltip: (d, tooltip_formatter) => default_tooltip(d, tooltip_formatter),
   is_money: true,
@@ -306,6 +322,8 @@ export class NivoResponsiveHBar extends React.Component{
       labelSkipWidth,
       markers,
     } = this.props;
+    legends && window.feature_detection.is_IE() ? legends[0].symbolShape = IESymbolShape : null;
+
     return (
       //have to have an empty string in key to make sure
       //that negative bars will be displayed
@@ -425,7 +443,8 @@ export class NivoResponsiveLine extends React.Component {
     const {
       y_scale_zoomed,
     } = this.state;
-
+    
+    legends && window.feature_detection.is_IE() ? legends[0].symbolShape = IESymbolShape : null;
     return (
       <Fragment>
         {show_yaxis_zoom && !enableArea &&


### PR DESCRIPTION
Another alternative is delcaring `IESymbolShape` in `shared.js` and setting custom shape every time `legends` is set. 

Best would be setting this inside `general_default_props` in `NivoCharts.js` but don't think that can work

fixes #97 