### PR TITLE
Internal Services Panel now hides the bar graph when in A11y Mode

### DIFF
--- a/client/src/panels/panel_declarations/finances/internal_services/internal_services.js
+++ b/client/src/panels/panel_declarations/finances/internal_services/internal_services.js
@@ -103,17 +103,11 @@ export const declare_internal_services_panel = () => declare_panel({
         return result;
       }, []);
 
-      const to_render = <div>
-        <div className="medium_panel_text" style={{marginBottom: "15px"}}>
-          <TM
-            k="internal_service_panel_text"
-            args={{
-              subject,
-              isc_fte_pct: isc_fte / total_fte,
-              gov_isc_fte_pct: gov_isc_fte / gov_fte_total,
-            }}
-          />
-        </div>
+      let graph_content;
+      if (window.is_a11y_mode) {
+        graph_content = null;
+      } else {
+        graph_content = 
         <div className="frow md-middle"> 
           <div className="fcol-md-3">
             <div className="well legend-container">
@@ -137,7 +131,21 @@ export const declare_internal_services_panel = () => declare_panel({
               }}
             />
           </div>
+        </div>;
+      }
+
+      const to_render = <div>
+        <div className="medium_panel_text" style={{marginBottom: "15px"}}>
+          <TM
+            k="internal_service_panel_text"
+            args={{
+              subject,
+              isc_fte_pct: isc_fte / total_fte,
+              gov_isc_fte_pct: gov_isc_fte / gov_fte_total,
+            }}
+          />
         </div>
