### PR TITLE
make FTEs and other integer columns use floats

### DIFF
--- a/client/src/core/TableClass.js
+++ b/client/src/core/TableClass.js
@@ -408,8 +408,8 @@ export class Table extends mix().with(staticStoreMixin){
         // need to handle special cases of '.', '', and '-'
         if ( _.includes(['percentage', 'decimal', 'decimal1', 'percentage1', 'percentage2'], type) && !_.isNaN(parseFloat(val)) ){
           row_obj[key]=parseFloat(val);
-        } else if ( (type === 'big_int' || type === 'int') && !_.isNaN(parseInt(val,10))){
-          row_obj[key]=parseInt(val,10);
+        } else if ( (type === 'big_int' || type === 'int') && !_.isNaN(parseFloat(val)) ){
+          row_obj[key]=parseFloat(val);
         } else if (_.includes(['.','','-'], val) && _.includes(['percentage', 'decimal', 'decimal1', 'percentage1', 'percentage2', 'big_int', 'big_int', 'int'], type) ){
           row_obj[key]=0;
         }


### PR DESCRIPTION
Just to give an idea of the scale of this fix, Gov-wide FTEs in 2014-15 went from 339,589 to 339,632

This didn't change the planned FTE counts, I guess no one plans using fractional FTEs