### PR TITLE
Add a robots noindex meta tag to the error boundary 

### DIFF
--- a/client/src/core/ErrorBoundary.js
+++ b/client/src/core/ErrorBoundary.js
@@ -1,6 +1,13 @@
 import { get_static_url, make_request } from '../request_utils.js';
 import { log_standard_event } from './analytics.js';
 
+
+const NoIndex = () => ReactDOM.createPortal(
+  <meta name="robots" content="noindex" />,
+  document.head
+);
+
+
 export class ErrorBoundary extends React.Component {
   constructor(){
     super();
@@ -72,6 +79,7 @@ export class ErrorBoundary extends React.Component {
             alignItems: "center",
           }}
         >
+          <NoIndex />
           <span>
             {
               {  


### PR DESCRIPTION
Should clear/prevent future indexing of broken/dead routes in search engines. For example, you can search for a now-dead program and get an InfoBase link that takes results in an error boundary page.

This might be a considerable source of traffic to dead infographics, so possibly the root cause of #443. If I get around to digging through analytics to check that assumption, I'll update here with the answer. 