### PR TITLE
Be explicit about files to include when deploying GCloud functions

### DIFF
--- a/email_backend/.gcloudignore
+++ b/email_backend/.gcloudignore
@@ -1,23 +1,9 @@
-.gcloudignore
-.git
-.gitignore
+# ignore everything
+/[!.]*
+/.?*
 
-node_modules
-*.DS_Store
-*.swp
-*.swo
-.vscode/
-npm-debug*
-*credentials*.json
-
-coverage
-coverage/
-src
-src/
-deploy_scripts
-deploy_scripts/
-
-.bablerc
-.eslintrc.json
-jest.config.js
-README.md
+# explicitly include just what's actually required in the cloud function
+!/package.json
+!/package-lock.json
+!/transpiled_build/**
+!/templates/**

--- a/server/.gcloudignore
+++ b/server/.gcloudignore
@@ -6,28 +6,12 @@
 # For more information, run:
 #   $ gcloud topic gcloudignore
 #
-.gcloudignore
-.git
-.gitignore
 
-node_modules
-*.DS_Store
-*.swp
-*.swo
-.vscode/
-npm-debug*
-*credentials*.json
+# ignore everything
+/[!.]*
+/.?*
 
-coverage
-coverage/
-src
-src/
-deploy_scripts
-deploy_scripts/
-
-mongo
-
-.bablerc
-.eslintrc.json
-jest.config.js
-README.md
+# explicitly include just what's actually required in the cloud function
+!/package.json
+!/package-lock.json
+!/transpiled_build/**

--- a/server/.gcloudignore
+++ b/server/.gcloudignore
@@ -1,12 +1,3 @@
-# This file specifies files that are *not* uploaded to Google Cloud Platform
-# using gcloud. It follows the same syntax as .gitignore, with the addition of
-# "#!include" directives (which insert the entries of the given .gitignore-style
-# file at that point).
-#
-# For more information, run:
-#   $ gcloud topic gcloudignore
-#
-
 # ignore everything
 /[!.]*
 /.?*


### PR DESCRIPTION
GCloud function deploys are pointed at a directory and then deploy everything inside of it, unless that directory contains a `.gcloudingore` in its root which can explicitly **exclude** files.

Didn't like that, was too easy to add a new file to a project root and accidentally include it in all deploys, and was hard to retroactively detect when this had happened.

Instead, I've set up our `.gcloudignore` files to ignore EVERYTHING, and then explicitly **include** just the files actually required in a deploy. This way, if someone adds a new file that's actually required and forgets to include it, things should at least fail-fast.