### PR TITLE
Catalina-proof mongodb

### DIFF
--- a/scripts/dev_scripts/tmux_env.sh
+++ b/scripts/dev_scripts/tmux_env.sh
@@ -47,7 +47,7 @@ else
     send-keys 'cd client && while true; do npm run IB_base_watch; sleep 30; done' C-m \; \
     selectp -t 4 \; \
     split-window -v \; \
-    send-keys 'cd server && mongod' C-m \; \
+    send-keys 'cd server && npm run mongod' C-m \; \
     split-window -h \; \
     send-keys 'cd server && while true; do npm run populate_db:exitcrash; sleep 30; done' C-m \;
 fi

--- a/scripts/dev_scripts/tmux_env.sh
+++ b/scripts/dev_scripts/tmux_env.sh
@@ -37,17 +37,25 @@ else
   #  - to the right of mongod, open window for API populate_db process, keep trying to start it as the API packages may still be installing
   tmux new-session -t "IB" \; \
     split-window -h \; \
-    send-keys "cd client && $can_reach_npm && npm ci || true && npm run IB_q_both" C-m \; \
+    send-keys "cd client" C-m \; \
+    send-keys "$can_reach_npm && npm ci || true && npm run IB_q_both" C-m \; \
     split-window -v \; \
-    send-keys 'cd client && while true; do npm run serve-loopback; sleep 30; done' C-m \; \
+    send-keys 'cd client' C-m \; \
+    send-keys 'while true; do npm run serve-loopback; sleep 30; done' C-m \; \
     split-window -v \; \
-    send-keys "cd server && $can_reach_npm && npm ci || true && npm start" C-m \; \
+    send-keys "cd server" C-m \; \
+    send-keys "$can_reach_npm && npm ci || true && npm start" C-m \; \
     selectp -t 2 \; \
     split-window -h \; \
-    send-keys 'cd client && while true; do npm run IB_base_watch; sleep 30; done' C-m \; \
+    send-keys 'cd client' C-m \; \
+    send-keys 'while true; do npm run IB_base_watch; sleep 30; done' C-m \; \
     selectp -t 4 \; \
     split-window -v \; \
-    send-keys 'cd server && npm run mongod' C-m \; \
+    send-keys 'cd server' C-m \; \
+    send-keys 'npm run mongod' C-m \; \
     split-window -h \; \
-    send-keys 'cd server && while true; do npm run populate_db:exitcrash; sleep 30; done' C-m \;
+    send-keys 'cd server' C-m \; \
+    send-keys 'while true; do npm run populate_db:exitcrash; sleep 30; done' C-m \; \
+    selectp -t 0 \; \
+    send-keys '^c' C-m \;
 fi

--- a/server/.gitignore
+++ b/server/.gitignore
@@ -8,3 +8,5 @@ npm-debug*
 coverage
 *credentials*.json
 transpiled_build/
+mongo/mongo.log
+mongo/db/*

--- a/server/mongo/mongod.conf
+++ b/server/mongo/mongod.conf
@@ -1,0 +1,4 @@
+storage:
+  dbPath: ./mongo/db
+net:
+  bindIp: 127.0.0.1

--- a/server/mongo/start_mongod.sh
+++ b/server/mongo/start_mongod.sh
@@ -4,4 +4,13 @@ if [[ ! -e ./mongo/db ]]; then
   mkdir ./mongo/db
 fi
 
+if [[ -e ./mongo/db/mongod.lock ]]; then 
+  running_mongod_pid=$(lsof ./mongo/db/mongod.lock | awk 'NR == 2 {print $2}')
+
+  # sticks in loop until the process is actually dead, otherwise it's a race between the subsequent mongod starting and this old one finishing its cleanup
+  while kill $running_mongod_pid; do 
+    sleep 1
+  done
+fi
+
 mongod --config ./mongo/mongod.conf

--- a/server/mongo/start_mongod.sh
+++ b/server/mongo/start_mongod.sh
@@ -1,0 +1,7 @@
+#! /bin/bash
+
+if [[ ! -e ./mongo/db ]]; then 
+  mkdir ./mongo/db
+fi
+
+mongod --config ./mongo/mongod.conf

--- a/server/package.json
+++ b/server/package.json
@@ -65,7 +65,7 @@
     "populate_db:debug": "nodemon --watch ../data -e csv --exec babel-node --inspect src/populate_db.js",
     "prebuild": "rm -rf transpiled_build",
     "build": "babel src/ --out-dir transpiled_build --copy-files --ignore node_modules",
-    "mongod": "(if [[ ! -e ./mongo/db ]]; then mkdir ./mongo/db; fi; mongod --config ./mongo/mongod.conf)"
+    "mongod": "./mongo/start_mongod.sh"
   },
   "authors": [
     "Alex Cousineau-Leduc",

--- a/server/package.json
+++ b/server/package.json
@@ -64,7 +64,8 @@
     "populate_db:exitcrash": "nodemon --exitcrash --watch ../data -e csv --exec babel-node src/populate_db.js",
     "populate_db:debug": "nodemon --watch ../data -e csv --exec babel-node --inspect src/populate_db.js",
     "prebuild": "rm -rf transpiled_build",
-    "build": "babel src/ --out-dir transpiled_build --copy-files --ignore node_modules"
+    "build": "babel src/ --out-dir transpiled_build --copy-files --ignore node_modules",
+    "mongod": "(if [[ ! -e ./mongo/db ]]; then mkdir ./mongo/db; fi; mongod --config ./mongo/mongod.conf)"
   },
   "authors": [
     "Alex Cousineau-Leduc",


### PR DESCRIPTION
Fixes #502 

In dev, instead of running an un-configured `mongod` for the local server, use `npm run mongod` from within the `/server` dir to use a mongodb configured to store locally in `server/mongo/db`. No longer need to disable SIP and mount root to create a `/data/db` on new/newly updated Macs.

The script behind `npm run mongod` also takes care of creating a `mongo/db` directory if it doesn't exist yet, AND kills any previously running/zombie mongod's running for the server (since it failing to properly die on crashes seems common).