+        {graph_content}
       </div>;
   
       return (

--- a/client/src/panels/panel_declarations/finances/internal_services/internal_services.js
+++ b/client/src/panels/panel_declarations/finances/internal_services/internal_services.js
@@ -12,9 +12,13 @@ import {
   declare_panel, 
 } from '../../shared.js';
 
+
 const { Gov, Tag } = Subject;
 const { std_years } = year_templates;
-const { GraphLegend } = declarative_charts;
+const { 
+  GraphLegend, 
+  A11YTable, 
+} = declarative_charts;
 const { text_maker, TM } = create_text_maker_component(text);
 
 export const declare_internal_services_panel = () => declare_panel({
@@ -105,7 +109,23 @@ export const declare_internal_services_panel = () => declare_panel({
 
       let graph_content;
       if (window.is_a11y_mode) {
-        graph_content = null;
+        graph_content = (
+          <A11YTable 
+            table_name={text_maker("internal_service_panel_title")}
+            data={_.chain(bar_data)
+              .flatMap( _.keys )
+              .uniq()
+              .pull('date')
+              .map( (label) => (
+                {
+                  label,
+                  data: _.map(bar_data, label),
+                }
+              ) )
+              .value()}
+            label_col_header={text_maker("program")}
+            data_col_headers={std_years.map(yr => run_template(yr))}
+          />);
       } else {
         graph_content = 
         <div className="frow md-middle"> 

--- a/client/src/panels/panel_declarations/finances/internal_services/internal_services.js
+++ b/client/src/panels/panel_declarations/finances/internal_services/internal_services.js
@@ -107,52 +107,54 @@ export const declare_internal_services_panel = () => declare_panel({
         return result;
       }, []);
 
-      let graph_content;
-      if (window.is_a11y_mode) {
-        graph_content = (
-          <A11YTable 
-            table_name={text_maker("internal_service_panel_title")}
-            data={_.chain(bar_data)
-              .flatMap( _.keys )
-              .uniq()
-              .pull('date')
-              .map( (label) => (
-                {
-                  label,
-                  data: _.map(bar_data, label),
-                }
-              ) )
-              .value()}
-            label_col_header={text_maker("program")}
-            data_col_headers={std_years.map(yr => run_template(yr))}
-          />);
-      } else {
-        graph_content = 
-        <div className="frow md-middle"> 
-          <div className="fcol-md-3">
-            <div className="well legend-container">
-              <GraphLegend
-                items={legend_items}
-              />
+      const graph_content = (() => {
+        if (window.is_a11y_mode) {
+          return (
+            <A11YTable 
+              table_name={text_maker("internal_service_panel_title")}
+              data={_.chain(bar_data)
+                .flatMap( _.keys )
+                .uniq()
+                .pull('date')
+                .map( (label) => (
+                  {
+                    label,
+                    data: _.map(bar_data, label),
+                  }
+                ) )
+                .value()}
+              label_col_header={text_maker("program")}
+              data_col_headers={std_years.map(yr => run_template(yr))}
+            />);
+        } else {
+          return (
+            <div className="frow md-middle"> 
+              <div className="fcol-md-3">
+                <div className="well legend-container">
+                  <GraphLegend
+                    items={legend_items}
+                  />
+                </div>
+              </div>
+              <div className="fcol-md-9" style = {{height: '300px'}} aria-hidden = {true}>
+                <NivoResponsiveBar
+                  data = {bar_data}
+                  indexBy = "date"
+                  colorBy = {d => colors(d.id)}
+                  keys = {label_keys}
+                  is_money = {false}
+                  margin = {{
+                    top: 15,
+                    right: 30,
+                    bottom: 40,
+                    left: 50,
+                  }}
+                />
+              </div>
             </div>
-          </div>
-          <div className="fcol-md-9" style = {{height: '300px'}} aria-hidden = {true}>
-            <NivoResponsiveBar
-              data = {bar_data}
-              indexBy = "date"
-              colorBy = {d => colors(d.id)}
-              keys = {label_keys}
-              is_money = {false}
-              margin = {{
-                top: 15,
-                right: 30,
-                bottom: 40,
-                left: 50,
-              }}
-            />
-          </div>
-        </div>;
-      }
+          );
+        }
+      })();
 
       const to_render = <div>
         <div className="medium_panel_text" style={{marginBottom: "15px"}}>

--- a/client/src/panels/panel_declarations/finances/sobj/spend_by_so_hist.js
+++ b/client/src/panels/panel_declarations/finances/sobj/spend_by_so_hist.js
@@ -128,26 +128,27 @@ export const declare_spend_by_so_hist_panel = () => declare_panel({
       const { panel_args, info } = calculations;
       const {ticks, data} = panel_args;
     
-      let graph_content;
-      if(window.is_a11y_mode){
-        graph_content = (
-          <A11YTable
-            data={
-              _.map(data, ({label, data}) => ({
-                label,
-                /* eslint-disable react/jsx-key */
-                data: data.map(amt => <Format type="compact1_written" content={amt} />),
-              }))
-            }
-            label_col_header={text_maker("so")}
-            data_col_headers={ticks} 
-          />
-        );
-      } else {
-        graph_content = (
-          <SobjLine data={data} />
-        );
-      }
+      const graph_content = (() => {
+        if(window.is_a11y_mode){
+          return(
+            <A11YTable
+              data={
+                _.map(data, ({label, data}) => ({
+                  label,
+                  /* eslint-disable react/jsx-key */
+                  data: data.map(amt => <Format type="compact1_written" content={amt} />),
+                }))
+              }
+              label_col_header={text_maker("so")}
+              data_col_headers={ticks} 
+            />
+          );
+        } else {
+          return(
+            <SobjLine data={data} />
+          );
+        }
+      })();
   
       return (
         <InfographicPanel

--- a/client/src/panels/panel_declarations/finances/sobj/spend_rev_split.js
+++ b/client/src/panels/panel_declarations/finances/sobj/spend_rev_split.js
@@ -44,8 +44,7 @@ function render({calculations, footnotes, sources}) {
 
   const graph_content = (() => {
     if (window.is_a11y_mode) {
-      return (
-        null);
+      return (null);
     } else {
       return (
         <div style = {{height: '400px'}} aria-hidden = {true}>

--- a/client/src/panels/panel_declarations/finances/sobj/spend_rev_split.js
+++ b/client/src/panels/panel_declarations/finances/sobj/spend_rev_split.js
@@ -39,30 +39,30 @@ function render({calculations, footnotes, sources}) {
     (spend_rev_value,tick_index)=>({
       title: ticks[tick_index],
       [ticks[tick_index]]: spend_rev_value,
-    }));
+    })
+  );
 
-  let graph_content;
-  if(window.is_a11y_mode){
-    //all information is contained in text
-    graph_content = null;
-  } else {
-    
-    graph_content = (
-      <div style = {{height: '400px'}} aria-hidden = {true}>
-        <NivoResponsiveBar
-          data = {spend_rev_data}
-          keys = {ticks}
-          indexBy = "title"
-          enableLabel = {true}
-          isInteractive = {false}
-          label_format = { d=><tspan y={-4}> {formats.compact1(d, {raw: true})} </tspan>}
-          colorBy = {d => d.data[d.id] < 0 ? window.infobase_color_constants.highlightColor : window.infobase_color_constants.secondaryColor}
-          enableGridX={false}
-        />
-      </div>
-    );
-      
-  }
+  const graph_content = (() => {
+    if (window.is_a11y_mode) {
+      return (
+        null);
+    } else {
+      return (
+        <div style = {{height: '400px'}} aria-hidden = {true}>
+          <NivoResponsiveBar
+            data = {spend_rev_data}
+            keys = {ticks}
+            indexBy = "title"
+            enableLabel = {true}
+            isInteractive = {false}
+            label_format = { d=><tspan y={-4}> {formats.compact1(d, {raw: true})} </tspan>}
+            colorBy = {d => d.data[d.id] < 0 ? window.infobase_color_constants.highlightColor : window.infobase_color_constants.secondaryColor}
+            enableGridX={false}
+          />
+        </div>
+      );
+    }
+  })();
 
   return (
     <StdPanel


### PR DESCRIPTION
The bar graphs were displaying in a11y mode for specifically:
level: dept, category: finance
panel: internal services (full name: Full-time employees in Internal Services, under declare_internal_services_panel)

I followed the same fixing format that I found in another file, specifically for:
level: dept, category: finance
panel: spend_rev_split (Full name: Expenditures and Revenues, under declare_spend_rev_split_panel)

Although the bar graph is now hidden, the data is not shown in a table. This is the case for a lot of other bar graphs on the page; as they are set to simply hide the data when in a11y mode. This should be fixed altogether in a future update. 

For now though, there shouldn't be any issues with graphs in a11y mode. 

fixes #506 