### PR TITLE
Fix for target display bug in flat indicator table

### DIFF
--- a/client/src/panels/panel_declarations/results/result_flat_table.js
+++ b/client/src/panels/panel_declarations/results/result_flat_table.js
@@ -196,7 +196,7 @@ class ResultsTable extends React.Component {
           </div>
           <HeightClippedGraph clipHeight={200}>
             <div className="results-flat-table">
-              {indicator_table_from_list(filtered_indicators, !subject.is_first_wave && last_drr_doc === 'drr17')}
+              {indicator_table_from_list(filtered_indicators, last_drr_doc === 'drr17')}
             </div>
           </HeightClippedGraph>
         </div>


### PR DESCRIPTION
There was a check for subject.is_first_wave which shouldn't have been there--the target display code has more to do with the datasheets vs titan than whether the dept is old policy.