### PR TITLE
Results status summary donut

### DIFF
--- a/client/src/panels/panel_declarations/results/drr_summary.js
+++ b/client/src/panels/panel_declarations/results/drr_summary.js
@@ -12,6 +12,9 @@ import {
   Results,
 
   declare_panel,
+
+  NivoResponsivePie,
+
 } from "../shared.js";
 import { 
   row_to_drr_status_counts,
@@ -19,11 +22,12 @@ import {
   GranularResultCounts,
   ordered_status_keys,
   filter_and_genericize_doc_counts,
+  result_statuses,
 } from './results_common.js';
 
 import { IconArray } from '../../../charts/IconArray.js';
 
-const { A11YTable } = declarative_charts;
+const { A11YTable, GraphLegend } = declarative_charts;
 const { result_simple_statuses } = businessConstants;
 const { current_drr_key, result_docs } = Results;
 
@@ -36,6 +40,15 @@ const grid_colors = {
   not_available: "results-icon-array-na",
   future: "results-icon-array-neutral",
 };
+
+const result_color_scale = d3.scaleOrdinal()
+  .domain(["met","not_met","not_available","future"])
+  .range([
+    window.infobase_color_constants.successDarkColor,
+    window.infobase_color_constants.failDarkColor,
+    window.infobase_color_constants.warnDarkColor,
+    window.infobase_color_constants.tertiaryColor,
+  ]);
 
 const icon_order = _.chain(ordered_status_keys)
   .map( (status_key, ix) => [status_key, ix*5] )
@@ -180,6 +193,88 @@ const StatusGrid = props => {
 };
 
 
+
+class PercentageViz extends React.Component {
+  constructor(props){
+    super(props);
+    const { counts } = this.props;
+
+    const all_ids = _.keys(counts);
+
+    this.state = {
+      selected: _.filter(all_ids, id => id !== "future"), // default to no future
+    };
+  }
+
+  render(){
+    const { counts } = this.props;
+    const { selected } = this.state;
+
+    const data = _.chain(counts)
+      .toPairs()
+      .map(pair => ({label: result_statuses[pair[0]].text, value: pair[1], id: pair[0]}))
+      .value();
+    
+
+    const graph_data = _.filter(data, d=>_.includes(selected,d.id));
+    const graph_total = _.sumBy(graph_data, 'value');
+
+    const new_summary_text_args = {
+      drr_total: graph_total,
+      drr_indicators_met: _.includes(selected, 'met') && counts.met,
+      drr_indicators_not_met: _.includes(selected, 'not_met') && counts.not_met,
+      drr_indicators_not_available: _.includes(selected, 'not_available') && counts.not_available,
+      drr_indicators_future: _.includes(selected, 'future') && counts.future,
+    };
+
+    return (
+      <Fragment>
+        <div className="frow">
+          <div className="fcol-md-6 fcol-xs-6" >
+            <div>
+              {text_maker("graph_legend_instructions")}
+            </div>
+            <div className="centerer">
+              <div className="legend-container">
+                <GraphLegend
+                  items={_.chain(data)
+                    .map( ({ label, id }) => ({
+                      label: label,
+                      active: _.includes(selected, id),
+                      id,
+                      color: result_color_scale(id),
+                    }))
+                    .value()
+                  }
+                  onClick={id => {!(selected.length === 1 && selected.includes(id)) &&
+                    this.setState({
+                      selected: _.toggle_list(selected, id),
+                    });
+                  }}
+                />
+              </div>
+            </div>
+          </div>
+          <div className="fcol-md-6 fcol-xs-6 medium_panel_text" >
+            <TM
+              k="new_drr_summary_text_summary"
+              args={new_summary_text_args} 
+            />
+          </div>
+        </div>
+        <div style={{height: '400px'}} aria-hidden = {true}>
+          <NivoResponsivePie
+            data = {graph_data}
+            colorBy = {obj=>result_color_scale(obj.id)}
+            total = {graph_total}
+            height = '400px'
+          />
+        </div>
+      </Fragment>
+    );
+  };
+};
+
 export const DrrSummary = ({ subject, counts, verbose_counts, is_gov, num_depts }) => {
   const current_drr_counts_with_generic_keys = filter_and_genericize_doc_counts(verbose_counts, current_drr_key);
 
@@ -202,16 +297,17 @@ export const DrrSummary = ({ subject, counts, verbose_counts, is_gov, num_depts 
       </div>
     </div>
     <div className="frow middle-xs between-md" style={{marginBottom: "30px"}} >
-      { summary_text_args[`${current_drr_key}_past_total`] !== 0 &&
-        <div className="fcol-md-6 fcol-xs-12 medium_panel_text" >
-          <TM
-            k="drr_summary_text_summary_left"
-            args={summary_text_args} 
-          />
+      <div className={"fcol-md-12 fcol-xs-12"} >
+        <div style={{padding: "30px"}}>
+          <StatusGrid {...counts} />
         </div>
-      }
-      <div className={`fcol-md-${ summary_text_args[`${current_drr_key}_past_total`] !== 0 ? 6 : 12 } fcol-xs-12 medium_panel_text`} >
-        <StatusGrid {...counts} />
+        <div style={{padding: "10px"}}>
+          <p>Detailed explanation of result statuses here</p>
+          <p>With some examples</p>
+          <p>Detailed explanation of result statuses here</p>
+          <p>With some examples</p>
+        </div>
+        <PercentageViz summary_text_args={summary_text_args} counts={counts} />
       </div>
     </div>
   </Fragment>;

--- a/client/src/panels/panel_declarations/results/drr_summary.js
+++ b/client/src/panels/panel_declarations/results/drr_summary.js
@@ -163,9 +163,6 @@ const StatusGrid = props => {
 
   return (
     <div>
-      <div className="h3">
-        <TM k="results_icon_array_title" args={{year: current_drr_year}} />
-      </div>
       <div>
         <MiniLegend items={legend_data} />
         <div>
@@ -230,45 +227,52 @@ class PercentageViz extends React.Component {
     return (
       <Fragment>
         <div className="frow">
-          <div className="fcol-md-6 fcol-xs-6" >
-            <div>
-              {text_maker("graph_legend_instructions")}
-            </div>
-            <div className="centerer">
-              <div className="legend-container">
-                <GraphLegend
-                  items={_.chain(data)
-                    .map( ({ label, id }) => ({
-                      label: label,
-                      active: _.includes(selected, id),
-                      id,
-                      color: result_color_scale(id),
-                    }))
-                    .value()
-                  }
-                  onClick={id => {!(selected.length === 1 && selected.includes(id)) &&
-                    this.setState({
-                      selected: _.toggle_list(selected, id),
-                    });
-                  }}
-                />
-              </div>
-            </div>
-          </div>
-          <div className="fcol-md-6 fcol-xs-6 medium_panel_text" >
+          <div className="fcol-md-4 fcol-xs-4 medium_panel_text" >
             <TM
               k="new_drr_summary_text_summary"
               args={new_summary_text_args} 
             />
           </div>
-        </div>
-        <div style={{height: '400px'}} aria-hidden = {true}>
-          <NivoResponsivePie
-            data = {graph_data}
-            colorBy = {obj=>result_color_scale(obj.id)}
-            total = {graph_total}
-            height = '400px'
-          />
+          <div className="fcol-md-4 fcol-xs-4 medium_panel_text" >
+            <div style={{height: '280px'}} aria-hidden = {true}>
+              <NivoResponsivePie
+                data = {graph_data}
+                colorBy = {obj=>result_color_scale(obj.id)}
+                total = {graph_total}
+                height = '280px'
+                is_money = {false}
+                margin = {{
+                  top: 30,
+                  right: 30,
+                  bottom: 30,
+                  left: 30,
+                }}
+              />
+            </div>
+          </div>
+          <div className="fcol-md-4 fcol-xs-4" >
+            <div className="medium_panel_text">
+              {text_maker("graph_legend_instructions")}
+            </div>
+            <div className="legend-container">
+              <GraphLegend
+                items={_.chain(data)
+                  .map( ({ label, id }) => ({
+                    label: label,
+                    active: _.includes(selected, id),
+                    id,
+                    color: result_color_scale(id),
+                  }))
+                  .value()
+                }
+                onClick={id => {!(selected.length === 1 && selected.includes(id)) &&
+                  this.setState({
+                    selected: _.toggle_list(selected, id),
+                  });
+                }}
+              />
+            </div>
+          </div>
         </div>
       </Fragment>
     );
@@ -290,23 +294,23 @@ export const DrrSummary = ({ subject, counts, verbose_counts, is_gov, num_depts 
   return <Fragment>
     <div className="frow middle-xs between-md">
       <div className="fcol-md-12 fcol-xs-12 medium_panel_text" >
-        <TM 
-          k="drr_summary_text_intro"
-          args={summary_text_args} 
-        />
+        <TM k="drr_summary_text_intro" args={summary_text_args} />
+      </div>
+    </div>
+    <div className="frow middle-xs between-md">
+      <div className="fcol-md-7 fcol-xs-7 medium_panel_text" >
+        <div style={{padding: "10px"}}>
+          <TM k="result_status_explanation"/>
+        </div>
+      </div>
+      <div className="fcol-md-5 fcol-xs-5" >
+        <div style={{padding: "30px"}}>
+          <StatusGrid {...counts} />
+        </div>
       </div>
     </div>
     <div className="frow middle-xs between-md" style={{marginBottom: "30px"}} >
       <div className={"fcol-md-12 fcol-xs-12"} >
-        <div style={{padding: "30px"}}>
-          <StatusGrid {...counts} />
-        </div>
-        <div style={{padding: "10px"}}>
-          <p>Detailed explanation of result statuses here</p>
-          <p>With some examples</p>
-          <p>Detailed explanation of result statuses here</p>
-          <p>With some examples</p>
-        </div>
         <PercentageViz summary_text_args={summary_text_args} counts={counts} />
       </div>
     </div>

--- a/client/src/panels/panel_declarations/results/drr_summary_text.yaml
+++ b/client/src/panels/panel_declarations/results/drr_summary_text.yaml
@@ -71,8 +71,8 @@ result_status_explanation:
     The result status depends on how the target was defined, e.g. a minimum target requires a measured outcome (actual result) greater than the target.
     
     * If the measured outcome satisfies the target, the indicator is assigned a status of {{gl_tt "Target met" "RESULTS_MET"}}.
-    * If the measured outcome is outside the range or standard established by the the target, the indicator's status is {{gl_tt "Target not met" "RESULTS_NOT_MET"}}.
+    * If the measured outcome is outside the range or standard established by the target, the indicator's status is {{gl_tt "Target not met" "RESULTS_NOT_MET"}}.
     * Indicators for which no target was set, or for which data was unavailable, are assigned the status {{gl_tt "No result available" "RESULTS_NOT_AVAILABLE"}}.
-    * If the date to achieve the target is after the end of the fiscal year (March 31), or if there is no date to achieve the target the status is {{gl_tt "Result to be achieved in the future" "RESULTS_ONGOING"}}.
+    * If the date to achieve the target is after the end of the fiscal year (March 31), or if there is no date to achieve the target, the status is {{gl_tt "Result to be achieved in the future" "RESULTS_ONGOING"}}.
   fr: |
     TODO

--- a/client/src/panels/panel_declarations/results/drr_summary_text.yaml
+++ b/client/src/panels/panel_declarations/results/drr_summary_text.yaml
@@ -46,6 +46,24 @@ drr_summary_text_summary_left:
       {{#if drr_indicators_not_available}}* **{{fmt_big_int drr_indicators_not_available}}** (**{{fmt_percentage1 (divide drr_indicators_not_available drr_past_total)}}**) {{gl_tt "n’ont pas de résultat disponible" "RESULTS_NOT_AVAILABLE"}}{{/if}}
     {{/if}}
 
+
+new_drr_summary_text_summary:
+  transform: [handlebars,markdown]
+  en: |
+    Of the **{{fmt_big_int drr_total}}** indicators reported:
+      {{#if drr_indicators_met}}* **{{fmt_big_int drr_indicators_met}}** (**{{fmt_percentage1 (divide drr_indicators_met drr_total)}}**) {{gl_tt "met" "RESULTS_MET"}} their target{{/if}}
+      {{#if drr_indicators_not_met}}* **{{fmt_big_int drr_indicators_not_met}}** (**{{fmt_percentage1 (divide drr_indicators_not_met drr_total)}}**) did {{gl_tt "not meet" "RESULTS_NOT_MET"}} their target{{/if}}
+      {{#if drr_indicators_not_available}}* **{{fmt_big_int drr_indicators_not_available}}** (**{{fmt_percentage1 (divide drr_indicators_not_available drr_total)}}**) have {{gl_tt "no result available" "RESULTS_NOT_AVAILABLE"}}{{/if}}
+      {{#if drr_indicators_future}}* **{{fmt_big_int drr_indicators_future}}** (**{{fmt_percentage1 (divide drr_indicators_future drr_total)}}**) are {{gl_tt "to be achieved in the future" "RESULTS_ONGOING"}}{{/if}}
+  fr: |
+    {{#if drr_total}}
+    TODO TODO TODO needs to match the english text
+    De ces **{{fmt_big_int drr_past_total}}** indicateurs qui devaient atteindre leur cible au plus tard le 31 mars {{target_year}}:
+      {{#if drr_indicators_met}}* **{{fmt_big_int drr_indicators_met}}** (**{{fmt_percentage1 (divide drr_indicators_met drr_past_total)}}**) {{gl_tt "ont atteint" "RESULTS_MET"}} leur cible{{/if}}
+      {{#if drr_indicators_not_met}}* **{{fmt_big_int drr_indicators_not_met}}** (**{{fmt_percentage1 (divide drr_indicators_not_met drr_past_total)}}**) {{gl_tt "n’ont pas atteint" "RESULTS_NOT_MET"}} leur cible{{/if}}
+      {{#if drr_indicators_not_available}}* **{{fmt_big_int drr_indicators_not_available}}** (**{{fmt_percentage1 (divide drr_indicators_not_available drr_past_total)}}**) {{gl_tt "n’ont pas de résultat disponible" "RESULTS_NOT_AVAILABLE"}}{{/if}}
+    {{/if}}
+
 gov_drr_summary_org_table_text:
   transform: [handlebars,markdown]
   en: |
@@ -62,3 +80,9 @@ results_icon_array_title:
     {{year}} Performance Indicators
   fr: |
     Indicateurs de performance {{year}}
+
+graph_legend_instructions:
+  en: |
+    Click to change which results are counted in the full set:
+  fr: |
+    TODO

--- a/client/src/panels/panel_declarations/results/drr_summary_text.yaml
+++ b/client/src/panels/panel_declarations/results/drr_summary_text.yaml
@@ -15,37 +15,15 @@ drr_summary_text_intro:
     {{else}}
       In **{{year}}**, {{subj_name subject}} sought to achieve **{{fmt_big_int drr_results}}** results.
     {{/if}}
-    Progress towards meeting these results was measured using **{{fmt_big_int drr_total}}** {{gl_tt "indicators" "IND_RESULT"}}, {{#if drr_past_total}} **{{fmt_big_int drr_past_total}}**
-    of which were seeking to achieve their target **by March 31, {{target_year}}**{{#if drr_future_total}} and{{else}}.{{/if}}
-    {{/if}}{{#if drr_future_total}} **{{fmt_big_int drr_future_total}}** of which are seeking to achieve their target **after March 31, {{target_year}}**
-    or **on an ongoing basis**.{{/if}}
+    Progress towards meeting these results was measured using **{{fmt_big_int drr_total}}** indicators, and a {{gl_tt "Result Status" "RESULTS_STATUS"}} was assigned to each indicator
+    based on the measured outcome of the indicator's target.
   fr: |
     {{#if is_gov}}
       En **{{year}}**, **{{num_depts}}** organisations ont cherché à obtenir **{{fmt_big_int drr_results}}** résultats.
     {{else}}
       En **{{year}}**, {{subj_name subject}} a cherché à atteindre **{{fmt_big_int drr_results}}** résultats.
     {{/if}}
-    Les progrès accomplis dans l'atteinte de ces résultats ont été mesurés à l’aide de **{{fmt_big_int drr_total}}** {{gl_tt "indicateurs" "IND_RESULT"}}, {{#if drr_past_total}} dont
-    **{{fmt_big_int drr_past_total}}** avaient des cibles à **atteindre au plus tard le 31 mars {{target_year}}**{{#if drr_future_total}} et{{else}}.{{/if}}
-    {{/if}}{{#if drr_future_total}} dont **{{fmt_big_int drr_future_total}}** visaient à atteindre leurs cibles **continuellement** ou **après mars 31
-    {{target_year}}**.{{/if}}
-drr_summary_text_summary_left:
-  transform: [handlebars,markdown]
-  en: |
-    {{#if drr_past_total}}
-    Of the **{{fmt_big_int drr_past_total}}** indicators that sought to achieve their target by March 31, {{target_year}}:
-      {{#if drr_indicators_met}}* **{{fmt_big_int drr_indicators_met}}** (**{{fmt_percentage1 (divide drr_indicators_met drr_past_total)}}**) {{gl_tt "met" "RESULTS_MET"}} their target{{/if}}
-      {{#if drr_indicators_not_met}}* **{{fmt_big_int drr_indicators_not_met}}** (**{{fmt_percentage1 (divide drr_indicators_not_met drr_past_total)}}**) did {{gl_tt "not meet" "RESULTS_NOT_MET"}} their target{{/if}}
-      {{#if drr_indicators_not_available}}* **{{fmt_big_int drr_indicators_not_available}}** (**{{fmt_percentage1 (divide drr_indicators_not_available drr_past_total)}}**) have {{gl_tt "no result available" "RESULTS_NOT_AVAILABLE"}}{{/if}}
-    {{/if}}
-  fr: |
-    {{#if drr_past_total}}
-    De ces **{{fmt_big_int drr_past_total}}** indicateurs qui devaient atteindre leur cible au plus tard le 31 mars {{target_year}}:
-      {{#if drr_indicators_met}}* **{{fmt_big_int drr_indicators_met}}** (**{{fmt_percentage1 (divide drr_indicators_met drr_past_total)}}**) {{gl_tt "ont atteint" "RESULTS_MET"}} leur cible{{/if}}
-      {{#if drr_indicators_not_met}}* **{{fmt_big_int drr_indicators_not_met}}** (**{{fmt_percentage1 (divide drr_indicators_not_met drr_past_total)}}**) {{gl_tt "n’ont pas atteint" "RESULTS_NOT_MET"}} leur cible{{/if}}
-      {{#if drr_indicators_not_available}}* **{{fmt_big_int drr_indicators_not_available}}** (**{{fmt_percentage1 (divide drr_indicators_not_available drr_past_total)}}**) {{gl_tt "n’ont pas de résultat disponible" "RESULTS_NOT_AVAILABLE"}}{{/if}}
-    {{/if}}
-
+    TODO: need french translation for this bit
 
 new_drr_summary_text_summary:
   transform: [handlebars,markdown]
@@ -84,5 +62,17 @@ results_icon_array_title:
 graph_legend_instructions:
   en: |
     Click to change which results are counted in the full set:
+  fr: |
+    TODO
+
+result_status_explanation:
+  transform: [handlebars,markdown]
+  en: |
+    The result status depends on how the target was defined, e.g. a minimum target requires a measured outcome (actual result) greater than the target.
+    
+    * If the measured outcome satisfies the target, the indicator is assigned a status of {{gl_tt "Target met" "RESULTS_MET"}}.
+    * If the measured outcome is outside the range or standard established by the the target, the indicator's status is {{gl_tt "Target not met" "RESULTS_NOT_MET"}}.
+    * Indicators for which no target was set, or for which data was unavailable, are assigned the status {{gl_tt "No result available" "RESULTS_NOT_AVAILABLE"}}.
+    * If the date to achieve the target is after the end of the fiscal year (March 31), or if there is no date to achieve the target the status is {{gl_tt "Result to be achieved in the future" "RESULTS_ONGOING"}}.
   fr: |
     TODO

--- a/client/src/panels/panel_declarations/results/results_intro_text.yaml
+++ b/client/src/panels/panel_declarations/results/results_intro_text.yaml
@@ -65,6 +65,7 @@ drr_summary_text:
       à l'aide de **{{fmt_big_int drr_indicators}}** indicateurs, et un état du résultat a été associé à chaque indicateur
       selon la mesure du résultat prévu pour la cible de l'indicateur.
     {{/if}}
+    TODO: need french translation for this bit
 
 
 reports_links_text:


### PR DESCRIPTION
One possibility for improving the results summary.

Adds a donut plot to the main DRR summary, controllable with a graph legend in the usable way, that lets a user decide what the denominator should be for calculating result status %s.

Also added space for more text if we want to increase the amount of explanatory text.