### PR TITLE
set glossary search min length to 2

### DIFF
--- a/client/src/search/GlossarySearch.js
+++ b/client/src/search/GlossarySearch.js
@@ -21,7 +21,7 @@ const GlossarySearch = withRouter(
         onSelect = {
           ({id}) => history.push( glossary_href(id).replace("#","/") )
         }
-        minLength = { 3 }
+        minLength = { 2 }
       />;
     }
   }

--- a/client/src/search/GlossarySearch.js
+++ b/client/src/search/GlossarySearch.js
@@ -21,7 +21,7 @@ const GlossarySearch = withRouter(
         onSelect = {
           ({id}) => history.push( glossary_href(id).replace("#","/") )
         }
-        minLength = { 4 }
+        minLength = { 3 }
       />;
     }
   }


### PR DESCRIPTION
fixes #392 
I think `2` as min length for `DP`