### PR TITLE
Adding Hoverlabels to the waffles for colourblind; possibly changing to NivoWaffle Graph

### DIFF
--- a/client/src/charts/IconArray.js
+++ b/client/src/charts/IconArray.js
@@ -7,12 +7,12 @@ export class IconArray extends React.Component {
     } = this.props;
 
     const rendered_items = _.map(items, (item, ix) =>
-      <div
+      <div 
         key={ix}
-        title={item}//figure out passing in variable
         style={{
           flex: "0 0 auto",
         }}
+        title={(items[0].status_key)}
       >
         {render_item(item)}
       </div>

--- a/client/src/charts/IconArray.js
+++ b/client/src/charts/IconArray.js
@@ -12,7 +12,6 @@ export class IconArray extends React.Component {
         style={{
           flex: "0 0 auto",
         }}
-        title={(items[0].status_key)}
       >
         {render_item(item)}
       </div>

--- a/client/src/charts/IconArray.js
+++ b/client/src/charts/IconArray.js
@@ -9,6 +9,7 @@ export class IconArray extends React.Component {
     const rendered_items = _.map(items, (item, ix) =>
       <div
         key={ix}
+        title={item}//figure out passing in variable
         style={{
           flex: "0 0 auto",
         }}

--- a/client/src/panels/panel_declarations/results/drr_summary.js
+++ b/client/src/panels/panel_declarations/results/drr_summary.js
@@ -69,6 +69,7 @@ const MiniLegend = ({ items }) => (
             marginRight: "5px",
           }}
           className={className}
+          title={id}
         />
         <span> {label} </span>
       </div>

--- a/client/src/panels/panel_declarations/results/drr_summary.js
+++ b/client/src/panels/panel_declarations/results/drr_summary.js
@@ -19,6 +19,7 @@ import {
   GranularResultCounts,
   ordered_status_keys,
   filter_and_genericize_doc_counts,
+  result_statuses,
 } from './results_common.js';
 
 import { IconArray } from '../../../charts/IconArray.js';
@@ -69,7 +70,7 @@ const MiniLegend = ({ items }) => (
             marginRight: "5px",
           }}
           className={className}
-          title={id}
+          title={result_statuses[id].text}
         />
         <span> {label} </span>
       </div>
@@ -169,6 +170,7 @@ const StatusGrid = props => {
                   render_item={ ({status_key}) => 
                     <div 
                       className={classNames(icon_array_size_class, grid_colors[status_key])} 
+                      title={result_statuses[status_key].text}
                     />
                   }
                 />


### PR DESCRIPTION
adding labels to show when hovering over a colour - improving website use for those who are colourblind
fixes #196 
