### PR TITLE
Add eslintignore to projects, ignore non-source code

### DIFF
--- a/client/.eslintignore
+++ b/client/.eslintignore
@@ -1,0 +1,3 @@
+patches/*
+build/*
+build_prod/*

--- a/email_backend/.eslintignore
+++ b/email_backend/.eslintignore
@@ -1,0 +1,2 @@
+coverage/*
+transpiled_build/*

--- a/server/.eslintignore
+++ b/server/.eslintignore
@@ -1,0 +1,2 @@
+coverage/*
+transpiled_build/*


### PR DESCRIPTION
Non-source being code on the output end of any build/generation process, stuff that shouldn't be linted ever. I think VS Code's eslint plugin occasionally finding these files was a big CPU hog (if not, then this will at least prevent the flood of extraneous linter warnings when you happen to open a transpiled file, etc,).