### PR TITLE
Specify image versions in CI Config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
   # Note: the image used for this job is built from a docker file found in ../dockerfiles/build
   test_email_backend:
     docker:
-      - image: eaadtbs/ib-ci-build:latest
+      - image: eaadtbs/ib-ci-build:v1.1
         <<: *dockerhub_auth
     working_directory: "~/InfoBase"
     steps:
@@ -49,7 +49,7 @@ jobs:
   # Note: the image used for this job is built from a docker file found in ../dockerfiles/build
   cleanup_dev_dbs:
     docker:
-      - image: eaadtbs/ib-ci-test:latest
+      - image: eaadtbs/ib-ci-test:v1.1
         <<: *dockerhub_auth
     working_directory: "~/InfoBase"
     steps:
@@ -76,7 +76,7 @@ jobs:
   # Note: the image used for this job is built from a docker file found in ../dockerfiles/build
   build:
     docker:
-      - image: eaadtbs/ib-ci-build:latest
+      - image: eaadtbs/ib-ci-build:v1.1
         <<: *dockerhub_auth
     working_directory: "~/InfoBase"
     steps:
@@ -161,7 +161,7 @@ jobs:
   # Note: the image used for this job is built from a docker file found in ../dockerfiles/test
   test_server:
     docker:
-      - image: eaadtbs/ib-ci-test:latest
+      - image: eaadtbs/ib-ci-test:v1.1
         <<: *dockerhub_auth
     working_directory: "~/InfoBase"
     steps:
@@ -190,7 +190,7 @@ jobs:
   # Note: the image used for this job is built from a docker file found in ../dockerfiles/test
   test_end_to_end: # slower but more in-depth than the test job. Wait until these have passed before deploying the client
     docker:
-      - image: eaadtbs/ib-ci-test:latest
+      - image: eaadtbs/ib-ci-test:v1.1
         <<: *dockerhub_auth
     working_directory: "~/InfoBase"
     steps:
@@ -227,7 +227,7 @@ jobs:
   deploy_data:
     working_directory: "~/InfoBase"
     docker:
-      - image: eaadtbs/ib-ci-test:latest
+      - image: eaadtbs/ib-ci-test:v1.1
         <<: *dockerhub_auth
     steps:
       - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,13 +1,7 @@
-build_image: &build_image
-  - image: eaadtbs/ib-ci-build:v1.1
-    auth:
-      username: $DOCKERHUB_USERNAME
-      password: $DOCKERHUB_PASSWORD
-test_image: &test_image
-  - image: eaadtbs/ib-ci-test:v1.1
-    auth:
-      username: $DOCKERHUB_USERNAME
-      password: $DOCKERHUB_PASSWORD
+dockerhub_auth: &dockerhub_auth
+  auth:
+    username: $DOCKERHUB_USERNAME
+    password: $DOCKERHUB_PASSWORD
 
 # yaml fragment for deploy filters
 deploy_filter: &deploy_filter 
@@ -23,7 +17,8 @@ jobs:
   # Note: the image used for this job is built from a docker file found in ../dockerfiles/build
   test_email_backend:
     docker:
-      *build_image
+      - image: eaadtbs/ib-ci-build:v1.1
+        <<: *dockerhub_auth
     working_directory: "~/InfoBase"
     steps:
       - checkout:
@@ -53,7 +48,8 @@ jobs:
   # Note: the image used for this job is built from a docker file found in ../dockerfiles/build
   cleanup_dev_dbs:
     docker:
-      *build_image
+      - image: eaadtbs/ib-ci-test:v1.1
+        <<: *dockerhub_auth
     working_directory: "~/InfoBase"
     steps:
       - checkout:
@@ -79,7 +75,8 @@ jobs:
   # Note: the image used for this job is built from a docker file found in ../dockerfiles/build
   build:
     docker:
-      *build_image
+      - image: eaadtbs/ib-ci-build:v1.1
+        <<: *dockerhub_auth
     working_directory: "~/InfoBase"
     steps:
       - checkout:
@@ -163,7 +160,8 @@ jobs:
   # Note: the image used for this job is built from a docker file found in ../dockerfiles/test
   test_server:
     docker:
-      *build_image
+      - image: eaadtbs/ib-ci-test:v1.1
+        <<: *dockerhub_auth
     working_directory: "~/InfoBase"
     steps:
       - attach_workspace:
@@ -191,7 +189,8 @@ jobs:
   # Note: the image used for this job is built from a docker file found in ../dockerfiles/test
   test_end_to_end: # slower but more in-depth than the test job. Wait until these have passed before deploying the client
     docker:
-      *build_image
+      - image: eaadtbs/ib-ci-test:v1.1
+        <<: *dockerhub_auth
     working_directory: "~/InfoBase"
     steps:
       - attach_workspace:
@@ -227,7 +226,8 @@ jobs:
   deploy_data:
     working_directory: "~/InfoBase"
     docker:
-      *build_image
+      - image: eaadtbs/ib-ci-test:v1.1
+        <<: *dockerhub_auth
     steps:
       - attach_workspace:
           at: ./

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,13 @@ dockerhub_auth: &dockerhub_auth
     username: $DOCKERHUB_USERNAME
     password: $DOCKERHUB_PASSWORD
 
