### PR TITLE
Fix API logging for (real) GET requests

### DIFF
--- a/server/src/server_utils.js
+++ b/server/src/server_utils.js
@@ -22,13 +22,13 @@ const get_query_and_variables_from_request = (req) => {
     const {query, variables} = req.body;
     return {query, variables};
   } else if( req.query ){
-    const { query, variables: variables_string } = req.query;
+    const {query, variables} = req.query;
 
     const confirmed_query = /^query/.test(query) && query
 
-    const variables = variables_string && JSON.parse(variables_string);
+    const parsed_variables = variables && JSON.parse(variables);
 
-    return {query: confirmed_query, variables};
+    return {query: confirmed_query, variables: parsed_variables};
   } else {
     return {};
   }

--- a/server/src/server_utils.js
+++ b/server/src/server_utils.js
@@ -2,17 +2,12 @@ import { decompressFromBase64 } from 'lz-string';
 import md5 from 'md5';
 
 import _ from 'lodash';
-
-const safely_split_query_string = (query_string) => query_string.includes("&variables=") ?
-  query_string.split("&variables=") :
-  [query_string, ""];
-
   
 // Side effect alert: this function mutates the suplied request object so that the conversion persists to subsequent server midleware
 // ... bit of a hack, and I'm not just talking about a function having side effects
 export const convert_GET_with_compressed_query_to_POST = (req) => {
   const decoded_decompressed_query = decompressFromBase64(req.headers['encoded-compressed-query']);
-  const [query, variables] = safely_split_query_string(decoded_decompressed_query);
+  const [query, variables] = decoded_decompressed_query.split("&variables=");
 
   req.method = "POST";
   req.body = {

--- a/server/src/server_utils.js
+++ b/server/src/server_utils.js
@@ -3,11 +3,16 @@ import md5 from 'md5';
 
 import _ from 'lodash';
 
+const safely_split_query_string = (query_string) => query_string.includes("&variables=") ?
+  query_string.split("&variables=") :
+  [query_string, ""];
+
+  
 // Side effect alert: this function mutates the suplied request object so that the conversion persists to subsequent server midleware
 // ... bit of a hack, and I'm not just talking about a function having side effects
 export const convert_GET_with_compressed_query_to_POST = (req) => {
   const decoded_decompressed_query = decompressFromBase64(req.headers['encoded-compressed-query']);
-  const [query, variables] = decoded_decompressed_query.split("&variables=");
+  const [query, variables] = safely_split_query_string(decoded_decompressed_query);
 
   req.method = "POST";
   req.body = {
@@ -22,9 +27,7 @@ const get_query_and_variables_from_request = (req) => {
     const {query, variables} = req.body;
     return {query, variables};
   } else if( req.query ){
-    const [query, variables_string] = req.query.includes("&variables=") ?
-      req.query.split("&variables=") :
-      [req.query, ""];
+    const { query, variables: variables_string } = req.query;
 
     const confirmed_query = /^query/.test(query) && query
 

--- a/server/src/server_utils.js
+++ b/server/src/server_utils.js
@@ -22,11 +22,13 @@ const get_query_and_variables_from_request = (req) => {
     const {query, variables} = req.body;
     return {query, variables};
   } else if( req.query ){
-    const [query, variables_string] = req.query.split("&variables=");
+    const [query, variables_string] = req.query.includes("&variables=") ?
+      req.query.split("&variables=") :
+      [req.query, ""];
 
     const confirmed_query = /^query/.test(query) && query
 
-    const variables = JSON.parse(variables_string);
+    const variables = variables_string && JSON.parse(variables_string);
 
     return {query: confirmed_query, variables};
   } else {

--- a/server/src/server_utils.unit-test.js
+++ b/server/src/server_utils.unit-test.js
@@ -8,7 +8,7 @@ import {
 
 const query_string = 'query ($lang: String!) {\n  root(lang: $lang) {\n    gov {\n      id\n      __typename\n    }\n    __typename\n  }\n}';
 const variable_string = '{"lang":"en","_query_name":"test"}';
-const uncompressed_query = `${query_string}&variables=${variable_string}`;
+const query_object = {query: query_string, variables: variable_string};
 const compressed_query = "I4VwpgTgngBAFAEgDYEMB2BzAXDAygFwgEtMBCAShgG8AoGGCAe0fzlUx2XQ0tvvoyMAbtTr96RACZjxAfVn4oABzBoUAWzAyYAX23zFKtZrF6dAMiEpiKAEZIwAZwC8VAETsMbrG9VuANG6yoJBQssZg3m74TvhuOkA";
 
 
@@ -47,7 +47,7 @@ describe("get_log_object_for_request", function(){
       headers: {
         origin: "test",
       },
-      query: uncompressed_query,
+      query: query_object,
     };
 
     const log_object = get_log_object_for_request(GET_request);
@@ -67,7 +67,7 @@ describe("get_log_object_for_request", function(){
       headers: {
         origin: "test",
       },
-      query: query_string,
+      query: {query: query_string},
     };
 
     const log_object = get_log_object_for_request(GET_request);

--- a/server/src/server_utils.unit-test.js
+++ b/server/src/server_utils.unit-test.js
@@ -41,7 +41,7 @@ describe("convert_GET_with_compressed_query_to_POST", function(){
 
 
 describe("get_log_object_for_request", function(){
-  it("Builds log as expected for a normal GET request", () => {
+  it("Builds log as expected for a normal GET request with variables", () => {
     const GET_request = {
       method: "GET",
       headers: {
@@ -57,6 +57,26 @@ describe("get_log_object_for_request", function(){
     expect(log_object.non_query).toEqual(undefined);
     expect(log_object.query_name).toEqual("test");
     expect(log_object.variables).toEqual({lang: "en"});
+    expect(log_object.query_hash).toEqual( expect.stringMatching(/.?/) );
+    expect(log_object.query).toEqual(query_string);
+  });
+
+  it("Builds log as expected for a normal GET request without variables", () => {
+    const GET_request = {
+      method: "GET",
+      headers: {
+        origin: "test",
+      },
+      query: query_string,
+    };
+
+    const log_object = get_log_object_for_request(GET_request);
+
+    expect(log_object.origin).toEqual("test");
+    expect(log_object.method).toEqual("GET");
+    expect(log_object.non_query).toEqual(undefined);
+    expect(log_object.query_name).toEqual("test");
+    expect(log_object.variables).toEqual({});
     expect(log_object.query_hash).toEqual( expect.stringMatching(/.?/) );
     expect(log_object.query).toEqual(query_string);
   });

--- a/server/src/server_utils.unit-test.js
+++ b/server/src/server_utils.unit-test.js
@@ -75,7 +75,7 @@ describe("get_log_object_for_request", function(){
     expect(log_object.origin).toEqual("test");
     expect(log_object.method).toEqual("GET");
     expect(log_object.non_query).toEqual(undefined);
-    expect(log_object.query_name).toEqual("test");
+    expect(log_object.query_name).toEqual(undefined);
     expect(log_object.variables).toEqual({});
     expect(log_object.query_hash).toEqual( expect.stringMatching(/.?/) );
     expect(log_object.query).toEqual(query_string);


### PR DESCRIPTION
This case only ever came up when a third party wanted to poke our API, glad they got in touch! 