### PR TITLE
Standardizing People Panels

### DIFF
--- a/client/src/panels/panel_declarations/people/employee_executive_level.js
+++ b/client/src/panels/panel_declarations/people/employee_executive_level.js
@@ -1,4 +1,5 @@
 import text from "./employee_executive_level.yaml";
+import { AverageSharePie } from './AverageSharePie.js';
 import {
   formats,
   run_template,
@@ -12,6 +13,7 @@ import {
   declare_panel,
 
   LineBarToggleGraph,
+  HeightClippedGraph,
 } from "../shared.js"; 
 
 const { text_maker, TM } = create_text_maker_component(text);
@@ -93,18 +95,28 @@ export const declare_employee_executive_level_panel = () => declare_panel({
           </Col>
           { !window.is_a11y_mode &&
             <Col size={12} isGraph>
-              <LineBarToggleGraph
-                {...{
-                  legend_title: text_maker("ex_level"),
-                  bar: true,
-                  graph_options: {
-                    y_axis: text_maker("employees"),
-                    ticks: ticks,
-                    formatter: formats.big_int_raw,
-                  },
-                  initial_graph_mode: "bar_stacked",
-                  data: panel_args,
-                }}
+              <HeightClippedGraph>
+                <LineBarToggleGraph
+                  {...{
+                    legend_title: text_maker("ex_level"),
+                    bar: true,
+                    graph_options: {
+                      y_axis: text_maker("employees"),
+                      ticks: ticks,
+                      formatter: formats.big_int_raw,
+                    },
+                    initial_graph_mode: "bar_stacked",
+                    data: panel_args,
+                  }}
+                />
+              </HeightClippedGraph>
+            </Col>
+          }
+          { !window.is_a11y_mode &&
+            <Col size={12} isGraph>
+              <AverageSharePie
+                panel_args = {panel_args}
+                label_col_header = {text_maker("ex_level")}
               />
             </Col>
           }

--- a/client/src/panels/panel_declarations/people/employee_fol.js
+++ b/client/src/panels/panel_declarations/people/employee_fol.js
@@ -112,7 +112,7 @@ export const declare_employee_fol_panel = () => declare_panel({
               />
             </Col>
           }
-          { !window.is_a11y_mode && level === "dept" &&
+          { !window.is_a11y_mode && /* level === "dept" && */
             <Col size={12} isGraph>
               <HeightClippedGraph>
                 <LineBarToggleGraph 

--- a/client/src/panels/panel_declarations/people/employee_fol.js
+++ b/client/src/panels/panel_declarations/people/employee_fol.js
@@ -112,7 +112,7 @@ export const declare_employee_fol_panel = () => declare_panel({
               />
             </Col>
           }
-          { !window.is_a11y_mode && /* level === "dept" && */
+          { !window.is_a11y_mode && 
             <Col size={12} isGraph>
               <HeightClippedGraph>
                 <LineBarToggleGraph 

--- a/client/src/panels/panel_declarations/people/employee_gender.js
+++ b/client/src/panels/panel_declarations/people/employee_gender.js
@@ -111,7 +111,7 @@ export const declare_employee_gender_panel = () => declare_panel({
               />
             </Col>
           }
-          { !window.is_a11y_mode && level === "dept" &&
+          { !window.is_a11y_mode && /* level === "dept" && */
             <Col size={12} isGraph>
               <HeightClippedGraph>
                 <LineBarToggleGraph 

--- a/client/src/panels/panel_declarations/people/employee_gender.js
+++ b/client/src/panels/panel_declarations/people/employee_gender.js
@@ -111,7 +111,7 @@ export const declare_employee_gender_panel = () => declare_panel({
               />
             </Col>
           }
-          { !window.is_a11y_mode && /* level === "dept" && */
+          { !window.is_a11y_mode && 
             <Col size={12} isGraph>
               <HeightClippedGraph>
                 <LineBarToggleGraph 

--- a/client/src/panels/panel_declarations/people/employee_type.js
+++ b/client/src/panels/panel_declarations/people/employee_type.js
@@ -98,7 +98,7 @@ export const declare_employee_type_panel = () => declare_panel({
               />
             </Col>
           }
-          { !window.is_a11y_mode && level === "dept" &&
+          { !window.is_a11y_mode && /* level === "dept" && */
             <Col size={12} isGraph>
               <HeightClippedGraph>
                 <LineBarToggleGraph 

--- a/client/src/panels/panel_declarations/people/employee_type.js
+++ b/client/src/panels/panel_declarations/people/employee_type.js
@@ -98,7 +98,7 @@ export const declare_employee_type_panel = () => declare_panel({
               />
             </Col>
           }
-          { !window.is_a11y_mode && /* level === "dept" && */
+          { !window.is_a11y_mode && 
             <Col size={12} isGraph>
               <HeightClippedGraph>
                 <LineBarToggleGraph 


### PR DESCRIPTION
All panels now display both the pie chart and the morphing graph for more information 

(people can now also see the exact numbers on the morphing graph, as they could not before only seeing the pie chart, or had to change to text only mode)

Fixes #507