+build_image: &build_image
+  - image: eaadtbs/ib-ci-build:v1.1
+    <<: *dockerhub_auth
+test_image: &test_image
+  - image: eaadtbs/ib-ci-test:v1.1
+    <<: *dockerhub_auth
+
 # yaml fragment for deploy filters
 deploy_filter: &deploy_filter 
   filters:
@@ -14,12 +21,10 @@ deploy_filter: &deploy_filter
 version: 2
 jobs:
 
-
   # Note: the image used for this job is built from a docker file found in ../dockerfiles/build
   test_email_backend:
     docker:
-      - image: eaadtbs/ib-ci-build:v1.1
-        <<: *dockerhub_auth
+      <<: *build_image
     working_directory: "~/InfoBase"
     steps:
       - checkout:
@@ -49,8 +54,7 @@ jobs:
   # Note: the image used for this job is built from a docker file found in ../dockerfiles/build
   cleanup_dev_dbs:
     docker:
-      - image: eaadtbs/ib-ci-test:v1.1
-        <<: *dockerhub_auth
+      <<: *build_image
     working_directory: "~/InfoBase"
     steps:
       - checkout:
@@ -76,8 +80,7 @@ jobs:
   # Note: the image used for this job is built from a docker file found in ../dockerfiles/build
   build:
     docker:
-      - image: eaadtbs/ib-ci-build:v1.1
-        <<: *dockerhub_auth
+      <<: *build_image
     working_directory: "~/InfoBase"
     steps:
       - checkout:
@@ -161,8 +164,7 @@ jobs:
   # Note: the image used for this job is built from a docker file found in ../dockerfiles/test
   test_server:
     docker:
-      - image: eaadtbs/ib-ci-test:v1.1
-        <<: *dockerhub_auth
+      <<: *build_image
     working_directory: "~/InfoBase"
     steps:
       - attach_workspace:
@@ -190,8 +192,7 @@ jobs:
   # Note: the image used for this job is built from a docker file found in ../dockerfiles/test
   test_end_to_end: # slower but more in-depth than the test job. Wait until these have passed before deploying the client
     docker:
-      - image: eaadtbs/ib-ci-test:v1.1
-        <<: *dockerhub_auth
+      <<: *build_image
     working_directory: "~/InfoBase"
     steps:
       - attach_workspace:
@@ -227,8 +228,7 @@ jobs:
   deploy_data:
     working_directory: "~/InfoBase"
     docker:
-      - image: eaadtbs/ib-ci-test:v1.1
-        <<: *dockerhub_auth
+      <<: *build_image
     steps:
       - attach_workspace:
           at: ./

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,14 +1,13 @@
-dockerhub_auth: &dockerhub_auth
-  auth:
-    username: $DOCKERHUB_USERNAME
-    password: $DOCKERHUB_PASSWORD
-
 build_image: &build_image
   - image: eaadtbs/ib-ci-build:v1.1
-    <<: *dockerhub_auth
+    auth:
+      username: $DOCKERHUB_USERNAME
+      password: $DOCKERHUB_PASSWORD
 test_image: &test_image
   - image: eaadtbs/ib-ci-test:v1.1
-    <<: *dockerhub_auth
+    auth:
+      username: $DOCKERHUB_USERNAME
+      password: $DOCKERHUB_PASSWORD
 
 # yaml fragment for deploy filters
 deploy_filter: &deploy_filter 
@@ -24,7 +23,7 @@ jobs:
   # Note: the image used for this job is built from a docker file found in ../dockerfiles/build
   test_email_backend:
     docker:
-      <<: *build_image
+      *build_image
     working_directory: "~/InfoBase"
     steps:
       - checkout:
@@ -54,7 +53,7 @@ jobs:
   # Note: the image used for this job is built from a docker file found in ../dockerfiles/build
   cleanup_dev_dbs:
     docker:
-      <<: *build_image
+      *build_image
     working_directory: "~/InfoBase"
     steps:
       - checkout:
@@ -80,7 +79,7 @@ jobs:
   # Note: the image used for this job is built from a docker file found in ../dockerfiles/build
   build:
     docker:
-      <<: *build_image
+      *build_image
     working_directory: "~/InfoBase"
     steps:
       - checkout:
@@ -164,7 +163,7 @@ jobs:
   # Note: the image used for this job is built from a docker file found in ../dockerfiles/test
   test_server:
     docker:
-      <<: *build_image
+      *build_image
     working_directory: "~/InfoBase"
     steps:
       - attach_workspace:
@@ -192,7 +191,7 @@ jobs:
   # Note: the image used for this job is built from a docker file found in ../dockerfiles/test
   test_end_to_end: # slower but more in-depth than the test job. Wait until these have passed before deploying the client
     docker:
-      <<: *build_image
+      *build_image
     working_directory: "~/InfoBase"
     steps:
       - attach_workspace:
@@ -228,7 +227,7 @@ jobs:
   deploy_data:
     working_directory: "~/InfoBase"
     docker:
-      <<: *build_image
+      *build_image
     steps:
       - attach_workspace:
           at: ./


### PR DESCRIPTION
Will make future docker image updates safer, as long as they are properly versioned.