### PR TITLE
FootnoteList rework

### DIFF
--- a/client/src/components/FootnoteList.js
+++ b/client/src/components/FootnoteList.js
@@ -1,0 +1,24 @@
+import './FootnoteList.scss';
+
+import { sanitized_dangerous_inner_html } from '../general_utils.js';
+
+import { FancyUL } from './misc_util_components.js';
+
+
+const FootnoteList = ({ footnotes }) => <div className={"footnote-list"}>
+  <FancyUL>
+    {_.chain(footnotes)
+      .uniqBy("text")
+      .map( 
+        ({text}, ix) => <div 
+          className={"footnote-list__note"} 
+          key={ix} 
+          dangerouslySetInnerHTML={sanitized_dangerous_inner_html(text)}
+        />
+      )
+      .value()
+    }
+  </FancyUL>
+</div>;
+
+export { FootnoteList };

--- a/client/src/components/FootnoteList.scss
+++ b/client/src/components/FootnoteList.scss
@@ -1,0 +1,11 @@
+.footnote-list {
+  margin: 0px 20px;
+}
+
+.footnote-list__note {
+  font-size: 14px;
+
+  & > p {
+    margin: 0px;
+  }
+}

--- a/client/src/components/Panel.js
+++ b/client/src/components/Panel.js
@@ -5,10 +5,8 @@ import { GlossaryItem } from './glossary_components.js';
 import classNames from 'classnames';
 
 import { Details } from './Details.js';
-import { 
-  FootnoteList,
-  create_text_maker_component,
-} from './misc_util_components.js';
+import { FootnoteList } from './FootnoteList.js';
+import { create_text_maker_component } from './misc_util_components.js';
 
 
 const { TM } = create_text_maker_component(text);

--- a/client/src/components/index.js
+++ b/client/src/components/index.js
@@ -31,6 +31,7 @@ export { GlossaryIcon, GlossaryItem } from './glossary_components.js';
 export { WellList } from './WellList.js';
 export { DisplayTable } from './DisplayTable.js';
 export { LabeledTable } from './LabeledTable.js';
+export { FootnoteList } from './FootnoteList.js';
 
 export {
   Explorer,
@@ -46,7 +47,6 @@ export {
   TrivialTextMaker,
   TrivialTM,
   ExternalLink,
-  FootnoteList,
   Year,
   TextAbbrev,
   lang,

--- a/client/src/components/misc_util_components.js
+++ b/client/src/components/misc_util_components.js
@@ -4,10 +4,7 @@ import { Fragment } from 'react';
 import { run_template, trivial_text_maker, create_text_maker } from '../models/text.js';
 import { formats } from '../core/format.js';
 
-import { 
-  text_abbrev,
-  sanitized_dangerous_inner_html,
-} from '../general_utils.js';
+import { text_abbrev } from '../general_utils.js';
 
 import { TextMaker, TM } from './TextMaker.js';
 
@@ -39,16 +36,6 @@ const FancyUL = ({children, ul_class})=> (
     }
   </ul>
 );
-
-const FootnoteList = ({ footnotes }) => <div style={{padding: "10px"}}>
-  <FancyUL>
-    {_.chain(footnotes)
-      .uniqBy("text")
-      .map( ({text}, ix) => <div key={ix} dangerouslySetInnerHTML={sanitized_dangerous_inner_html(text)} />)
-      .value()
-    }
-  </FancyUL>
-</div>;
 
 const Year = ({y}) => run_template(`{{${y}}}`);
 
@@ -90,7 +77,6 @@ export {
   TrivialTextMaker,
   TrivialTM,
   ExternalLink,
-  FootnoteList,
   Year,
   TextAbbrev,
   lang,

--- a/client/src/components/misc_util_components.js
+++ b/client/src/components/misc_util_components.js
@@ -41,17 +41,13 @@ const FancyUL = ({children, ul_class})=> (
 );
 
 const FootnoteList = ({ footnotes }) => <div style={{padding: "10px"}}>
-  <ul>
+  <FancyUL>
     {_.chain(footnotes)
       .uniqBy("text")
-      .map( ({text}, ix) => 
-        <li key={ix}>
-          <div dangerouslySetInnerHTML={sanitized_dangerous_inner_html(text)} />
-        </li>
-      )
+      .map( ({text}, ix) => <div key={ix} dangerouslySetInnerHTML={sanitized_dangerous_inner_html(text)} />)
       .value()
     }
-  </ul>
+  </FancyUL>
 </div>;
 
 const Year = ({y}) => run_template(`{{${y}}}`);

--- a/client/src/rpb/shared.js
+++ b/client/src/rpb/shared.js
@@ -1,12 +1,12 @@
 import { TextMaker, text_maker } from './rpb_text_provider.js';
 import { sources as all_sources } from '../metadata/data_sources.js';
-import { sanitized_dangerous_inner_html } from '../general_utils.js';
 import { Subject } from '../models/subject';
 import {
   DeptSearch,
   FancyUL,
   ShareButton,
   WriteToClipboard,
+  FootnoteList,
 } from '../components/index.js';
 import { IconCopyLink } from '../icons/icons.js';
 
@@ -94,16 +94,12 @@ const ReportDetails = ({
       </section>
       <div className="rpb-separator" />
       {!_.isEmpty(footnotes) && 
-      <div 
-        className="mrgn-tp-lg"
-      >
-        <div className="h5"> <TextMaker text_key="footnotes" /> </div>
-        <ul>
-          {_.map( footnotes, (note, index) => 
-            <li key={index}> <div dangerouslySetInnerHTML={sanitized_dangerous_inner_html(note)} /> </li> 
-          )}
-        </ul>
-      </div>
+        <div 
+          className="mrgn-tp-lg"
+        >
+          <div className="h5"> <TextMaker text_key="footnotes" /> </div>
+          <FootnoteList footnotes={footnotes} />
+        </div>
       }
     </section>
   );

--- a/client/src/rpb/state_and_data.js
+++ b/client/src/rpb/state_and_data.js
@@ -240,10 +240,7 @@ function create_mapStateToProps(){
 
     return _.chain(gov_footnotes)
       .concat(subject_footnotes)
-      .map('text')
-      .uniqBy()
-      .compact()
-      .concat([ text_maker('different_org_names_rpb_footnote') ])
+      .concat([ {text: text_maker('different_org_names_rpb_footnote')} ])
       .value();
   });
 


### PR DESCRIPTION
Closes #436

TODO:
  - [x] don't love the margins on `<p>`s in inside the `FancyUL`,  might tweak that
  - ~should the footnote header/details behaviour be part of the standard `FootnoteList` component? I think I want it to be, for consistency between the panels and the RPB (and anywhere else we display footnotes, if I'm forgetting somewhere)~ Nah, that'd be a more brittle direction to take things for not much benefit
  - ~doesn't completely solve the problem where footnote items that were entered through Titan as single item lists look like they're broken (although it looks less wild than before). Should I try to deal with that more directly? Maybe ask the pipeline to handle them~ Looks like, at least the case that kicked this off, was not a markdown list. It was a footnote that actually contained a bullet character and a tab...