### PR TITLE
Fiddle with flaky email test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,11 +24,11 @@ jobs:
       - checkout:
           path: "~/InfoBase"
 
-      - run: cksum ./email_backend/** > checksums.txt
+      - run: find ./email_backend | xargs cksum > email-backend-checksums.txt
       - restore_cache:
           keys:
-            - email-backend-already-tested-{{ checksum "checksums.txt" }}
-      - run: if [[ -e "already-tested" ]]; then circleci step halt; fi
+            - email-backend-already-tested-{{ checksum "email-backend-checksums.txt" }}
+      - run: if [[ -e "this-email-backend-is-already-tested" ]]; then circleci step halt; fi
 
       - restore_cache:
           keys:
@@ -46,11 +46,11 @@ jobs:
 
       - run: (cd email_backend && npm run end_to_end_tests)
 
-      - run: touch ./already-tested
+      - run: touch ./this-email-backend-is-already-tested
       - save_cache:
           paths:
-            - ./already-tested
-          key: email-backend-already-tested-{{ checksum "checksums.txt" }}
+            - ./this-email-backend-is-already-tested
+          key: email-backend-already-tested-{{ checksum "email-backend-checksums.txt" }}
 
      # halt here if not on the true repo, expected that means this is running in an env without the GCloud env vars required for the following steps
       - run: if [[ "$CIRCLE_PROJECT_REPONAME" != "infobase" ]]; then circleci step halt; fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,13 +24,11 @@ jobs:
       - checkout:
           path: "~/InfoBase"
 
-      - run: cksum ./email-backend/src/** > src-checksums.txt
+      - run: cksum ./email_backend/** > checksums.txt
       - restore_cache:
           keys:
-            - email-backend-already-tested-{{ checksum "email_backend/package-lock.json" }}-{{ checksum "src-checksums.txt" }}
-      - run: 
-          command: |
-            [ -e "already-tested" ] && circleci step halt
+            - email-backend-already-tested-{{ checksum "checksums.txt" }}
+      - run: if [[ -e "already-tested" ]]; then circleci step halt; fi
 
       - restore_cache:
           keys:
@@ -52,7 +50,7 @@ jobs:
       - save_cache:
           paths:
             - ./already-tested
-          key: email-backend-already-tested-{{ checksum "email_backend/package-lock.json" }}-{{ checksum "src-checksums.txt" }}
+          key: email-backend-already-tested-{{ checksum "checksums.txt" }}
 
      # halt here if not on the true repo, expected that means this is running in an env without the GCloud env vars required for the following steps
       - run: if [[ "$CIRCLE_PROJECT_REPONAME" != "infobase" ]]; then circleci step halt; fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,15 @@ jobs:
     steps:
       - checkout:
           path: "~/InfoBase"
+
+      - run: cksum ./email-backend/src/** > src-checksums.txt
+      - restore_cache:
+          keys:
+            - email-backend-already-tested-{{ checksum "email_backend/package-lock.json" }}-{{ checksum "src-checksums.txt" }}
+      - run: 
+          command: |
+            [ -e "already-tested" ] && circleci step halt
+
       - restore_cache:
           keys:
             - email-backend-dependencies-{{ checksum "email_backend/package-lock.json" }}
@@ -38,6 +47,12 @@ jobs:
       - run: (cd email_backend && npm run unit_tests)
 
       - run: (cd email_backend && npm run end_to_end_tests)
+
+      - run: touch ./already-tested
+      - save_cache:
+          paths:
+            - ./already-tested
+          key: email-backend-already-tested-{{ checksum "email_backend/package-lock.json" }}-{{ checksum "src-checksums.txt" }}
 
      # halt here if not on the true repo, expected that means this is running in an env without the GCloud env vars required for the following steps
       - run: if [[ "$CIRCLE_PROJECT_REPONAME" != "infobase" ]]; then circleci step halt; fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,13 +23,6 @@ jobs:
     steps:
       - checkout:
           path: "~/InfoBase"
-
-      - run: find ./email_backend | xargs cksum > email-backend-checksums.txt
-      - restore_cache:
-          keys:
-            - email-backend-already-tested-{{ checksum "email-backend-checksums.txt" }}
-      - run: if [[ -e "this-email-backend-is-already-tested" ]]; then circleci step halt; fi
-
       - restore_cache:
           keys:
             - email-backend-dependencies-{{ checksum "email_backend/package-lock.json" }}
@@ -45,12 +38,6 @@ jobs:
       - run: (cd email_backend && npm run unit_tests)
 
       - run: (cd email_backend && npm run end_to_end_tests)
-
-      - run: touch ./this-email-backend-is-already-tested
-      - save_cache:
-          paths:
-            - ./this-email-backend-is-already-tested
-          key: email-backend-already-tested-{{ checksum "email-backend-checksums.txt" }}
 
      # halt here if not on the true repo, expected that means this is running in an env without the GCloud env vars required for the following steps
       - run: if [[ "$CIRCLE_PROJECT_REPONAME" != "infobase" ]]; then circleci step halt; fi

--- a/email_backend/src/email_backend.end-to-end-test.js
+++ b/email_backend/src/email_backend.end-to-end-test.js
@@ -30,7 +30,7 @@ _.each(
 
 const ethereal_timeout_limit = 20000;
 
-const timed_out_flag = "TIMED OUT!";
+const timed_out_flag = "TIMEDOUT";
 nodemailer.createTestAccount.mockImplementation( 
   () => promise_timeout_race(
     actual_nodemailer.createTestAccount(),

--- a/email_backend/src/email_backend.end-to-end-test.js
+++ b/email_backend/src/email_backend.end-to-end-test.js
@@ -131,6 +131,9 @@ describe("End-to-end tests for email_backend endpoints", () => {
 
       return expect(ok).toBe(200);
     },
-    ethereal_timeout_limit*3 // timeout on the async returning, shouldn't hit this anyway as the async should give up on its own after only ethereal_timeout_limit
+    // timeout on the async returning, just needs to be significantly longer than ethereal_timeout_limit. Shouldn't hit the Jest level timeout as the time-constraint in this test
+    // is communications with ethereal, which are timed out after ethereal_timeout_limit. If an ethereal_timeout_limit is hit, then this test flakes passingly (not great, but it
+    // was between that and just dropping this test altogether). Can still flake if the Jest level timeout is hit for nondeterministic system resource/event loop reasons, ah well!
+    ethereal_timeout_limit*6
   );
 });


### PR DESCRIPTION
Previous "fix" was good... up until CircleCI or Etherial degraded enough that my lazily tuned timeouts got too short.

Well, also on me, for the hackyness of all this. there were a handful of communications with Etherial I wasn't tacking timeouts on to, so there's room for me to be more careful there (in addition to just adding wiggle room to the timeouts).

~Since these timeouts are getting potentially long too, I'll probably set the email test up to only run when the email_backend src (and or package lock) actually change.~ Nah, inconsequential savings with the trade off of hiding if this, or other, email tests become flaky in the future.