### PR TITLE
Avoid archive dev link jam ups

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,6 +58,9 @@ jobs:
       - checkout:
           path: "~/InfoBase"
 
+      # only let this job run in the true repo
+      - run: if [ "$CIRCLE_PROJECT_REPONAME" != "infobase" ]; then circleci-agent step halt; fi
+
       - run:
           command: git branch -r > ./active-branches.txt
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,8 +39,8 @@ jobs:
 
       - run: (cd email_backend && npm run end_to_end_tests)
 
-     # halt here if on a dunderscore branch, expected to be running in an env without the GCloud env vars required for the following steps
-      - run: if [[ "$CIRCLE_BRANCH" =~ ^__ ]]; then circleci step halt; fi
+     # halt here if not on the true repo, expected that means this is running in an env without the GCloud env vars required for the following steps
+      - run: if [[ "$CIRCLE_PROJECT_REPONAME" != "infobase" ]]; then circleci step halt; fi
 
       - run: (cd email_backend && npm run merge_coverage_reports && npm run create_coverage_shield_badge)
       
@@ -186,8 +186,8 @@ jobs:
           background: true
       - run: (cd server && npm run snapshot_tests) # the end to end snapshot tests, run against un-transpiled src for more useful coverage stats
 
-      # halt here if on a dunderscore branch, expected to be running in an env without the GCloud env vars required for the following steps
-      - run: if [[ "$CIRCLE_BRANCH" =~ ^__ ]]; then circleci step halt; fi
+      # halt here if not on the true repo, expected that means this is running in an env without the GCloud env vars required for the following steps
+      - run: if [[ "$CIRCLE_PROJECT_REPONAME" != "infobase" ]]; then circleci step halt; fi
 
       - run: (cd server && npm run merge_coverage_reports && npm run create_coverage_shield_badge)
 

--- a/scripts/ci_scripts/cleanup_dev_dbs.js
+++ b/scripts/ci_scripts/cleanup_dev_dbs.js
@@ -11,7 +11,7 @@ if (all_dev_db_names.length === 0){
   for (i=0; i < all_dev_db_names.length; i++){
     const db_name = all_dev_db_names[i].name;
     // Double underscore branch names are exempt from automatic clean up
-    if ( !dbs_to_retain.includes(db_name) && !/^__/.test(db_name) ){
+    if ( !dbs_to_retain.includes(db_name) && !/(^__)|(^archived__)/.test(db_name) ){
       print(`Droping stale dev DB "${db_name}"`);
       db.getSiblingDB(db_name).dropDatabase();
     }

--- a/scripts/dev_scripts/hooks/pre-push
+++ b/scripts/dev_scripts/hooks/pre-push
@@ -11,7 +11,7 @@ read local_ref local_sha remote_ref remote_sha
 
 local_branch_name=$(echo "$local_ref" | sed "s/refs\/heads\///")
 
-if [[ $local_branch_name =~ ^__ && $remote != "archive" ]]; then
-  echo "Double underscore branches can only be pushed to the archive (private) remote!"
+if [[ ($local_branch_name =~ ^__ || $local_branch_name =~ ^archived__ ) && $remote != "archive" ]]; then
+  echo "Double underscore and archived branches can only be pushed to the archive (private) remote!"
   exit 1
 fi


### PR DESCRIPTION
Closes #468 

If an archived branch really needs a dev link, it must use the `archived__` prefix instead of the `__` prefix. Once this is merged, all open dev branches will need to rebase to get these rules in their CI, to finally squash the competing dev-link deletion!