### PR TITLE
Standardize glossary tooltip anchor styles

### DIFF
--- a/client/src/components/Panel.js
+++ b/client/src/components/Panel.js
@@ -1,6 +1,6 @@
 import './Panel.scss';
 import text from './Panel.yaml';
-import { GlossaryLink } from './glossary_components.js';
+import { GlossaryItem } from './glossary_components.js';
 
 import classNames from 'classnames';
 
@@ -57,7 +57,7 @@ const PanelGlossary = ({keys}) => {
       >
         {_.map(keys, (key,ix) =>
           <li key={ix}>
-            <GlossaryLink id={key} item_class="glossary-link"/>
+            <GlossaryItem id={key} item_class="glossary-link"/>
             {ix !== last_ix && ", "}
           </li>
         )}

--- a/client/src/components/Panel.yaml
+++ b/client/src/components/Panel.yaml
@@ -10,6 +10,6 @@ panel_a11y_source_expl:
 
 panel_glossary_text:
   en: |
-    Glossary:
+    Additional terms:
   fr: |
-    Glossaire :
+    Définitions supplémentaires :

--- a/client/src/components/glossary_components.js
+++ b/client/src/components/glossary_components.js
@@ -46,7 +46,7 @@ export const GlossaryIcon = ({id, alternate_text, arrow_selector, inner_selector
   </GlossaryTooltipWrapper>
 );
 
-export const GlossaryLink = ({id, alternate_text, item_class, arrow_selector, inner_selector}) => (
+export const GlossaryItem = ({id, alternate_text, item_class, arrow_selector, inner_selector}) => (
   <GlossaryTooltipWrapper
     id={id}
     arrow_selector={arrow_selector}

--- a/client/src/components/glossary_components.js
+++ b/client/src/components/glossary_components.js
@@ -3,23 +3,31 @@ import { GlossaryEntry } from '../models/glossary.js';
 import { glossary_href } from '../link_utils.js';
 import { trivial_text_maker } from '../models/text.js';
 
-const GlossaryTooltipItem = ({id, arrow_selector, inner_selector, children}) => (
-  <a
-    href={ window.is_a11y_mode ? glossary_href(id) : null}
-    title={ window.is_a11y_mode ? trivial_text_maker("glossary_link_title") : null}
-    className="tag-glossary-item"
-    data-toggle="tooltip"
-    data-ibtt-glossary-key={id}
-    data-ibtt-html="true"
-    data-ibtt-arrowselector={arrow_selector ? arrow_selector : null}
-    data-ibtt-innerselector={inner_selector ? inner_selector : null}
-  >
-    {children}
-  </a>
+const GlossaryTooltipWrapper = ({no_bottom_border, id, arrow_selector, inner_selector, children}) => (
+  window.is_a11y_mode ? 
+    <a
+      href={window.is_a11y_mode ? glossary_href(id) : null}
+      title={window.is_a11y_mode ? trivial_text_maker("glossary_link_title") : null}
+    >
+      {children}
+    </a> :
+    <span 
+      className="nowrap glossary-tooltip-link"
+      style={no_bottom_border && {borderBottom: "none"}}
+      tabIndex="0"
+      data-ibtt-glossary-key={id}
+      data-toggle="tooltip"
+      data-ibtt-html="true"
+      data-ibtt-arrowselector={arrow_selector ? arrow_selector : null}
+      data-ibtt-innerselector={inner_selector ? inner_selector : null}
+    >
+      {children}
+    </span>
 );
 
 export const GlossaryIcon = ({id, alternate_text, arrow_selector, inner_selector, icon_color, icon_alt_color}) => (
-  <GlossaryTooltipItem
+  <GlossaryTooltipWrapper
+    no_bottom_border={true}
     id={id}
     arrow_selector={arrow_selector}
     inner_selector={inner_selector}
@@ -35,11 +43,11 @@ export const GlossaryIcon = ({id, alternate_text, arrow_selector, inner_selector
           vertical_align={"-0.3em"}
         />
     }
-  </GlossaryTooltipItem>
+  </GlossaryTooltipWrapper>
 );
 
 export const GlossaryLink = ({id, alternate_text, item_class, arrow_selector, inner_selector}) => (
-  <GlossaryTooltipItem
+  <GlossaryTooltipWrapper
     id={id}
     arrow_selector={arrow_selector}
     inner_selector={inner_selector}
@@ -47,6 +55,6 @@ export const GlossaryLink = ({id, alternate_text, item_class, arrow_selector, in
     <span className={item_class}>
       {alternate_text ? alternate_text : GlossaryEntry.lookup(id).title}
     </span>
-  </GlossaryTooltipItem>
+  </GlossaryTooltipWrapper>
 );
 

--- a/client/src/components/index.js
+++ b/client/src/components/index.js
@@ -27,7 +27,7 @@ export { PDFGenerator } from './PDFGenerator.js';
 export { CountdownCircle } from './CountdownCircle.js';
 export { Countdown } from './Countdown.js';
 export { LogInteractionEvents } from './LogInteractionEvents.js';
-export { GlossaryIcon, GlossaryLink } from './glossary_components.js';
+export { GlossaryIcon, GlossaryItem } from './glossary_components.js';
 export { WellList } from './WellList.js';
 export { DisplayTable } from './DisplayTable.js';
 export { LabeledTable } from './LabeledTable.js';

--- a/client/src/extended_bootstrap_css/bootstrap-wet-fixes-extensions.scss
+++ b/client/src/extended_bootstrap_css/bootstrap-wet-fixes-extensions.scss
@@ -76,8 +76,8 @@ hr {
 
 .glossary-tooltip-link,
 .glossary-tooltip-link:visited {
-  text-decoration: none !important;
-  border-bottom: 1px dotted $textColor !important;
+  text-decoration: none;
+  border-bottom: 1px dotted $textColor;
   transition: width 2s;
   opacity: 0.8;
 }

--- a/client/src/panels/panel_declarations/finances/welcome_mat/welcome_mat.js
+++ b/client/src/panels/panel_declarations/finances/welcome_mat/welcome_mat.js
@@ -856,7 +856,8 @@ const common_program_crso_calculate = function(subject, info, options){
   return {type, info, calcs};
 };
 
-
+const footnotes = ["MACHINERY", "PLANNED_EXP", "FTE", "PLANNED_FTE", "EXP"];
+const depends_on = ['programSpending', 'programFtes'];
 export const declare_welcome_mat_panel = () => declare_panel({
   panel_key: "welcome_mat",
   levels: ["gov", "dept", "program", "crso", "tag"],
@@ -864,10 +865,9 @@ export const declare_welcome_mat_panel = () => declare_panel({
     switch (level){
       case "gov":
         return {
-          footnotes: ["MACHINERY", "PLANNED_EXP", "FTE", "PLANNED_FTE", "EXP"],
-          glossary_keys: ["FTE"],
+          footnotes,
           info_deps: ["programFtes_gov_info"],
-          depends_on: ['programSpending','programFtes'],
+          depends_on,
           missing_info: "ok",
           calculate (subject, info, options){
             const { programSpending, programFtes } = this.tables; 
@@ -886,10 +886,9 @@ export const declare_welcome_mat_panel = () => declare_panel({
         };
       case "dept":
         return {
-          footnotes: ["MACHINERY", "PLANNED_EXP", "FTE", "PLANNED_FTE", "EXP"],
-          glossary_keys: ["FTE"],
+          footnotes,
           info_deps: ["programFtes_dept_info"],
-          depends_on: ['programSpending','programFtes', 'orgVoteStatEstimates', 'orgVoteStatPa'],
+          depends_on: ['orgVoteStatEstimates', 'orgVoteStatPa', ...depends_on],
           missing_info: "ok",
           calculate (subject, info, options){
             const { programSpending, programFtes, orgVoteStatEstimates } = this.tables; 
@@ -945,30 +944,30 @@ export const declare_welcome_mat_panel = () => declare_panel({
         };
       case "program":
         return {
-          footnotes: ["MACHINERY", "PLANNED_EXP", "FTE", "PLANNED_FTE", "EXP"],
-          glossary_keys: ["FTE"],
+          footnotes,
           info_deps: ["programFtes_program_info"],
-          depends_on: ['table6', 'table12'],
+          depends_on,
+          glossary_keys: ["FTE"],
           missing_info: "ok",
           calculate: common_program_crso_calculate,
           render,
         };
       case "crso":
         return {
-          footnotes: ["MACHINERY", "PLANNED_EXP", "FTE", "PLANNED_FTE", "EXP"],
-          glossary_keys: ["FTE"],
+          footnotes,
           info_deps: ["programFtes_crso_info"],
-          depends_on: ['table6', 'table12'],
+          depends_on,
+          glossary_keys: ["FTE"],
           missing_info: "ok",
           calculate: common_program_crso_calculate,
           render,
         };
       case "tag":
         return {
-          footnotes: ["MACHINERY", "PLANNED_EXP", "FTE", "PLANNED_FTE", "EXP"],
-          glossary_keys: ["FTE"],
+          footnotes,
           info_deps: ["programFtes_program_info"],
-          depends_on: ['programSpending','programFtes'],
+          depends_on,
+          glossary_keys: ["FTE"],
           missing_info: "ok",
           calculate (subject, info, options){
             const { programSpending, programFtes } = this.tables; 

--- a/client/src/panels/panel_declarations/finances/welcome_mat/welcome_mat.js
+++ b/client/src/panels/panel_declarations/finances/welcome_mat/welcome_mat.js
@@ -833,9 +833,9 @@ function get_calcs(subject, q6, q12){
 
 
 const common_program_crso_calculate = function(subject, info, options){
-  const { table6, table12 } = this.tables; 
-  const q6 = table6.q(subject);
-  const q12 = table12.q(subject);
+  const { programSpending, programFtes } = this.tables; 
+  const q6 = programSpending.q(subject);
+  const q12 = programFtes.q(subject);
 
   const has_planned = has_planning_data(subject, q6);
   const has_hist = has_hist_data(subject, q6);

--- a/client/src/rpb/TablePicker.scss
+++ b/client/src/rpb/TablePicker.scss
@@ -42,81 +42,18 @@
   background-color: $buttonPrimaryColor;
   padding-right: 3px;
   border-radius: 0px 8px 8px 0px;
-  border:none;
+  border: none;
   color: $textLightColor;
 
   // Fix inconsistent sub-pixel white gaps in IE11
   padding-left: 1px;
   margin-right: -1px;
-}
 
-.tag-glossary-item {
-  width: 25px;
-  height: 30px;
-
-  & > .tag-glossary-icon {
-    height: inherit;
-    width: inherit;
+  // override glossary icon size
+  & > .glossary-tooltip-link > svg {
+    width: 1.5em !important;
+    height: 2em !important;
   }
-
-  & > .tag-tooltip-text {
-    visibility: hidden;
-    color: $textLightColor;
-    background-color: $primaryColor;
-    text-align: left;
-    border-radius: 5px;
-    padding: 1px 20px 10px 20px;
-    position: absolute;
-    z-index: 1;
-    font-size: 0.8em;
-    border: none; 
-    
-    @media (min-width: $minLargeDevice) { 
-      width: 550px;
-    }
-    @media (min-width: $minMediumDevice) and (max-width: $maxLargeDevice) { 
-      width: 70vw;
-      right: 0vw;
-    }
-    @media (max-width: $maxMediumDevice) { 
-      width: 80vw;
-      right: 0vw;
-    }
-  }
-}
-
-.TablePicker__tooltip-inner{
-  background-color: $primaryColor;
-}
-.tooltip[x-placement^="right"]>.TablePicker__tooltip-arrow {
-  border-right-color: $primaryColor;
-  border-left-color: transparent;
-  border-top-color: transparent;
-  border-bottom-color: transparent;
-}
-.tooltip[x-placement^="left"]>.TablePicker__tooltip-arrow {
-  border-left-color: $primaryColor;
-  border-right-color: transparent;
-  border-top-color: transparent;
-  border-bottom-color: transparent;
-}
-.tooltip[x-placement^="bottom"]>.TablePicker__tooltip-arrow {
-  border-bottom-color: $primaryColor;
-  border-right-color: transparent;
-  border-top-color: transparent;
-  border-left-color: transparent;
-}
-.tooltip[x-placement^="top"]>.TablePicker__tooltip-arrow {
-  border-top-color: $primaryColor;
-  border-right-color: transparent;
-  border-left-color: transparent;
-  border-bottom-color: transparent;
-}
-
-
-.tag-glossary-item:hover > .tag-tooltip-text,
-.tag-button-helper:focus > .tag-glossary-item > .tag-tooltip-text {
-  visibility: visible;
 }
 
 .tag-cloud-main > li:hover > button,


### PR DESCRIPTION
Anchor? Like, the piece of text that the tooltip is anchored to, not like a `<a>`.

*Specifically* not like a `<a>`, because half the point of this PR was making sure they're always spans instead (in standard mode, a11y mode always uses links).

TODO:
  - [x] double check IE, some stuff I changed was weird and may have been the way it was to fix an IE problem? No clear comment about it, just guessing
  - [x] change panel "Glossary:" section label to something like "Other related terms:" or something? Right now it may be confusing that there's glossary items in the panel that aren't in the footer (especially since some panels have some of their glossary entries repeated in panel text and footer, that should be cleaned up too)