### PR TITLE
Some tweaks to the survey popup

### DIFF
--- a/client/src/components/modals_and_popovers/FixedPopover.js
+++ b/client/src/components/modals_and_popovers/FixedPopover.js
@@ -49,6 +49,7 @@ export class FixedPopover extends React.Component {
       subtitle,
       header,
       body,
+      max_body_height,
       footer,
       dialog_position,
       additional_dialog_class,
@@ -123,7 +124,9 @@ export class FixedPopover extends React.Component {
             {header_content}
           </Modal.Header>
           { body &&
-            <Modal.Body>
+            <Modal.Body
+              style={max_body_height ? {maxHeight: max_body_height, overflowY: "scroll"} : {}}
+            >
               {body}
             </Modal.Body>
           }
@@ -144,4 +147,8 @@ FixedPopover.defaultProps = {
   close_text: _.upperFirst( trivial_text_maker("close") ),
   close_button_in_header: false,
   on_close_callback: _.noop,
+
+  // if the popup gets too tall, it will be cut-off (and possibly non-interactable for it) on mobile
+  // 40vh is a bit arbitrary as a default, but leaves room for long header/footer content
+  max_body_height: "40vh",
 };

--- a/client/src/core/SurveyPopup.js
+++ b/client/src/core/SurveyPopup.js
@@ -139,7 +139,7 @@ export const SurveyPopup = withRouter(
         }
         body={<TM k="survey_popup_body" />}
         footer={
-          <Fragment>
+          <div style={{display: "flex", justifyContent: "center"}}>
             <a 
               href={text_maker("survey_link")}
               target="_blank" rel="noopener noreferrer"
@@ -160,8 +160,7 @@ export const SurveyPopup = withRouter(
                 </button>,
               )
             }
-          </Fragment>
-
+          </div>
         }
       />;
     }

--- a/client/src/core/SurveyPopup.js
+++ b/client/src/core/SurveyPopup.js
@@ -90,8 +90,8 @@ export const SurveyPopup = withRouter(
 
       log_standard_event({
         SUBAPP: window.location.hash.replace('#','') || "start",
-        MISC1: "SURVEY_POPUP_INTERACTION",
-        MISC2: button_type,
+        MISC1: "SURVEY_POPUP",
+        MISC2: `interaction: ${button_type}`,
       });
 
       this.setState({active: false});
@@ -115,10 +115,18 @@ export const SurveyPopup = withRouter(
         chance,
       } = this.state;
 
-      const should_render = is_survey_campaign_over() && active && Math.random() < chance;
+      const should_show = is_survey_campaign_over() && active && Math.random() < chance;
+
+      if (should_show){
+        log_standard_event({
+          SUBAPP: window.location.hash.replace('#','') || "start",
+          MISC1: "SURVEY_POPUP",
+          MISC2: 'displayed',
+        });
+      }
 
       return <FixedPopover
-        show={should_render}
+        show={should_show}
         title={
           <Fragment>
             <IconFeedback

--- a/client/src/core/SurveyPopup.js
+++ b/client/src/core/SurveyPopup.js
@@ -13,6 +13,10 @@ const {
 } = create_text_maker_component(text);
 
 
+const chance_increment = 0.2;
+const survey_campaign_end_date = new Date(2020, 3, 14).getTime()/1000;
+
+
 const get_path_root = (path) => _.chain(path)
   .replace(/^\//, '')
   .split('/')
@@ -37,8 +41,7 @@ const get_state_defaults = () => {
   };
 };
 
-
-const chance_increment = 0.2;
+const is_survey_campaign_over = () => Date.now() > survey_campaign_end_date;
 
 export const SurveyPopup = withRouter(
   class _SurveyPopup extends React.Component {
@@ -112,7 +115,7 @@ export const SurveyPopup = withRouter(
         chance,
       } = this.state;
 
-      const should_render = active && Math.random() < chance;
+      const should_render = is_survey_campaign_over() && active && Math.random() < chance;
 
       return <FixedPopover
         show={should_render}


### PR DESCRIPTION
TODO:
  - [x] give it a set end-date, some time mid march
  - [x] track how often it displays in addition to the options clicked, so that we can do the math to figure out how often users bounce from the site after seeing the popup
  - [x] buttons have ugly placement in french due to differences in text content length. Probably also in mobile regardless of language
  - [x] be defensive about popups with too much content, if they end up taller than the screen on mobile, you can't scroll to what got cut off (may not be able to close or select the desired option in this case). Give the body of the popup a max, vh based, height value since cutting off/making the body scroll 