### PR TITLE
Drop MLT references in code and data, TagExplorer configuration cleanup

### DIFF
--- a/client/src/TagExplorer/TagExplorer.js
+++ b/client/src/TagExplorer/TagExplorer.js
@@ -53,7 +53,6 @@ const route_arg_to_year_map = {
 };
 const year_to_route_arg_map = _.invert(route_arg_to_year_map);
 
-const dp_only_schemes = ["MLT"];
 
 const children_grouper = (node, children) => {
   if(node.root){
@@ -175,13 +174,11 @@ class ExplorerPage extends React.Component {
     const [
       goco_props, 
       hwh_props,
-      //mlt_props,
       wwh_props,
       hi_props,
     ] = _.chain([ 
       Tag.lookup("GOCO"),
       Tag.lookup("HWH"),
-      //Tag.lookup("MLT"),
       Tag.lookup("WWH"),
       Tag.lookup("HI"),
     ])
@@ -277,7 +274,7 @@ class ExplorerPage extends React.Component {
               const route_base = window.location.href.split('#')[0];
 
               const new_route = {
-                [actual_year]: `#tag-explorer/${_.includes(dp_only_schemes, hierarchy_scheme) ? "min" : hierarchy_scheme }/actual`,
+                [actual_year]: `#tag-explorer/${hierarchy_scheme}/actual`,
                 [planning_year]: `#tag-explorer/${hierarchy_scheme}/planned`,
               }[key];
 
@@ -446,7 +443,7 @@ export default class TagExplorer extends React.Component {
     } = match;
 
     hierarchy_scheme = (
-      _.includes(['min','dept','GOCO','HWH', "WWH", "CCOFOG", "MLT", "HI"], hierarchy_scheme) ? 
+      _.includes(['min','dept','GOCO','HWH', "WWH", "CCOFOG", "HI"], hierarchy_scheme) ? 
         hierarchy_scheme :
         'min'
     );

--- a/client/src/TagExplorer/TagExplorer.js
+++ b/client/src/TagExplorer/TagExplorer.js
@@ -443,7 +443,7 @@ export default class TagExplorer extends React.Component {
     } = match;
 
     hierarchy_scheme = (
-      _.includes(['min','dept','GOCO','HWH', "WWH", "CCOFOG", "HI"], hierarchy_scheme) ? 
+      _.includes(['min','dept','GOCO','HWH', "WWH", "HI"], hierarchy_scheme) ? 
         hierarchy_scheme :
         'min'
     );

--- a/client/src/TagExplorer/hierarchy_scheme_configs.js
+++ b/client/src/TagExplorer/hierarchy_scheme_configs.js
@@ -20,7 +20,7 @@ const tag_configs = _.chain(Tag.tag_roots)
     title: name,
     text: description,
     is_m2m,
-    can_roll_up: is_m2m,
+    can_roll_up: !is_m2m,
     get_depth_one_nodes: (year) => _.map(
       children_tags, 
       tag => ({
@@ -59,7 +59,7 @@ const min_config = {
   title: trivial_text_maker("how_were_accountable"),
   text: trivial_text_maker("portfolio_description"),
   is_m2m: false,
-  can_roll_up: false,
+  can_roll_up: true,
   get_depth_one_nodes: (year) => _.chain( Ministry.get_all() )
     .map(min => ({
       id: min.guid,
@@ -80,7 +80,7 @@ const dept_config = {
   title: trivial_text_maker("organizations_public_funds"),
   text: trivial_text_maker("a_z_list_of_orgs"),
   is_m2m: false,
-  can_roll_up: false,
+  can_roll_up: true,
   get_depth_one_nodes: (year) => _.map(
     Dept.get_all(),
     org => get_org_nodes(org, year),

--- a/client/src/TagExplorer/hierarchy_scheme_configs.js
+++ b/client/src/TagExplorer/hierarchy_scheme_configs.js
@@ -1,0 +1,100 @@
+
+import { Subject } from '../models/subject.js';
+import { trivial_text_maker } from '../models/text.js';
+import { sanitized_dangerous_inner_html } from '../general_utils.js';
+import { get_resources_for_subject } from '../explorer_common/resource_explorer_common.js';
+
+import { related_tags_row } from './tag_hierarchy_utils.js';
+
+const {
+  Tag,
+  Ministry,
+  Dept,
+} = Subject;
+
+
+const tag_configs = _.chain(Tag.tag_roots)
+  .omit(["CCOFOG"])
+  .map( ({ id, name, description, is_m2m, children_tags }) => ({
+    id,
+    title: name,
+    text: description,
+    is_m2m,
+    can_roll_up: is_m2m,
+    get_depth_one_nodes: (year) => _.map(
+      children_tags, 
+      tag => ({
+        id: tag.guid,
+        data: {
+          name: tag.name,
+          resources: is_m2m ? null : get_resources_for_subject(tag, year),
+          subject: tag,
+          defs: tag.is_lowest_level_tag && _.compact(
+            [
+              !_.isEmpty(tag.description) && {
+                term: trivial_text_maker('description'),
+                def: <div dangerouslySetInnerHTML={sanitized_dangerous_inner_html(tag.description)} />,
+              },
+              tag.is_m2m && !_.isEmpty( tag.related_tags() ) && 
+                related_tags_row( tag.related_tags(), "tag" ),
+            ]
+          ),  
+        },
+      })
+    ),
+  }) )
+  .value();
+
+
+const get_org_nodes = (org, year) => ({
+  id: org.guid,
+  data: {
+    name: org.name,
+    subject: org,
+    resources: get_resources_for_subject(org, year),
+  },
+});
+const min_config = {
+  id: 'min',
+  title: trivial_text_maker("how_were_accountable"),
+  text: trivial_text_maker("portfolio_description"),
+  is_m2m: false,
+  can_roll_up: false,
+  get_depth_one_nodes: (year) => _.chain( Ministry.get_all() )
+    .map(min => ({
+      id: min.guid,
+      data: {
+        name: min.name,
+        subject: min,
+        resources: get_resources_for_subject(min, year),
+      },
+      children: _.map(
+        min.orgs, 
+        org => get_org_nodes(org, year)
+      ), 
+    }) )
+    .value(),
+};
+const dept_config = {
+  id: 'dept',
+  title: trivial_text_maker("organizations_public_funds"),
+  text: trivial_text_maker("a_z_list_of_orgs"),
+  is_m2m: false,
+  can_roll_up: false,
+  get_depth_one_nodes: (year) => _.map(
+    Dept.get_all(),
+    org => get_org_nodes(org, year),
+  ),
+};
+
+
+export const hierarchy_scheme_configs = _.chain([
+  min_config,
+  dept_config,
+  ...tag_configs,
+])
+  .map(config => [config.id, config])
+  .fromPairs()
+  .value();
+
+export const default_scheme_id = 'min';

--- a/client/src/TagExplorer/resource_scheme.js
+++ b/client/src/TagExplorer/resource_scheme.js
@@ -20,7 +20,7 @@ const { planning_years } = year_templates;
 const planning_year = _.first(planning_years);
 
 
-const non_rolling_up_schemes = ['WWH', 'MLT', 'HI'];
+const non_rolling_up_schemes = ['HWH', 'WWH', 'HI'];
 
 const related_tags_row = (related_tags, subject_type) => {
   const term = subject_type === "program" ? 
@@ -74,7 +74,6 @@ function create_resource_hierarchy({hierarchy_scheme, year}){
         case 'HWH':
         case 'WWH':
         case 'CCOFOG':
-        case 'MLT':
         case 'HI':
           return _.map(Tag.lookup(hierarchy_scheme).children_tags, tag => ({
             id: tag.guid,

--- a/client/src/TagExplorer/resource_scheme.js
+++ b/client/src/TagExplorer/resource_scheme.js
@@ -73,7 +73,6 @@ function create_resource_hierarchy({hierarchy_scheme, year}){
         case 'GOCO':
         case 'HWH':
         case 'WWH':
-        case 'CCOFOG':
         case 'HI':
           return _.map(Tag.lookup(hierarchy_scheme).children_tags, tag => ({
             id: tag.guid,

--- a/client/src/TagExplorer/resource_scheme.js
+++ b/client/src/TagExplorer/resource_scheme.js
@@ -156,8 +156,8 @@ const get_initial_resource_state = ({hierarchy_scheme, year}) => {
   return {
     hierarchy_scheme: scheme_id,
     year: year || planning_year,
-    sort_col: !can_roll_up ? 'spending' : 'name',
-    is_descending: !can_roll_up,
+    sort_col: can_roll_up ? 'spending' : 'name',
+    is_descending: can_roll_up,
   };
 };
 

--- a/client/src/TagExplorer/resource_scheme.js
+++ b/client/src/TagExplorer/resource_scheme.js
@@ -174,7 +174,7 @@ function create_resource_hierarchy({hierarchy_scheme, year}){
               data: {
                 name: tag.name,
                 subject: tag,
-                resources: _.includes(["MLT"], hierarchy_scheme) ? null : get_resources(tag),
+                resources: get_resources(tag),
                 defs: tag.description && [
                   {
                     term: text_maker('description'),
@@ -257,7 +257,7 @@ const resource_scheme = {
   get_props_selector: () => {
     return augmented_state => ({ 
       ...augmented_state.resources,
-      is_m2m: _.includes(['HWH', 'WWH', 'MLT', 'HI'], augmented_state.resources.hierarchy_scheme),
+      is_m2m: _.includes(['HWH', 'WWH', 'HI'], augmented_state.resources.hierarchy_scheme),
     });
   },
   dispatch_to_props: dispatch => ({ 

--- a/client/src/TagExplorer/tag_hierarchy_utils.js
+++ b/client/src/TagExplorer/tag_hierarchy_utils.js
@@ -1,0 +1,33 @@
+import { trivial_text_maker } from '../models/text.js';
+import { infograph_href_template } from '../link_utils.js';
+import { HeightClipper } from '../components/index.js';
+
+export const related_tags_row = (related_tags, subject_type) => {
+  const term = subject_type === "program" ? 
+    trivial_text_maker('related_tags_for_program') : 
+    trivial_text_maker('related_tags');
+
+  const list_content = (
+    <ul className="ExplorerNode__List">
+      {_.map(related_tags, related_tag =>
+        <li key={related_tag.id}>
+          <a href={infograph_href_template(related_tag)} >
+            {related_tag.name} 
+          </a>
+        </li>
+      )}
+    </ul>
+  );
+  const def = related_tags.length > 6 ?
+    <HeightClipper 
+      allowReclip={true} 
+      clipHeight={110}
+      children={list_content} 
+    /> :
+    list_content;
+
+  return {
+    term,
+    def,
+  };
+};

--- a/client/src/models/populate_stores.js
+++ b/client/src/models/populate_stores.js
@@ -274,6 +274,10 @@ function populate_program_tag_linkages(programs_m2m_tags){
     const tag = Tag.lookup(tagID);
     const tag_root_id = tag.root.id;
 
+    // CCOFOGs are currently disabled, they have quirks to resolve and code around (duplicated nodes as you go down, some tagging done at the root level some at other levels, etc.)
+    if(tag_root_id === "CCOFOG"){
+      return;
+    }
 
     program.tags.push(tag);
     tag.programs.push(program);

--- a/client/src/models/populate_stores.js
+++ b/client/src/models/populate_stores.js
@@ -273,10 +273,12 @@ function populate_program_tag_linkages(programs_m2m_tags){
     const program = Program.lookup(program_id);
     const tag = Tag.lookup(tagID);
     const tag_root_id = tag.root.id;
-    // if(tag_root_id === "CCOFOG" || tag_root_id === "MLT" || tag_root_id === "WWH"){
-    if(tag_root_id === "CCOFOG" || tag_root_id === "MLT" ){
+
+    // we have CCOFOG data but, for [reason] we don't use them in the InfoBase currently
+    if(tag_root_id === "CCOFOG"){
       return;
     }
+
     program.tags.push(tag);
     tag.programs.push(program);
   }); 

--- a/client/src/models/populate_stores.js
+++ b/client/src/models/populate_stores.js
@@ -274,10 +274,6 @@ function populate_program_tag_linkages(programs_m2m_tags){
     const tag = Tag.lookup(tagID);
     const tag_root_id = tag.root.id;
 
-    // we have CCOFOG data but, for [reason] we don't use them in the InfoBase currently
-    if(tag_root_id === "CCOFOG"){
-      return;
-    }
 
     program.tags.push(tag);
     tag.programs.push(program);

--- a/client/src/models/tags.js
+++ b/client/src/models/tags.js
@@ -74,12 +74,6 @@ const Tag = class Tag extends extensible_subject_store(){
       } else {
         return trivial_text_maker("gocos");
       }
-    } else if(this.root.id === "MLT"){
-      if(!this.is_lowest_level_tag){
-        return trivial_text_maker("priorities");
-      } else {
-        return trivial_text_maker("commitments");
-      }
     } else {
       if (_.nonEmpty(this.programs) && _.isEmpty(this.children_tags)){
         return trivial_text_maker("tag")+"(s)";

--- a/client/src/panels/panel_declarations/misc/resource_structure/resource_structure.js
+++ b/client/src/panels/panel_declarations/misc/resource_structure/resource_structure.js
@@ -132,7 +132,7 @@ class RootedResourceExplorer extends React.Component {
       </div>
     </div>;
 
-    if(_.includes(["CCOFOG", "WWH"], subject.root.id)){
+    if(_.includes(["WWH"], subject.root.id)){
       return inner_content;
     }
  

--- a/client/src/panels/panel_declarations/misc/resource_structure/resource_structure.js
+++ b/client/src/panels/panel_declarations/misc/resource_structure/resource_structure.js
@@ -132,7 +132,7 @@ class RootedResourceExplorer extends React.Component {
       </div>
     </div>;
 
-    if(_.includes(["MLT", "CCOFOG", "WWH"], subject.root.id)){
+    if(_.includes(["CCOFOG", "WWH"], subject.root.id)){
       return inner_content;
     }
  

--- a/client/src/panels/panel_declarations/misc/tags_related_to_subject_panels.js
+++ b/client/src/panels/panel_declarations/misc/tags_related_to_subject_panels.js
@@ -22,7 +22,6 @@ const { HeightClipper, WellList } = util_components;
 const scheme_order = [
   "GOCO",
   "WWH",
-  "MLT",
   "CCOFOG",
   "HWH",
 ];

--- a/data/program_tag_types.csv
+++ b/data/program_tag_types.csv
@@ -2,7 +2,6 @@
 "HWH","MtoM","How we help","Comment nous aidons","Information is organized according to how the Programs are delivered (e.g. grants, loans, etc.)","L'information est organisée selon le mécanisme de prestation des programmes (p. ex. bourse, prêts)"
 "GOCO","OtoM","What we do","Ce que nous faisons","Each governmental program is mapped to a high-level activity which is itself associated to a major area of work","Chaque programme gouvernemental est lié à une activité de haut niveau qui est elle-même associée à un domaine de travail important"
 "WWH","MtoM","Who we help","Qui aidons-nous","A group of people, economic segments, institutions and organization that a Program is intended to help/impact","Groupe de personnes, segment économique, institutions et organisations sur lesquels le programme devrait avoir une incidence"
-"MLT","MtoM","Ministerial Mandate Letter","Lettre de mandat du ministre","Clearly lay out each minister's priorities as mandated by the Prime Minister","Cette lettre établit clairement les priorités de chaque ministre, selon le mandat que lui a confié le premier ministre"
 "CCOFOG","OtoM","Canadian Classification of Functions of Government","Classifications canadiennes des fonctions des administrations publiques",,
 "HI","MtoM","Horizontal Initiatives","Initiatives horizontales","When two or more departments work together to achieve Government objectives","Lorsqu'au mois deux ministères travaillent ensemble pour atteindre les objectives du gouvernement"
 


### PR DESCRIPTION
Closes #459 

TODO:
  - [x] drop MLTs
  - [x] are CCOFOGs also dead? We drop them during population, even though users still download them all
    - ~yeah, they're dead, dropping them too~
    -  got push-back on this, so maybe they aren't truly dead. Leaving them turned off for now, but still removing a lot of references to them in the tag explorer cleanup process
  - [x] bit of room for cleanup across the tag explorer code, central configs for hierarchy schemes, etc.
  - [x] coordinate with pipeline to drop the MLT root tag in `program_tag_types.csv` ~and COFOG data too~