### PR TITLE
Result flat table filter fix

### DIFF
--- a/client/src/common_text/common_lang.yaml
+++ b/client/src/common_text/common_lang.yaml
@@ -270,9 +270,6 @@ another_org_search:
 no_data:
   en: No data available for this table
   fr: Aucune donnée n'est disponible pour ce tableau
-no_data_for_filters:
-  en: No data available for the selected filters
-  fr: Aucune donnée n'est disponible pour les filtres sélectionnés
 open_data_link:
   en: Open Data Link
   fr: Lien vers les données ouvertes

--- a/client/src/common_text/common_lang.yaml
+++ b/client/src/common_text/common_lang.yaml
@@ -270,6 +270,9 @@ another_org_search:
 no_data:
   en: No data available for this table
   fr: Aucune donnée n'est disponible pour ce tableau
+no_data_for_filters:
+  en: No data available for the selected filters
+  fr: Aucune donnée n'est disponible pour les filtres sélectionnés
 open_data_link:
   en: Open Data Link
   fr: Lien vers les données ouvertes

--- a/client/src/components/DisplayTable.js
+++ b/client/src/components/DisplayTable.js
@@ -115,6 +115,8 @@ export class DisplayTable extends React.Component {
                         const sortable = _.has(sort_values, column_key);
                         const searchable = _.has(search_values, column_key);
       
+                        const current_search_input = (searchable && searches[column_key]) || null;
+
                         return (
                           <th 
                             key={column_key}
@@ -127,11 +129,12 @@ export class DisplayTable extends React.Component {
                                   desc={descending && sort_by === column_key}
                                 />
                               </div>
-                            } 
+                            }
                             { searchable &&
                               <DebouncedTextInput
                                 inputClassName={"search input-sm"}
                                 placeHolder={text_maker('filter_data')}
+                                defaultValue={current_search_input}
                                 updateCallback={ (search_value) => {
                                   const updated_searches = _.mapValues(
                                     searches,

--- a/client/src/components/DisplayTable.js
+++ b/client/src/components/DisplayTable.js
@@ -105,7 +105,7 @@ export class DisplayTable extends React.Component {
               }
             </tr>
             <tr className="table-header">
-              {
+              { rows.length > 0 &&
                 _.chain(rows)
                   .first()
                   .thru(
@@ -172,6 +172,13 @@ export class DisplayTable extends React.Component {
             )}
           </tbody>
         </table>
+        { sorted_filtered_data.length === 0 &&
+          <TM 
+            k="no_data" 
+            el="div" 
+            style={{width: "100%", textAlign: "center"}} 
+          />
+        }
       </div>
     );
   }

--- a/client/src/components/TextMaker.js
+++ b/client/src/components/TextMaker.js
@@ -10,7 +10,7 @@ const TextMaker = ({text_maker_func, text_key, el, args, style, className, templ
     {
       style,
       className,
-      dangerouslySetInnerHTML: {__html: html}
+      dangerouslySetInnerHTML: {__html: html},
     }
   );
 };

--- a/client/src/components/TextMaker.js
+++ b/client/src/components/TextMaker.js
@@ -2,17 +2,21 @@ import { trivial_text_maker } from '../models/text.js';
 
 // I think eslint is wrong here
 /* disable-eslint react/jsx-no-danger-children */
-const TextMaker = ({text_maker_func, text_key, el, args, template_str}) => {
+const TextMaker = ({text_maker_func, text_key, el, args, style, className, template_str}) => {
   const tm_func = _.isFunction(text_maker_func) ? text_maker_func : trivial_text_maker;
   const html = tm_func(text_key,_.clone(args)); //must clone args because props are immutable, text-maker will mutate obj
   return React.createElement(
     el || 'span',
-    { dangerouslySetInnerHTML: {__html: html} }
+    {
+      style,
+      className,
+      dangerouslySetInnerHTML: {__html: html}
+    }
   );
 };
 
 //shorthand for the above
-const TM = ({k, el, args, tmf}) => <TextMaker text_key={k} el={el} args={args} text_maker_func={tmf}/>;
+const TM = ({k, el, args, tmf, style, className}) => <TextMaker text_key={k} el={el} args={args} text_maker_func={tmf} style={style} className={className} />;
 
 export {
   TextMaker,

--- a/client/src/panels/panel_declarations/results/result_flat_table.js
+++ b/client/src/panels/panel_declarations/results/result_flat_table.js
@@ -192,7 +192,6 @@ class ResultsTable extends React.Component {
         </div>
       );
     }
-
   }
 }
 

--- a/client/src/panels/panel_declarations/results/result_flat_table.js
+++ b/client/src/panels/panel_declarations/results/result_flat_table.js
@@ -170,7 +170,7 @@ class ResultsTable extends React.Component {
       const filtered_indicators = _.filter(flat_indicators, ind => _.isEmpty(status_active_list) || _.includes(status_active_list,ind.indicator.status_key));
       const toggle_status_status_key = (status_key) => this.setState({status_active_list: _.toggle_list(status_active_list, status_key)});
       const clear_status_filter = () => this.setState({status_active_list: []});
-      
+
       return (
         <div>
           <div className="medium_panel_text">
@@ -184,11 +184,19 @@ class ResultsTable extends React.Component {
               onClearClick={clear_status_filter}
             />
           </div>
-          <HeightClippedGraph clipHeight={200}>
-            <div className="results-flat-table">
-              {indicator_table_from_list(filtered_indicators)}
-            </div>
-          </HeightClippedGraph>
+          {
+            filtered_indicators.length > 0 ?
+              <HeightClippedGraph clipHeight={200}>
+                <div className="results-flat-table">
+                  {indicator_table_from_list(filtered_indicators)}
+                </div>
+              </HeightClippedGraph> :
+              <TM 
+                k="no_data_for_filters" 
+                el="div" 
+                style={{width: "100%", textAlign: "center"}} 
+              />
+          }
         </div>
       );
     }

--- a/client/src/panels/panel_declarations/results/result_flat_table.js
+++ b/client/src/panels/panel_declarations/results/result_flat_table.js
@@ -184,19 +184,11 @@ class ResultsTable extends React.Component {
               onClearClick={clear_status_filter}
             />
           </div>
-          {
-            filtered_indicators.length > 0 ?
-              <HeightClippedGraph clipHeight={200}>
-                <div className="results-flat-table">
-                  {indicator_table_from_list(filtered_indicators)}
-                </div>
-              </HeightClippedGraph> :
-              <TM 
-                k="no_data_for_filters" 
-                el="div" 
-                style={{width: "100%", textAlign: "center"}} 
-              />
-          }
+          <HeightClippedGraph clipHeight={200}>
+            <div className="results-flat-table">
+              {indicator_table_from_list(filtered_indicators)}
+            </div>
+          </HeightClippedGraph>
         </div>
       );
     }


### PR DESCRIPTION
Had an error throwing in prod when the status filter was used to select any combination with 0 rows of data.

Updated `DisplayTable` to not crash when passed empty data. Also add some display tweaks for that case and make sure the in-table filter inputs stay in-sync with the component state.

Side note, added `style` and `className` prop pass-through on `TextMaker`/`TM` components, should prove handy (probably lots of places where we had to hack around the lack of these options, oops).