### PR TITLE
Show in-year estimates in "Authorities, Expenditures and Planned Spending" panel

### DIFF
--- a/client/src/models/years.js
+++ b/client/src/models/years.js
@@ -73,28 +73,8 @@ const actual_to_planned_gap_year = _.chain(year_templates)
   })
   .value();
 
-const actual_to_estimates_gap_year = _.chain(year_templates)
-  .thru( ({std_years, estimates_years}) => [_.last(std_years), _.last(estimates_years)] )
-  .map( (fiscal_year) => _.chain(fiscal_year)
-    .thru(run_template)
-    .split('-')
-    .first()
-    .parseInt()
-    .value()
-  )
-  .thru( ([last_pa_year, last_estimates_year]) => {
-    if(last_estimates_year - last_pa_year === 1){
-      return last_estimates_year;
-    } else if (last_estimates_year - last_pa_year === 0){
-      false;
-    } else {
-      throw new Error('Estimates in year is coming before last PA year. This should never happen?')
-    }
-  })
-  .value();
 
 export {
   year_templates,
   actual_to_planned_gap_year,
-  actual_to_estimates_gap_year,
 };

--- a/client/src/models/years.js
+++ b/client/src/models/years.js
@@ -73,8 +73,28 @@ const actual_to_planned_gap_year = _.chain(year_templates)
   })
   .value();
 
+const actual_to_estimates_gap_year = _.chain(year_templates)
+  .thru( ({std_years, estimates_years}) => [_.last(std_years), _.last(estimates_years)] )
+  .map( (fiscal_year) => _.chain(fiscal_year)
+    .thru(run_template)
+    .split('-')
+    .first()
+    .parseInt()
+    .value()
+  )
+  .thru( ([last_pa_year, last_estimates_year]) => {
+    if(last_estimates_year - last_pa_year === 1){
+      return last_estimates_year;
+    } else if (last_estimates_year - last_pa_year === 0){
+      false;
+    } else {
+      throw new Error('Estimates in year is coming before last PA year. This should never happen?')
+    }
+  })
+  .value();
 
 export {
   year_templates,
   actual_to_planned_gap_year,
+  actual_to_estimates_gap_year,
 };

