### PR TITLE
Survey popup

### DIFF
--- a/client/src/InfoBase/App.js
+++ b/client/src/InfoBase/App.js
@@ -2,7 +2,7 @@ import './App.scss';
 
 import { Suspense } from 'react';
 import { Route, Switch, Redirect } from 'react-router-dom';
-\
+
 import { initialize_analytics } from '../core/analytics.js';
 import { has_local_storage } from '../core/feature_detection.js';
 

--- a/client/src/InfoBase/App.js
+++ b/client/src/InfoBase/App.js
@@ -13,10 +13,11 @@ export const app_reducer = (state={ lang: window.lang }, { type, payload }) => {
 
 import { ErrorBoundary } from '../core/ErrorBoundary.js';
 import { DevFip } from '../core/DevFip.js';
-import { TooltipActivator } from '../glossary/TooltipActivator';
+import { TooltipActivator } from '../glossary/TooltipActivator.js';
 import { InsertRuntimeFooterLinks } from '../core/InsertRuntimeFooterLinks.js';
-import { ReactUnmounter } from '../core/NavComponents';
-import { EasyAccess } from '../core/EasyAccess';
+import { ReactUnmounter } from '../core/NavComponents.js';
+import { EasyAccess } from '../core/EasyAccess.js';
+import { SurveyPopup } from '../core/SurveyPopup.js';
 import { SpinnerWrapper } from '../components/SpinnerWrapper.js';
 import { PageDetails } from '../components/PageDetails.js';
 
@@ -55,6 +56,7 @@ export class App extends React.Component {
           <DevFip />
           <InsertRuntimeFooterLinks />
           <EasyAccess />
+          <SurveyPopup />
           <ReactUnmounter />
           { !window.is_a11y_mode && <TooltipActivator /> }
           <Suspense fallback={<SpinnerWrapper config_name={"route"} />}>

--- a/client/src/InfoBase/App.js
+++ b/client/src/InfoBase/App.js
@@ -2,7 +2,9 @@ import './App.scss';
 
 import { Suspense } from 'react';
 import { Route, Switch, Redirect } from 'react-router-dom';
+\
 import { initialize_analytics } from '../core/analytics.js';
+import { has_local_storage } from '../core/feature_detection.js';
 
 import { ensure_linked_stylesheets_load, retrying_react_lazy } from './common_app_component_utils.js';
 
@@ -56,7 +58,7 @@ export class App extends React.Component {
           <DevFip />
           <InsertRuntimeFooterLinks />
           <EasyAccess />
-          <SurveyPopup />
+          { has_local_storage && <SurveyPopup /> } 
           <ReactUnmounter />
           { !window.is_a11y_mode && <TooltipActivator /> }
           <Suspense fallback={<SpinnerWrapper config_name={"route"} />}>

--- a/client/src/components/modals_and_popovers/FixedPopover.js
+++ b/client/src/components/modals_and_popovers/FixedPopover.js
@@ -143,4 +143,5 @@ FixedPopover.defaultProps = {
   auto_close_time: false,
   close_text: _.upperFirst( trivial_text_maker("close") ),
   close_button_in_header: false,
+  on_close_callback: _.noop,
 };

--- a/client/src/core/EasyAccess.js
+++ b/client/src/core/EasyAccess.js
@@ -2,7 +2,6 @@ import { TrivialTM } from '../components/index.js';
 import { trivial_text_maker } from '../models/text.js';
 import { Fragment } from 'react';
 import {
-  IconFeedback,
   IconAbout,
   IconGlossary,
   IconDataset,
@@ -59,19 +58,6 @@ const EasyAccess_ = () =>
       />
       <span className="mrgn-lft-sm">
         <TM k="about_title" />
-      </span>
-    </a>
-    <a
-      href={trivial_text_maker("survey_link_href")}
-      className="link-unstyled nav-item"
-    >
-      <IconFeedback
-        title={trivial_text_maker("survey_link_text")}
-        inline={true}
-        aria_hide={true}
-      />
-      <span className="mrgn-lft-sm">
-        <TM k="survey_link_text" />
       </span>
     </a>
   </Fragment>;

--- a/client/src/core/InsertRuntimeFooterLinks.js
+++ b/client/src/core/InsertRuntimeFooterLinks.js
@@ -1,4 +1,4 @@
-import { trivial_text_maker } from '../models/text.js';
+import { trivial_text_maker, run_template } from '../models/text.js';
 import { index_lang_lookups } from '../InfoBase/index_data.js';
 
 const footer_link_items = _.compact([
@@ -15,6 +15,10 @@ const footer_link_items = _.compact([
     id: "footer-standard-link",
     href: index_lang_lookups.standard_version_url[window.lang],
     text: index_lang_lookups.standard_version_titile[window.lang],
+  },
+  {
+    href: run_template("{{survey_link}}"),
+    text: trivial_text_maker("survey_link_text"),
   },
 ]);
 

--- a/client/src/core/SurveyPopup.js
+++ b/client/src/core/SurveyPopup.js
@@ -90,7 +90,7 @@ export const SurveyPopup = withRouter(
     }
     shouldComponentUpdate(nextProps, nextState){
       const chance_to_open_changed = this.state.chance !== nextState.chance;
-      const is_closing = !this.state.active && this.state.active !== nextState.active;
+      const is_closing = this.state.active !== nextState.active;
 
       return chance_to_open_changed || is_closing;
     }

--- a/client/src/core/SurveyPopup.js
+++ b/client/src/core/SurveyPopup.js
@@ -82,10 +82,6 @@ export const SurveyPopup = withRouter(
       if ( _.includes(["yes", "no"], button_type) ){
         localStorage.setItem(`infobase_survey_popup_deactivated`, "true");
         localStorage.setItem(`infobase_survey_popup_deactivated_since`, Date.now());
-
-        if (button_type === "yes"){
-          window.open( text_maker("survey_link") );
-        }
       }
 
       this.setState({active: false});
@@ -125,22 +121,29 @@ export const SurveyPopup = withRouter(
         }
         body={<TM k="survey_popup_body" />}
         footer={
-          _.chain([
-            "yes",
-            "later",
-            "no",
-          ])
-            .compact()
-            .map( (button_type) => (
-              <button 
-                className="btn btn-ib-primary"
-                key={button_type}
-                onClick={ () => this.handleButtonPress(button_type) }
-              >
-                {text_maker(`survey_popup_${button_type}`)}
-              </button>
-            ) )
-            .value()
+          <Fragment>
+            <a 
+              href={text_maker("survey_link")}
+              target="_blank" rel="noopener noreferrer"
+              className="btn btn-ib-primary"
+              onClick={ () => this.handleButtonPress('yes') }
+            >
+              {text_maker('survey_popup_yes')}
+            </a>
+            {
+              _.map(
+                ["later", "no"],
+                (button_type) => <button 
+                  key={button_type}
+                  className="btn btn-ib-primary"
+                  onClick={ () => this.handleButtonPress(button_type) }
+                >
+                  {text_maker(`survey_popup_${button_type}`)}
+                </button>,
+              )
+            }
+          </Fragment>
+
         }
       />;
     }

--- a/client/src/core/SurveyPopup.js
+++ b/client/src/core/SurveyPopup.js
@@ -3,6 +3,7 @@ import text from "./SurveyPopup.yaml";
 import { Fragment } from 'react';
 import { withRouter } from 'react-router';
 
+import { log_standard_event } from './analytics.js';
 import { IconFeedback } from '../icons/icons.js';
 import { FixedPopover, create_text_maker_component } from '../components/index.js';
 
@@ -83,6 +84,12 @@ export const SurveyPopup = withRouter(
         localStorage.setItem(`infobase_survey_popup_deactivated`, "true");
         localStorage.setItem(`infobase_survey_popup_deactivated_since`, Date.now());
       }
+
+      log_standard_event({
+        SUBAPP: window.location.hash.replace('#','') || "start",
+        MISC1: "SURVEY_POPUP_INTERACTION",
+        MISC2: button_type,
+      });
 
       this.setState({active: false});
     }

--- a/client/src/core/SurveyPopup.js
+++ b/client/src/core/SurveyPopup.js
@@ -20,7 +20,7 @@ const route_root = (path) => _.chain(path)
 
 
 // less likely for users without local storage since they will always have a chance to see it, even after previously filling it out or dimissing it
-const chance_increment = has_local_storage ? 0.1 : 0.05;
+const chance_increment = has_local_storage ? 0.2 : 0.05;
 
 
 export const SurveyPopup = withRouter(
@@ -45,7 +45,7 @@ export const SurveyPopup = withRouter(
               default_state,
               (default_value, key) => {
                 const local_storage_value = localStorage.getItem(`infobase_survey_popup_${key}`);
-                return !_.isNull ? local_storage_value : default_value;
+                return !_.isNull(local_storage_value) ? local_storage_value : default_value;
               }
             );
           } else {
@@ -72,13 +72,13 @@ export const SurveyPopup = withRouter(
       this.state = {
         active: active,
         previous_route_root: null,
-        chance: chance,
+        chance: +chance, // comeso out of local storage as a string, cast to number here to be safe
       };
     }
     handleButtonPress(button_type){
       if ( _.includes(["yes", "no"], button_type) ){
-        localStorage.getItem(`infobase_survey_popup_active`, false);
-        localStorage.getItem(`infobase_survey_popup_deactivated_unix_time`, Date.now());
+        localStorage.setItem(`infobase_survey_popup_active`, false);
+        localStorage.setItem(`infobase_survey_popup_deactivated_unix_time`, Date.now());
 
         if (button_type === "yes"){
           window.open( text_maker("survey_link") );

--- a/client/src/core/SurveyPopup.js
+++ b/client/src/core/SurveyPopup.js
@@ -96,6 +96,13 @@ export const SurveyPopup = withRouter(
 
       return chance_to_open_changed || is_closing;
     }
+    componentDidMount(){
+      // if a new user bounces from the first page they see, want them to have some chance of getting the popup if they ever return
+      // this is clobered by the properly incrementing value for users who don't bounce though
+      if (this.state.chance === 0){
+        localStorage.setItem(`infobase_survey_popup_chance`, 0.25);
+      }
+    }
     render(){
       const {
         active,

--- a/client/src/core/SurveyPopup.js
+++ b/client/src/core/SurveyPopup.js
@@ -1,0 +1,49 @@
+import { withRouter } from 'react-router';
+
+import { has_local_storage } from './feature_detection.js';
+
+import { FixedPopover } from '../components/index.js';
+
+// less likely for users without local storage since they will always have a chance to see it, even after interacting with it
+const base_chance = has_local_storage ? 0.25 : 0.05;
+const chance_increment = has_local_storage ? 0.1 : 0.05;
+
+export const SurveyPopup = withRouter(
+  class _SurveyPopup extends React.Component {
+    constructor(props){
+      super(props);
+
+      const { history } = props;
+
+      history.listen(
+        (location, action) => {
+          if (action === 'PUSH' && history){
+            this.setState({
+              chance: this.state.chance + chance_increment,
+            });
+          }
+        }
+      );
+
+      this.state = {
+        active: true,
+        chance: base_chance,
+      };
+    }
+    shouldComponentUpdate(nextProps, nextState){
+      const {
+        active,
+        chance,
+      } = nextState;
+      
+      const should_get_chance_to_render = active && chance > this.state.chance;
+
+      return should_get_chance_to_render;
+    }
+    render(){
+      const { chance } = this.state;
+
+      return null;
+    }
+  }
+);

--- a/client/src/core/SurveyPopup.js
+++ b/client/src/core/SurveyPopup.js
@@ -1,8 +1,16 @@
+import text from "./SurveyPopup.yaml";
+
 import { withRouter } from 'react-router';
 
 import { has_local_storage } from './feature_detection.js';
 
-import { FixedPopover } from '../components/index.js';
+import { FixedPopover, create_text_maker_component } from '../components/index.js';
+
+const {
+  TM,
+  text_maker,
+} = create_text_maker_component(text);
+
 
 const route_root = (path) => _.chain(path)
   .replace(/^\//, '')
@@ -11,17 +19,17 @@ const route_root = (path) => _.chain(path)
   .value();
 
 // less likely for users without local storage since they will always have a chance to see it, even after previously filling it out or dimissing it
-const base_chance = has_local_storage ? 0.2 : 0.05;
-const chance_increment = has_local_storage ? 0.05 : 0.01;
+const base_chance = 1;
+const chance_increment = has_local_storage ? 0.1 : 0.05;
 
 export const SurveyPopup = withRouter(
   class _SurveyPopup extends React.Component {
     constructor(props){
       super(props);
 
-      const { history } = props;
+      this.handleButtonPress.bind(this);
 
-      history.listen(
+      props.history.listen(
         ({pathname}) => {
           if ( this.state.previous_route_root !== route_root(pathname) ){
             this.setState({
@@ -38,6 +46,19 @@ export const SurveyPopup = withRouter(
         chance: base_chance,
       };
     }
+    handleButtonPress(button_type){
+      switch(button_type){
+        case "yes":
+          //TODO
+          break;
+
+        case "no":
+          //TODO
+          break;
+      }
+
+      this.setState({active: false});
+    }
     render(){
       const {
         active,
@@ -47,7 +68,30 @@ export const SurveyPopup = withRouter(
       const should_render = Math.random() < chance;
 
       if (active && should_render){
-        return <div>bleh</div>;
+        return <FixedPopover
+          show={true}
+          header={<TM k="suvey_popup_header" />}
+          body={<TM k="survey_popup_body" />}
+          footer={
+            _.chain([
+              "yes",
+              "later",
+              has_local_storage && "no",
+            ])
+              .compact()
+              .map( (button_type) => (
+                <button 
+                  className="btn btn-ib-primary"
+                  key={button_type}
+                  onClick={ () => this.handleButtonPress(button_type) }
+                >
+                  {text_maker(`survey_popup_${button_type}`)}
+                </button>
+              ) )
+              .value()
+          }
+          on_close_callback={() => this.setState({active: false})}
+        />;
       } else {
         return null;
       }

--- a/client/src/core/SurveyPopup.js
+++ b/client/src/core/SurveyPopup.js
@@ -4,9 +4,15 @@ import { has_local_storage } from './feature_detection.js';
 
 import { FixedPopover } from '../components/index.js';
 
-// less likely for users without local storage since they will always have a chance to see it, even after interacting with it
-const base_chance = has_local_storage ? 0.25 : 0.05;
-const chance_increment = has_local_storage ? 0.1 : 0.05;
+const route_root = (path) => _.chain(path)
+  .replace(/^\//, '')
+  .split('/')
+  .first()
+  .value();
+
+// less likely for users without local storage since they will always have a chance to see it, even after previously filling it out or dimissing it
+const base_chance = has_local_storage ? 0.2 : 0.05;
+const chance_increment = has_local_storage ? 0.05 : 0.01;
 
 export const SurveyPopup = withRouter(
   class _SurveyPopup extends React.Component {
@@ -16,10 +22,11 @@ export const SurveyPopup = withRouter(
       const { history } = props;
 
       history.listen(
-        (location, action) => {
-          if (action === 'PUSH' && history){
+        ({pathname}) => {
+          if ( this.state.previous_route_root !== route_root(pathname) ){
             this.setState({
               chance: this.state.chance + chance_increment,
+              previous_route_root: route_root(pathname),
             });
           }
         }
@@ -27,23 +34,23 @@ export const SurveyPopup = withRouter(
 
       this.state = {
         active: true,
+        previous_route_root: null,
         chance: base_chance,
       };
     }
-    shouldComponentUpdate(nextProps, nextState){
+    render(){
       const {
         active,
         chance,
-      } = nextState;
-      
-      const should_get_chance_to_render = active && chance > this.state.chance;
+      } = this.state;
 
-      return should_get_chance_to_render;
-    }
-    render(){
-      const { chance } = this.state;
+      const should_render = Math.random() < chance;
 
-      return null;
+      if (active && should_render){
+        return <div>bleh</div>;
+      } else {
+        return null;
+      }
     }
   }
 );

--- a/client/src/core/SurveyPopup.js
+++ b/client/src/core/SurveyPopup.js
@@ -1,7 +1,9 @@
 import text from "./SurveyPopup.yaml";
 
+import { Fragment } from 'react';
 import { withRouter } from 'react-router';
 
+import { IconFeedback } from '../icons/icons.js';
 import { FixedPopover, create_text_maker_component } from '../components/index.js';
 
 const {
@@ -104,7 +106,16 @@ export const SurveyPopup = withRouter(
 
       return <FixedPopover
         show={should_render}
-        header={<TM k="suvey_popup_header" />}
+        title={
+          <Fragment>
+            <IconFeedback
+              title={text_maker("suvey_popup_header")}
+              color={window.infobase_color_constants.tertiaryColor}
+              alternate_color={false}
+            />
+            {text_maker("suvey_popup_header")}
+          </Fragment>
+        }
         body={<TM k="survey_popup_body" />}
         footer={
           _.chain([

--- a/client/src/core/SurveyPopup.js
+++ b/client/src/core/SurveyPopup.js
@@ -37,7 +37,7 @@ const get_state_defaults = () => {
 };
 
 
-const chance_increment = 0.15;
+const chance_increment = 0.2;
 
 export const SurveyPopup = withRouter(
   class _SurveyPopup extends React.Component {
@@ -100,7 +100,7 @@ export const SurveyPopup = withRouter(
       // if a new user bounces from the first page they see, want them to have some chance of getting the popup if they ever return
       // this is clobered by the properly incrementing value for users who don't bounce though
       if (this.state.chance === 0){
-        localStorage.setItem(`infobase_survey_popup_chance`, 0.25);
+        localStorage.setItem(`infobase_survey_popup_chance`, chance_increment);
       }
     }
     render(){

--- a/client/src/core/SurveyPopup.yaml
+++ b/client/src/core/SurveyPopup.yaml
@@ -5,9 +5,11 @@ suvey_popup_header:
 survey_popup_body:
   transform: [markdown]
   en: | 
-    Please take a few minutes at the end of your visit today to anonymously tell us about your experience with the GC InfoBase. We always value your feedback. Thank you!
+    Please take a few minutes at the end of your visit today to tell us about your experience with GC InfoBase.
 
-    Choosing “Yes, after my visit” will open our survey in a new window. You can return to this window and finish browsing the GC InfoBase before completing that survey, it will not time out.
+    Choosing “Yes, after my visit” will open our survey in a new window. You can return to this window to complete the survey after you have finished browsing the GC InfoBase; it will not time out.
+
+    We always value your feedback. Thank you!
   fr: TODO
 
 survey_popup_yes:

--- a/client/src/core/SurveyPopup.yaml
+++ b/client/src/core/SurveyPopup.yaml
@@ -5,12 +5,13 @@ suvey_popup_header:
 survey_popup_body:
   transform: [markdown]
   en: | 
-    We're running a quick study to see where people expect to find things on the site. Your responses will help us improve.  
+    Please take a few minutes at the end of your visit today to anonymously tell us about your experience with the GC InfoBase. Your feedback will help us improve. Thank you!
 
-    Choosing “Yes, after my visit” will open a new window that you can return to once you complete your visit.
+    Choosing “Yes, after my visit” will open a new window that you can return to once you finish browsing the GC InfoBase.
   fr: TODO
 
 survey_popup_yes:
+  transform: [handlebars]
   en: Yes, after my visit
   fr: TODO
 
@@ -21,3 +22,10 @@ survey_popup_later:
 survey_popup_no:
   en: No, do not ask again
   fr: TODO
+
+survey_link:
+  transform: [handlebars]
+  en: |
+    {{{survey_link}}}
+  fr: |
+    {{{survey_link}}}

--- a/client/src/core/SurveyPopup.yaml
+++ b/client/src/core/SurveyPopup.yaml
@@ -1,0 +1,23 @@
+suvey_popup_header:
+  en: Have a few minutes to help us improve this site?
+  fr: TODO
+
+survey_popup_body:
+  transform: [markdown]
+  en: | 
+    We're running a quick study to see where people expect to find things on the site. Your responses will help us improve.  
+
+    Choosing “Yes, after my visit” will open a new window that you can return to once you complete your visit.
+  fr: TODO
+
+survey_popup_yes:
+  en: Yes, after my visit
+  fr: TODO
+
+survey_popup_later:
+  en: Maybe some other time
+  fr: TODO
+
+survey_popup_no:
+  en: No, do not ask again
+  fr: TODO

--- a/client/src/core/SurveyPopup.yaml
+++ b/client/src/core/SurveyPopup.yaml
@@ -1,13 +1,13 @@
 suvey_popup_header:
-  en: Have a few minutes to help us improve this site?
+  en: Have a few minutes to help us improve the site?
   fr: TODO
 
 survey_popup_body:
   transform: [markdown]
   en: | 
-    Please take a few minutes at the end of your visit today to anonymously tell us about your experience with the GC InfoBase. Your feedback will help us improve. Thank you!
+    Please take a few minutes at the end of your visit today to anonymously tell us about your experience with the GC InfoBase. We always value your feedback. Thank you!
 
-    Choosing “Yes, after my visit” will open a new window that you can return to once you finish browsing the GC InfoBase.
+    Choosing “Yes, after my visit” will open our survey in a new window. You can return to this window and finish browsing the GC InfoBase before completing that survey, it will not time out.
   fr: TODO
 
 survey_popup_yes:

--- a/client/src/core/SurveyPopup.yaml
+++ b/client/src/core/SurveyPopup.yaml
@@ -1,6 +1,6 @@
 suvey_popup_header:
   en: Have a few minutes to help us improve the site?
-  fr: TODO
+  fr: Pouvez-vous prendre quelques minutes pour nous aider à améliorer le site?
 
 survey_popup_body:
   transform: [markdown]
@@ -10,20 +10,25 @@ survey_popup_body:
     Choosing “Yes, after my visit” will open our survey in a new window. You can return to this window to complete the survey after you have finished browsing the GC InfoBase; it will not time out.
 
     We always value your feedback. Thank you!
-  fr: TODO
+  fr: |
+    A la fin de votre visite aujourd'hui, prenez le temps de nous parler de votre expérience avec l'InfoBase du GC.
+
+    En sélectionnant "Oui, après ma visite", vous accéderez à une nouvelle fenêtre de notre enquête. Quand vous aurez fini de parcourir l'InfoBase du GC, vous pourrez revenir à cette fenêtre pour répondre au questionnaire ; il vous restera du temps.
+
+    Vos commentaires nous sont toujours précieux. Merci!
 
 survey_popup_yes:
   transform: [handlebars]
   en: Yes, after my visit
-  fr: TODO
+  fr: Oui, après ma visite
 
 survey_popup_later:
   en: Maybe some other time
-  fr: TODO
+  fr: Peut-être une autre fois
 
 survey_popup_no:
   en: No, do not ask again
-  fr: TODO
+  fr: Non, ne le demandez plus
 
 survey_link:
   transform: [handlebars]


### PR DESCRIPTION
Popup to forefront the feedback survey.

TODO:
  - [x] email around screenshot and text for feedback
  - [x] wire up analytics
  - [x] add icon to header?
  - [x] tweak chances, make it a bit more likely (also, increment after render instead of on route change, so that users who bounce on first page still have a higher chance of a popup on return)
  - [x] it will muddy up my nice code, but the "yes" option should really be a link instead of a button, so that cntrl+click can still open it in a new tab without switching to it 
  - [x] translate