### PR TITLE
Shore up has_results logic

### DIFF
--- a/client/src/models/populate_results.js
+++ b/client/src/models/populate_results.js
@@ -25,6 +25,11 @@ query($lang: String!, $id: String) {
 `;
 const _subject_has_results = {}; // This is also populated as a side effect of api_load_results_bundle and api_load_results_counts calls
 export function subject_has_results(subject){
+  if ( !_.isNull( subject.has_data('results_data') ) ){
+    // short curicuit if already set, this isn't a status that changes durring a session
+    return Promise.resolve();
+  }
+
   const { id } = subject;
 
   const level = subject.level === "dept" ? "org" : subject.level;

--- a/client/src/models/populate_results.js
+++ b/client/src/models/populate_results.js
@@ -450,6 +450,7 @@ export function api_load_results_bundle(subject, result_docs){
         doc => {
           _.setWith(_api_subject_ids_with_loaded_results, `${doc}.${level}.${id}`, true, Object);
 
+          // can't tell us if subject has no results for any doc, just if it has any for current doc, so only update the _subject_has_results entry if positive
           _subject_has_results[id] = _.nonEmpty(results) || _subject_has_results[id]; // side effect
         }
       );
@@ -581,7 +582,8 @@ export function api_load_results_counts(level = "summary"){
         }
         api_is_results_count_loaded[level] = true;
 
-        _.each( mapped_rows, ({id}) => _subject_has_results[id] = _.nonEmpty(mapped_rows) || _subject_has_results[id] ); // side effect
+        // if it's in the results count set, it has results data
+        _.each( mapped_rows, ({id}) => _subject_has_results[id] = true ); // side effect
 
         return Promise.resolve();
       })

--- a/client/src/models/populate_results.js
+++ b/client/src/models/populate_results.js
@@ -450,7 +450,7 @@ export function api_load_results_bundle(subject, result_docs){
         doc => {
           _.setWith(_api_subject_ids_with_loaded_results, `${doc}.${level}.${id}`, true, Object);
 
-          _subject_has_results[id] = _.nonEmpty(results); // side effect
+          _subject_has_results[id] = _.nonEmpty(results) || _subject_has_results[id]; // side effect
         }
       );
 
@@ -581,7 +581,7 @@ export function api_load_results_counts(level = "summary"){
         }
         api_is_results_count_loaded[level] = true;
 
-        _.each( mapped_rows, ({id}) => _subject_has_results[id] = _.nonEmpty(mapped_rows) ); // side effect
+        _.each( mapped_rows, ({id}) => _subject_has_results[id] = _.nonEmpty(mapped_rows) || _subject_has_results[id] ); // side effect
 
         return Promise.resolve();
       })


### PR DESCRIPTION
As a handy optimization, `has_results` gets prepopulated as a side-effect of queries for results counts and actual results bundles. The pre-population logic in results counts was valid (if over-stated), but the logic for the side-effect while loading a results bundle was faulty.

Basically, loading a result's bundle for a given doc_key and seeing that it has data tells you that its `has_results` should be true, but getting an empty response doesn't tell you anything (unless you're asking for every single doc_key, which we don't ever do so I won't account for that special case). The code had been incorrectly acting like an empty response confirmed that `has_data` should be false. Once `has_results` is set to false, it's never updated again.

So, any subject that didn't have all possible docs could potentially get marked as not having results erroneously (in practice, there weren't many cases where you could cause this in the app).

I've also set up `subject_has_results()` in `populate_results.js` to short circuit it's promise if it's being called for a subject that's already had it's `has_results` flag set, to stop any other ways it could be mucked with going forward (the first fix was still needed anyway, to stop it from being locked in with a potentially wrong value).

Closes #393 