--- a/client/src/panels/panel_declarations/finances/historical_auth_exp/auth_exp_prog_spending.js
+++ b/client/src/panels/panel_declarations/finances/historical_auth_exp/auth_exp_prog_spending.js
@@ -11,7 +11,6 @@ import {
   create_text_maker_component,
   NivoResponsiveLine,
   newIBCategoryColors,
-  formatter,
   util_components,
 
   declare_panel,
@@ -70,8 +69,8 @@ class AuthExpProgSpending extends React.Component {
     const { exp, auth, progSpending } = panel_args;
 
     const series_labels = [
-      text_maker("budgetary_expenditures"),
       text_maker("authorities"),
+      text_maker("budgetary_expenditures"),
       subject.has_planned_spending ? text_maker("planned_spending") : null,
     ];
 
@@ -98,31 +97,19 @@ class AuthExpProgSpending extends React.Component {
     
     let graph_content;
     if(window.is_a11y_mode){
-      const historical_data = _.map(
-        exp, 
-        (exp_value,year_index) => ({
-          label: history_ticks[year_index],
-          data: [
-            formatter("compact1_written", exp_value, {raw: true}),
-            formatter("compact1_written", auth[year_index], {raw: true}),
-            null,
-          ],
-        })
-      );
-      
-      const planning_data = _.map(
-        progSpending, 
-        (progSpending_value, year_index) => ({
-          label: plan_ticks[year_index],
-          data: [
-            null,
-            null,
-            formatter("compact1_written", progSpending_value, {raw: true}),
-          ],
-        })
-      );
-  
-      const data = _.concat(historical_data, planning_data);
+      const all_ticks = _.chain(auth_ticks)
+        .concat(exp_ticks, plan_ticks)
+        .uniq()
+        .value();
+
+      const data = _.map(all_ticks, tick => ({
+        label: tick,
+        data: [
+          auth[_.findIndex(auth_ticks, d=>d===tick)] || null,
+          exp[_.findIndex(exp_ticks, d=>d===tick)] || null,
+          progSpending[_.findIndex(plan_ticks, d=>d===tick)] || null,
+        ],
+      }));
   
       graph_content = (
         <A11YTable

--- a/client/src/panels/panel_declarations/finances/historical_auth_exp/auth_exp_prog_spending.js
+++ b/client/src/panels/panel_declarations/finances/historical_auth_exp/auth_exp_prog_spending.js
@@ -4,6 +4,7 @@ import {
   run_template,
   year_templates,
   actual_to_planned_gap_year,
+  actual_to_estimates_gap_year,
   declarative_charts,
   StdPanel,
   Col,

--- a/client/src/panels/panel_declarations/finances/historical_auth_exp/auth_exp_prog_spending.js
+++ b/client/src/panels/panel_declarations/finances/historical_auth_exp/auth_exp_prog_spending.js
@@ -102,9 +102,9 @@ class AuthExpProgSpending extends React.Component {
       const data = _.map(all_ticks, tick => ({
         label: tick,
         data: [
-          auth[_.findIndex(auth_ticks, d=>d===tick)] || null,
-          exp[_.findIndex(exp_ticks, d=>d===tick)] || null,
-          progSpending[_.findIndex(plan_ticks, d=>d===tick)] || null,
+          _.isNumber(auth[_.findIndex(auth_ticks, d=>d===tick)]) ? auth[_.findIndex(auth_ticks, d=>d===tick)] : null,
+          _.isNumber(exp[_.findIndex(exp_ticks, d=>d===tick)]) ? exp[_.findIndex(exp_ticks, d=>d===tick)] : null,
+          _.isNumber(progSpending[_.findIndex(plan_ticks, d=>d===tick)]) ? progSpending[_.findIndex(plan_ticks, d=>d===tick)] : null,
         ],
       }));
   

--- a/client/src/panels/panel_declarations/finances/historical_auth_exp/auth_exp_prog_spending.js
+++ b/client/src/panels/panel_declarations/finances/historical_auth_exp/auth_exp_prog_spending.js
@@ -84,6 +84,8 @@ class AuthExpProgSpending extends React.Component {
   
     const gap_year = (subject.has_planned_spending && actual_to_planned_gap_year) || null;
     
+    const estimates_extra_year = actual_to_estimates_gap_year || null;
+
     const additional_info = {
       last_history_year: run_template(_.last(std_years)),
       last_planned_year: _.last(plan_ticks),

--- a/client/src/panels/panel_declarations/finances/historical_auth_exp/auth_exp_prog_spending.js
+++ b/client/src/panels/panel_declarations/finances/historical_auth_exp/auth_exp_prog_spending.js
@@ -4,7 +4,6 @@ import {
   run_template,
   year_templates,
   actual_to_planned_gap_year,
-  actual_to_estimates_gap_year,
   declarative_charts,
   StdPanel,
   Col,
@@ -69,8 +68,8 @@ class AuthExpProgSpending extends React.Component {
     const { exp, auth, progSpending } = panel_args;
 
     const series_labels = [
-      text_maker("authorities"),
       text_maker("budgetary_expenditures"),
+      text_maker("authorities"),
       subject.has_planned_spending ? text_maker("planned_spending") : null,
     ];
 
@@ -82,8 +81,6 @@ class AuthExpProgSpending extends React.Component {
     const plan_ticks = _.map(planning_years, run_template);
   
     const gap_year = (subject.has_planned_spending && actual_to_planned_gap_year) || null;
-    
-    const estimates_extra_year = actual_to_estimates_gap_year || null;
 
     const additional_info = {
       last_history_year: run_template(_.last(std_years)),


### PR DESCRIPTION
Does what it says on the tin. Closes #421

TODO:

- [x] fix the A11y table version
- [x] double check that my logic on the years is right, based on the order that things (should be) tabled. -- I think we're good, if mains come out before DPs then its fine, if DPs come out before mains (unlikely) it would look weird but I *think* would still be fine. We should check on this graph when those updates go out though.
~~- [ ] possibly add another sentence of text?~~ Don't think this is necessary, it's already pretty wordy.