### PR TITLE
Results summary (ibcolors version)

### DIFF
--- a/client/src/panels/panel_declarations/results/drr_summary.js
+++ b/client/src/panels/panel_declarations/results/drr_summary.js
@@ -210,13 +210,15 @@ class PercentageViz extends React.Component {
       })
     );
     
+    const all_data_total = _.sumBy(all_data, 'value');
 
     const graph_data = _.filter(all_data, d=>_.includes(selected,d.id));
     const graph_total = _.sumBy(graph_data, 'value');
 
     const new_summary_text_args = {
       year: current_drr_year,
-      drr_total: graph_total,
+      drr_subset: graph_total,
+      drr_total: all_data_total,
       drr_indicators_met: _.includes(selected, 'met') && counts.met,
       drr_indicators_not_met: _.includes(selected, 'not_met') && counts.not_met,
       drr_indicators_not_available: _.includes(selected, 'not_available') && counts.not_available,
@@ -226,29 +228,6 @@ class PercentageViz extends React.Component {
     return (
       <Fragment>
         <div className="frow">
-          <div className="fcol-md-4 fcol-xs-4 medium_panel_text" >
-            <TM
-              k="new_drr_summary_text_summary"
-              args={new_summary_text_args} 
-            />
-          </div>
-          <div className="fcol-md-4 fcol-xs-4 medium_panel_text" >
-            <div style={{height: '280px'}} aria-hidden = {true}>
-              <NivoResponsivePie
-                data = {graph_data}
-                colorBy = {obj=>result_color_scale(obj.id)}
-                total = {graph_total}
-                height = '280px'
-                is_money = {false}
-                margin = {{
-                  top: 30,
-                  right: 30,
-                  bottom: 30,
-                  left: 30,
-                }}
-              />
-            </div>
-          </div>
           <div className="fcol-md-4 fcol-xs-4" >
             <div className="medium_panel_text">
               {text_maker("graph_legend_instructions")}
@@ -271,6 +250,29 @@ class PercentageViz extends React.Component {
                 }}
               />
             </div>
+          </div>
+          <div className="fcol-md-4 fcol-xs-4 medium_panel_text" >
+            <div style={{height: '280px'}} aria-hidden = {true}>
+              <NivoResponsivePie
+                data = {graph_data}
+                colorBy = {obj=>result_color_scale(obj.id)}
+                total = {graph_total}
+                height = '280px'
+                is_money = {false}
+                margin = {{
+                  top: 30,
+                  right: 30,
+                  bottom: 30,
+                  left: 30,
+                }}
+              />
+            </div>
+          </div>
+          <div className="fcol-md-4 fcol-xs-4 medium_panel_text" >
+            <TM
+              k="new_drr_summary_text_summary"
+              args={new_summary_text_args} 
+            />
           </div>
         </div>
       </Fragment>

--- a/client/src/panels/panel_declarations/results/drr_summary.js
+++ b/client/src/panels/panel_declarations/results/drr_summary.js
@@ -204,7 +204,7 @@ class PercentageViz extends React.Component {
     const all_data = _.map(
       counts,
       (value, key) => ({
-        label: result_statuses[key].text,
+        name: result_statuses[key].text,
         id: key,
         value,
       })
@@ -213,7 +213,6 @@ class PercentageViz extends React.Component {
 
     const graph_data = _.filter(all_data, d=>_.includes(selected,d.id));
     const graph_total = _.sumBy(graph_data, 'value');
-
 
     const new_summary_text_args = {
       year: current_drr_year,
@@ -257,8 +256,8 @@ class PercentageViz extends React.Component {
             <div className="legend-container">
               <GraphLegend
                 items={_.chain(all_data)
-                  .map( ({ label, id }) => ({
-                    label: label,
+                  .map( ({ name, id }) => ({
+                    label: name,
                     active: _.includes(selected, id),
                     id,
                     color: result_color_scale(id),

--- a/client/src/panels/panel_declarations/results/drr_summary.js
+++ b/client/src/panels/panel_declarations/results/drr_summary.js
@@ -164,9 +164,6 @@ const StatusGrid = props => {
 
   return (
     <div>
-      <div className="h3">
-        <TM k="results_icon_array_title" args={{year: current_drr_year}} />
-      </div>
       <div>
         <MiniLegend items={legend_data} />
         <div>
@@ -232,45 +229,52 @@ class PercentageViz extends React.Component {
     return (
       <Fragment>
         <div className="frow">
-          <div className="fcol-md-6 fcol-xs-6" >
-            <div>
-              {text_maker("graph_legend_instructions")}
-            </div>
-            <div className="centerer">
-              <div className="legend-container">
-                <GraphLegend
-                  items={_.chain(data)
-                    .map( ({ label, id }) => ({
-                      label: label,
-                      active: _.includes(selected, id),
-                      id,
-                      color: result_color_scale(id),
-                    }))
-                    .value()
-                  }
-                  onClick={id => {!(selected.length === 1 && selected.includes(id)) &&
-                    this.setState({
-                      selected: _.toggle_list(selected, id),
-                    });
-                  }}
-                />
-              </div>
-            </div>
-          </div>
-          <div className="fcol-md-6 fcol-xs-6 medium_panel_text" >
+          <div className="fcol-md-4 fcol-xs-4 medium_panel_text" >
             <TM
               k="new_drr_summary_text_summary"
               args={new_summary_text_args} 
             />
           </div>
-        </div>
-        <div style={{height: '400px'}} aria-hidden = {true}>
-          <NivoResponsivePie
-            data = {graph_data}
-            colorBy = {obj=>result_color_scale(obj.id)}
-            total = {graph_total}
-            height = '400px'
-          />
+          <div className="fcol-md-4 fcol-xs-4 medium_panel_text" >
+            <div style={{height: '280px'}} aria-hidden = {true}>
+              <NivoResponsivePie
+                data = {graph_data}
+                colorBy = {obj=>result_color_scale(obj.id)}
+                total = {graph_total}
+                height = '280px'
+                is_money = {false}
+                margin = {{
+                  top: 30,
+                  right: 30,
+                  bottom: 30,
+                  left: 30,
+                }}
+              />
+            </div>
+          </div>
+          <div className="fcol-md-4 fcol-xs-4" >
+            <div className="medium_panel_text">
+              {text_maker("graph_legend_instructions")}
+            </div>
+            <div className="legend-container">
+              <GraphLegend
+                items={_.chain(data)
+                  .map( ({ label, id }) => ({
+                    label: label,
+                    active: _.includes(selected, id),
+                    id,
+                    color: result_color_scale(id),
+                  }))
+                  .value()
+                }
+                onClick={id => {!(selected.length === 1 && selected.includes(id)) &&
+                  this.setState({
+                    selected: _.toggle_list(selected, id),
+                  });
+                }}
+              />
+            </div>
+          </div>
         </div>
       </Fragment>
     );
@@ -292,23 +296,23 @@ export const DrrSummary = ({ subject, counts, verbose_counts, is_gov, num_depts 
   return <Fragment>
     <div className="frow middle-xs between-md">
       <div className="fcol-md-12 fcol-xs-12 medium_panel_text" >
-        <TM 
-          k="drr_summary_text_intro"
-          args={summary_text_args} 
-        />
+        <TM k="drr_summary_text_intro" args={summary_text_args} />
+      </div>
+    </div>
+    <div className="frow middle-xs between-md">
+      <div className="fcol-md-7 fcol-xs-7 medium_panel_text" >
+        <div style={{padding: "10px"}}>
+          <TM k="result_status_explanation"/>
+        </div>
+      </div>
+      <div className="fcol-md-5 fcol-xs-5" >
+        <div style={{padding: "30px"}}>
+          <StatusGrid {...counts} />
+        </div>
       </div>
     </div>
     <div className="frow middle-xs between-md" style={{marginBottom: "30px"}} >
       <div className={"fcol-md-12 fcol-xs-12"} >
-        <div style={{padding: "30px"}}>
-          <StatusGrid {...counts} />
-        </div>
-        <div style={{padding: "10px"}}>
-          <p>Detailed explanation of result statuses here</p>
-          <p>With some examples</p>
-          <p>Detailed explanation of result statuses here</p>
-          <p>With some examples</p>
-        </div>
         <PercentageViz summary_text_args={summary_text_args} counts={counts} />
       </div>
     </div>

--- a/client/src/panels/panel_declarations/results/drr_summary.js
+++ b/client/src/panels/panel_declarations/results/drr_summary.js
@@ -214,6 +214,7 @@ class PercentageViz extends React.Component {
     const graph_data = _.filter(all_data, d=>_.includes(selected,d.id));
     const graph_total = _.sumBy(graph_data, 'value');
 
+
     const new_summary_text_args = {
       year: current_drr_year,
       drr_total: graph_total,
@@ -301,12 +302,14 @@ export const DrrSummary = ({ subject, counts, verbose_counts, is_gov, num_depts 
         <div style={{padding: "10px"}}>
           <TM k="result_status_explanation"/>
           <table>
-            {_.map( ordered_status_keys, status => (
-              <tr>
-                <td style={{padding: "10px"}}>{large_status_icons[status]}</td>
-                <td><TM k={`result_status_explanation_${status}`}/></td>
-              </tr>
-            ) )}
+            <tbody>
+              {_.map( ordered_status_keys, status => (
+                <tr key={status}>
+                  <td style={{padding: "10px"}}>{large_status_icons[status]}</td>
+                  <td><TM k={`result_status_explanation_${status}`}/></td>
+                </tr>
+              ) )}
+            </tbody>
           </table>
         </div>
       </div>

--- a/client/src/panels/panel_declarations/results/drr_summary.js
+++ b/client/src/panels/panel_declarations/results/drr_summary.js
@@ -215,6 +215,7 @@ class PercentageViz extends React.Component {
     const graph_total = _.sumBy(graph_data, 'value');
 
     const new_summary_text_args = {
+      year: current_drr_year,
       drr_total: graph_total,
       drr_indicators_met: _.includes(selected, 'met') && counts.met,
       drr_indicators_not_met: _.includes(selected, 'not_met') && counts.not_met,

--- a/client/src/panels/panel_declarations/results/drr_summary.js
+++ b/client/src/panels/panel_declarations/results/drr_summary.js
@@ -41,14 +41,7 @@ const grid_colors = {
   future: "results-icon-array-neutral",
 };
 
-const result_color_scale = d3.scaleOrdinal()
-  .domain(["met","not_met","not_available","future"])
-  .range([
-    window.infobase_color_constants.successDarkColor,
-    window.infobase_color_constants.failDarkColor,
-    window.infobase_color_constants.warnDarkColor,
-    window.infobase_color_constants.tertiaryColor,
-  ]);
+const result_color_scale = window.infobase_colors(); // NOTE: this is not going to guarantee that all results data (plots, grid, icons) will have the same colour scale, I'm just hacking it for now
 
 const icon_order = _.chain(ordered_status_keys)
   .map( (status_key, ix) => [status_key, ix*5] )

--- a/client/src/panels/panel_declarations/results/drr_summary.js
+++ b/client/src/panels/panel_declarations/results/drr_summary.js
@@ -200,13 +200,17 @@ class PercentageViz extends React.Component {
     const { counts } = this.props;
     const { selected } = this.state;
 
-    const data = _.chain(counts)
-      .toPairs()
-      .map(pair => ({label: result_statuses[pair[0]].text, value: pair[1], id: pair[0]}))
-      .value();
+    const all_data = _.map(
+      counts,
+      (value, key) => ({
+        label: result_statuses[key].text,
+        id: key,
+        value,
+      })
+    );
     
 
-    const graph_data = _.filter(data, d=>_.includes(selected,d.id));
+    const graph_data = _.filter(all_data, d=>_.includes(selected,d.id));
     const graph_total = _.sumBy(graph_data, 'value');
 
     const new_summary_text_args = {
@@ -249,7 +253,7 @@ class PercentageViz extends React.Component {
             </div>
             <div className="legend-container">
               <GraphLegend
-                items={_.chain(data)
+                items={_.chain(all_data)
                   .map( ({ label, id }) => ({
                     label: label,
                     active: _.includes(selected, id),

--- a/client/src/panels/panel_declarations/results/drr_summary.js
+++ b/client/src/panels/panel_declarations/results/drr_summary.js
@@ -23,6 +23,7 @@ import {
   result_color_scale,
 } from './results_common.js';
 
+import { large_status_icons } from './result_components.js';
 
 import { IconArray } from '../../../charts/IconArray.js';
 
@@ -298,6 +299,14 @@ export const DrrSummary = ({ subject, counts, verbose_counts, is_gov, num_depts 
       <div className="fcol-md-7 fcol-xs-7 medium_panel_text" >
         <div style={{padding: "10px"}}>
           <TM k="result_status_explanation"/>
+          <table>
+            {_.map( ordered_status_keys, status => (
+              <tr>
+                <td style={{padding: "10px"}}>{large_status_icons[status]}</td>
+                <td><TM k={`result_status_explanation_${status}`}/></td>
+              </tr>
+            ) )}
+          </table>
         </div>
       </div>
       <div className="fcol-md-5 fcol-xs-5" >

--- a/client/src/panels/panel_declarations/results/drr_summary.js
+++ b/client/src/panels/panel_declarations/results/drr_summary.js
@@ -10,11 +10,8 @@ import {
   businessConstants,
   get_source_links,
   Results,
-
   declare_panel,
-
   NivoResponsivePie,
-
 } from "../shared.js";
 import { 
   row_to_drr_status_counts,
@@ -23,7 +20,9 @@ import {
   ordered_status_keys,
   filter_and_genericize_doc_counts,
   result_statuses,
+  result_color_scale,
 } from './results_common.js';
+
 
 import { IconArray } from '../../../charts/IconArray.js';
 
@@ -41,7 +40,6 @@ const grid_colors = {
   future: "results-icon-array-neutral",
 };
 
-const result_color_scale = window.infobase_colors(); // NOTE: this is not going to guarantee that all results data (plots, grid, icons) will have the same colour scale, I'm just hacking it for now
 
 const icon_order = _.chain(ordered_status_keys)
   .map( (status_key, ix) => [status_key, ix*5] )

--- a/client/src/panels/panel_declarations/results/drr_summary.scss
+++ b/client/src/panels/panel_declarations/results/drr_summary.scss
@@ -1,17 +1,17 @@
 @import "../../../common_css/common-variables";
 
 .results-icon-array-pass {
-  background-color: $successDarkColor;
+  background-color: #206BBD;
 }
 
 .results-icon-array-fail {
-  background-color: $failDarkColor;
+  background-color: #4abbc4;
 }
 
 .results-icon-array-na {
-  background-color: $warnDarkColor;
+  background-color: #e89a40;
 }
 
 .results-icon-array-neutral {
-  background-color: $tertiaryColor;
+  background-color: #919bd4;
 }

--- a/client/src/panels/panel_declarations/results/drr_summary_text.yaml
+++ b/client/src/panels/panel_declarations/results/drr_summary_text.yaml
@@ -41,7 +41,7 @@ new_drr_summary_text_summary:
       {{#if drr_indicators_met}}* **{{fmt_big_int drr_indicators_met}}** (**{{fmt_percentage1 (divide drr_indicators_met drr_total)}}**) {{gl_tt "ont atteint" "RESULTS_MET"}} leur cible{{/if}}
       {{#if drr_indicators_not_met}}* **{{fmt_big_int drr_indicators_not_met}}** (**{{fmt_percentage1 (divide drr_indicators_not_met drr_total)}}**) {{gl_tt "n’ont pas atteint" "RESULTS_NOT_MET"}} leur cible{{/if}}
       {{#if drr_indicators_not_available}}* **{{fmt_big_int drr_indicators_not_available}}** (**{{fmt_percentage1 (divide drr_indicators_not_available drr_total)}}**) {{gl_tt "n’ont pas de résultat disponible" "RESULTS_NOT_AVAILABLE"}}{{/if}}
-      {{#if drr_indicators_future}}* **{{fmt_big_int drr_indicators_future}}** (**{{fmt_percentage1 (divide drr_indicators_future drr_total)}}**) sont {{gl_tt "à atteindre dans le future" "RESULTS_ONGOING"}}{{/if}}
+      {{#if drr_indicators_future}}* **{{fmt_big_int drr_indicators_future}}** (**{{fmt_percentage1 (divide drr_indicators_future drr_total)}}**) sont {{gl_tt "à atteindre dans le futur" "RESULTS_ONGOING"}}{{/if}}
     {{/if}}
 
 gov_drr_summary_org_table_text:
@@ -63,7 +63,7 @@ results_icon_array_title:
 
 graph_legend_instructions:
   en: |
-    Click to change which results are counted in the full set:
+    Click below to change which results are counted in the full set:
   fr: |
     Cliquez ci-dessous pour changer l’état des résultats pris en compte dans l’ensemble du cercle
 

--- a/client/src/panels/panel_declarations/results/drr_summary_text.yaml
+++ b/client/src/panels/panel_declarations/results/drr_summary_text.yaml
@@ -30,14 +30,14 @@ drr_summary_text_intro:
 new_drr_summary_text_summary:
   transform: [handlebars,markdown]
   en: |
-    Of the **{{fmt_big_int drr_total}}** indicators reported:
+    In **{{year}}**, of the **{{fmt_big_int drr_total}}** indicators reported:
       {{#if drr_indicators_met}}* **{{fmt_big_int drr_indicators_met}}** (**{{fmt_percentage1 (divide drr_indicators_met drr_total)}}**) {{gl_tt "met" "RESULTS_MET"}} their target{{/if}}
       {{#if drr_indicators_not_met}}* **{{fmt_big_int drr_indicators_not_met}}** (**{{fmt_percentage1 (divide drr_indicators_not_met drr_total)}}**) did {{gl_tt "not meet" "RESULTS_NOT_MET"}} their target{{/if}}
       {{#if drr_indicators_not_available}}* **{{fmt_big_int drr_indicators_not_available}}** (**{{fmt_percentage1 (divide drr_indicators_not_available drr_total)}}**) have {{gl_tt "no result available" "RESULTS_NOT_AVAILABLE"}}{{/if}}
       {{#if drr_indicators_future}}* **{{fmt_big_int drr_indicators_future}}** (**{{fmt_percentage1 (divide drr_indicators_future drr_total)}}**) are {{gl_tt "to be achieved in the future" "RESULTS_ONGOING"}}{{/if}}
   fr: |
     {{#if drr_total}}
-    De ces **{{fmt_big_int drr_total}}** indicateurs rapportés:
+    En **{{year}}**, de ces **{{fmt_big_int drr_total}}** indicateurs rapportés:
       {{#if drr_indicators_met}}* **{{fmt_big_int drr_indicators_met}}** (**{{fmt_percentage1 (divide drr_indicators_met drr_total)}}**) {{gl_tt "ont atteint" "RESULTS_MET"}} leur cible{{/if}}
       {{#if drr_indicators_not_met}}* **{{fmt_big_int drr_indicators_not_met}}** (**{{fmt_percentage1 (divide drr_indicators_not_met drr_total)}}**) {{gl_tt "n’ont pas atteint" "RESULTS_NOT_MET"}} leur cible{{/if}}
       {{#if drr_indicators_not_available}}* **{{fmt_big_int drr_indicators_not_available}}** (**{{fmt_percentage1 (divide drr_indicators_not_available drr_total)}}**) {{gl_tt "n’ont pas de résultat disponible" "RESULTS_NOT_AVAILABLE"}}{{/if}}

--- a/client/src/panels/panel_declarations/results/drr_summary_text.yaml
+++ b/client/src/panels/panel_declarations/results/drr_summary_text.yaml
@@ -69,18 +69,27 @@ graph_legend_instructions:
 
 
 result_status_explanation:
-  transform: [handlebars,markdown]
-  en: |
-    The result status depends on how the target was defined, e.g. a minimum target requires a measured outcome greater than the target.
-    
-    * If the measured outcome satisfies the target, the indicator is assigned a status of {{gl_tt "Target met" "RESULTS_MET"}}.
-    * If the measured outcome is outside the range or standard established by the target, the indicator's status is {{gl_tt "Target not met" "RESULTS_NOT_MET"}}.
-    * Indicators for which no target was set, or for which data was unavailable, are assigned the status {{gl_tt "No result available" "RESULTS_NOT_AVAILABLE"}}.
-    * If the date to achieve the target is after the end of the fiscal year (March 31), or if there is no date to achieve the target, the status is {{gl_tt "Result to be achieved in the future" "RESULTS_ONGOING"}}.
-  fr: |
-    L'état du résultat dépend de la manière dont la cible a été définie, par exemple une cible minimale exige un résultat mesuré (résultat réel) supérieur à la cible.
-    
-    * Si le résultat mesuré correspond à la cible, l'indicateur se voit attribuer l'état {{gl_tt "Cible atteinte" "RESULTS_MET"}}.
-    * Si le résultat mesuré se situe en dehors de la fourchette ou de la norme établie par la cible, l’état de l'indicateur est {{gl_tt "Cible non atteinte" "RESULTS_NOT_MET"}}.
-    * Les indicateurs pour lesquels aucune cible n'a été fixée, ou pour lesquels les données n'étaient pas disponibles, se voient attribuer l’état {{gl_tt "Résultat non disponible" "RESULTS_NOT_AVAILABLE"}}.
-    * Si la date d’atteinte de la cible est postérieure à la fin de l'exercice financier (31 mars), ou s'il n'y a pas de date d’atteinte de la cible, l’état est {{gl_tt "Résultat à atteindre dans le futur" "RESULTS_ONGOING"}}.
+  transform: [handlebars]
+  en: The result status depends on how the target was defined, e.g. a minimum target requires a measured outcome (actual result) greater than the target.
+
+  fr: L'état du résultat dépend de la manière dont la cible a été définie, par exemple une cible minimale exige un résultat mesuré (résultat réel) supérieur à la cible.
+
+result_status_explanation_met:
+  transform: [handlebars]
+  en: If the measured outcome satisfies the target, the indicator is assigned a status of {{gl_tt "Target met" "RESULTS_MET"}}.
+  fr: Si le résultat mesuré correspond à la cible, l'indicateur se voit attribuer l'état {{gl_tt "Cible atteinte" "RESULTS_MET"}}.
+
+result_status_explanation_not_met:
+  transform: [handlebars]
+  en: If the measured outcome is outside the range or standard established by the target, the indicator's status is {{gl_tt "Target not met" "RESULTS_NOT_MET"}}.
+  fr: Si le résultat mesuré se situe en dehors de la fourchette ou de la norme établie par la cible, l’état de l'indicateur est {{gl_tt "Cible non atteinte" "RESULTS_NOT_MET"}}.
+
+result_status_explanation_not_available:
+  transform: [handlebars]
+  en: Indicators for which no target was set, or for which data was unavailable, are assigned the status {{gl_tt "No result available" "RESULTS_NOT_AVAILABLE"}}.
+  fr: Les indicateurs pour lesquels aucune cible n'a été fixée, ou pour lesquels les données n'étaient pas disponibles, se voient attribuer l’état {{gl_tt "Résultat non disponible" "RESULTS_NOT_AVAILABLE"}}.
+
+result_status_explanation_future:
+  transform: [handlebars]
+  en: If the date to achieve the target is after the end of the fiscal year (March 31), or if there is no date to achieve the target, the status is {{gl_tt "Result to be achieved in the future" "RESULTS_ONGOING"}}.
+  fr: Si la date d’atteinte de la cible est postérieure à la fin de l'exercice financier (31 mars), ou s'il n'y a pas de date d’atteinte de la cible, l’état est {{gl_tt "Résultat à atteindre dans le futur" "RESULTS_ONGOING"}}.

--- a/client/src/panels/panel_declarations/results/drr_summary_text.yaml
+++ b/client/src/panels/panel_declarations/results/drr_summary_text.yaml
@@ -16,7 +16,7 @@ drr_summary_text_intro:
       In **{{year}}**, {{subj_name subject}} sought to achieve **{{fmt_big_int drr_results}}** results.
     {{/if}}
     Progress towards meeting these results was measured using **{{fmt_big_int drr_total}}** indicators, and a {{gl_tt "Result Status" "RESULTS_STATUS"}} was assigned to each indicator
-    based on the measured outcome of the indicator's target.
+    based on the measured outcome (actual result) of the indicator's target.
   fr: |
     {{#if is_gov}}
       En **{{year}}**, **{{num_depts}}** organisations ont cherché à obtenir **{{fmt_big_int drr_results}}** résultats.
@@ -35,11 +35,11 @@ new_drr_summary_text_summary:
       {{#if drr_indicators_future}}* **{{fmt_big_int drr_indicators_future}}** (**{{fmt_percentage1 (divide drr_indicators_future drr_total)}}**) are {{gl_tt "to be achieved in the future" "RESULTS_ONGOING"}}{{/if}}
   fr: |
     {{#if drr_total}}
-    TODO TODO TODO needs to match the english text
-    De ces **{{fmt_big_int drr_past_total}}** indicateurs qui devaient atteindre leur cible au plus tard le 31 mars {{target_year}}:
-      {{#if drr_indicators_met}}* **{{fmt_big_int drr_indicators_met}}** (**{{fmt_percentage1 (divide drr_indicators_met drr_past_total)}}**) {{gl_tt "ont atteint" "RESULTS_MET"}} leur cible{{/if}}
-      {{#if drr_indicators_not_met}}* **{{fmt_big_int drr_indicators_not_met}}** (**{{fmt_percentage1 (divide drr_indicators_not_met drr_past_total)}}**) {{gl_tt "n’ont pas atteint" "RESULTS_NOT_MET"}} leur cible{{/if}}
-      {{#if drr_indicators_not_available}}* **{{fmt_big_int drr_indicators_not_available}}** (**{{fmt_percentage1 (divide drr_indicators_not_available drr_past_total)}}**) {{gl_tt "n’ont pas de résultat disponible" "RESULTS_NOT_AVAILABLE"}}{{/if}}
+    De ces **{{fmt_big_int drr_past_total}}** indicateurs rapportés:
+      {{#if drr_indicators_met}}* **{{fmt_big_int drr_indicators_met}}** (**{{fmt_percentage1 (divide drr_indicators_met drr_total)}}**) {{gl_tt "ont atteint" "RESULTS_MET"}} leur cible{{/if}}
+      {{#if drr_indicators_not_met}}* **{{fmt_big_int drr_indicators_not_met}}** (**{{fmt_percentage1 (divide drr_indicators_not_met drr_total)}}**) {{gl_tt "n’ont pas atteint" "RESULTS_NOT_MET"}} leur cible{{/if}}
+      {{#if drr_indicators_not_available}}* **{{fmt_big_int drr_indicators_not_available}}** (**{{fmt_percentage1 (divide drr_indicators_not_available drr_total)}}**) {{gl_tt "n’ont pas de résultat disponible" "RESULTS_NOT_AVAILABLE"}}{{/if}}
+      {{#if drr_indicators_future}}* **{{fmt_big_int drr_indicators_future}}** (**{{fmt_percentage1 (divide drr_indicators_future drr_total)}}**) sont {{gl_tt "à atteindre dans le future" "RESULTS_ONGOING"}}{{/if}}
     {{/if}}
 
 gov_drr_summary_org_table_text:
@@ -68,7 +68,7 @@ graph_legend_instructions:
 result_status_explanation:
   transform: [handlebars,markdown]
   en: |
-    The result status depends on how the target was defined, e.g. a minimum target requires a measured outcome (actual result) greater than the target.
+    The result status depends on how the target was defined, e.g. a minimum target requires a measured outcome greater than the target.
     
     * If the measured outcome satisfies the target, the indicator is assigned a status of {{gl_tt "Target met" "RESULTS_MET"}}.
     * If the measured outcome is outside the range or standard established by the target, the indicator's status is {{gl_tt "Target not met" "RESULTS_NOT_MET"}}.

--- a/client/src/panels/panel_declarations/results/drr_summary_text.yaml
+++ b/client/src/panels/panel_declarations/results/drr_summary_text.yaml
@@ -71,8 +71,8 @@ result_status_explanation:
     The result status depends on how the target was defined, e.g. a minimum target requires a measured outcome (actual result) greater than the target.
     
     * If the measured outcome satisfies the target, the indicator is assigned a status of {{gl_tt "Target met" "RESULTS_MET"}}.
-    * If the measured outcome is outside the range or standard established by the the target, the indicator's status is {{gl_tt "Target not met" "RESULTS_NOT_MET"}}.
+    * If the measured outcome is outside the range or standard established by the target, the indicator's status is {{gl_tt "Target not met" "RESULTS_NOT_MET"}}.
     * Indicators for which no target was set, or for which data was unavailable, are assigned the status {{gl_tt "No result available" "RESULTS_NOT_AVAILABLE"}}.
-    * If the date to achieve the target is after the end of the fiscal year (March 31), or if there is no date to achieve the target the status is {{gl_tt "Result to be achieved in the future" "RESULTS_ONGOING"}}.
+    * If the date to achieve the target is after the end of the fiscal year (March 31), or if there is no date to achieve the target, the status is {{gl_tt "Result to be achieved in the future" "RESULTS_ONGOING"}}.
   fr: |
     TODO

--- a/client/src/panels/panel_declarations/results/drr_summary_text.yaml
+++ b/client/src/panels/panel_declarations/results/drr_summary_text.yaml
@@ -23,7 +23,9 @@ drr_summary_text_intro:
     {{else}}
       En **{{year}}**, {{subj_name subject}} a cherché à atteindre **{{fmt_big_int drr_results}}** résultats.
     {{/if}}
-    TODO: need french translation for this bit
+    Les progrès réalisés pour atteindre ces résultats ont été mesurés au moyen de **{{fmt_big_int drr_total}}** indicateurs, et un {{gl_tt "état du résultat" "RESULTS_STATUS"}}
+    a été attribué à chaque indicateur correspondant au résultat obtenu pour la cible de l'indicateur.
+
 
 new_drr_summary_text_summary:
   transform: [handlebars,markdown]
@@ -63,7 +65,8 @@ graph_legend_instructions:
   en: |
     Click to change which results are counted in the full set:
   fr: |
-    TODO
+    Cliquez ci-dessous pour changer l’état des résultats pris en compte dans l’ensemble du cercle
+
 
 result_status_explanation:
   transform: [handlebars,markdown]
@@ -75,4 +78,9 @@ result_status_explanation:
     * Indicators for which no target was set, or for which data was unavailable, are assigned the status {{gl_tt "No result available" "RESULTS_NOT_AVAILABLE"}}.
     * If the date to achieve the target is after the end of the fiscal year (March 31), or if there is no date to achieve the target, the status is {{gl_tt "Result to be achieved in the future" "RESULTS_ONGOING"}}.
   fr: |
-    TODO
+    L'état du résultat dépend de la manière dont la cible a été définie, par exemple une cible minimale exige un résultat mesuré (résultat réel) supérieur à la cible.
+    
+    * Si le résultat mesuré correspond à la cible, l'indicateur se voit attribuer l'état {{gl_tt "Cible atteinte" "RESULTS_MET"}}.
+    * Si le résultat mesuré se situe en dehors de la fourchette ou de la norme établie par la cible, l’état de l'indicateur est {{gl_tt "Cible non atteinte" "RESULTS_NOT_MET"}}.
+    * Les indicateurs pour lesquels aucune cible n'a été fixée, ou pour lesquels les données n'étaient pas disponibles, se voient attribuer l’état {{gl_tt "Résultat non disponible" "RESULTS_NOT_AVAILABLE"}}.
+    * Si la date d’atteinte de la cible est postérieure à la fin de l'exercice financier (31 mars), ou s'il n'y a pas de date d’atteinte de la cible, l’état est {{gl_tt "Résultat à atteindre dans le futur" "RESULTS_ONGOING"}}.

--- a/client/src/panels/panel_declarations/results/drr_summary_text.yaml
+++ b/client/src/panels/panel_declarations/results/drr_summary_text.yaml
@@ -37,7 +37,7 @@ new_drr_summary_text_summary:
       {{#if drr_indicators_future}}* **{{fmt_big_int drr_indicators_future}}** (**{{fmt_percentage1 (divide drr_indicators_future drr_total)}}**) are {{gl_tt "to be achieved in the future" "RESULTS_ONGOING"}}{{/if}}
   fr: |
     {{#if drr_total}}
-    De ces **{{fmt_big_int drr_past_total}}** indicateurs rapportés:
+    De ces **{{fmt_big_int drr_total}}** indicateurs rapportés:
       {{#if drr_indicators_met}}* **{{fmt_big_int drr_indicators_met}}** (**{{fmt_percentage1 (divide drr_indicators_met drr_total)}}**) {{gl_tt "ont atteint" "RESULTS_MET"}} leur cible{{/if}}
       {{#if drr_indicators_not_met}}* **{{fmt_big_int drr_indicators_not_met}}** (**{{fmt_percentage1 (divide drr_indicators_not_met drr_total)}}**) {{gl_tt "n’ont pas atteint" "RESULTS_NOT_MET"}} leur cible{{/if}}
       {{#if drr_indicators_not_available}}* **{{fmt_big_int drr_indicators_not_available}}** (**{{fmt_percentage1 (divide drr_indicators_not_available drr_total)}}**) {{gl_tt "n’ont pas de résultat disponible" "RESULTS_NOT_AVAILABLE"}}{{/if}}

--- a/client/src/panels/panel_declarations/results/drr_summary_text.yaml
+++ b/client/src/panels/panel_declarations/results/drr_summary_text.yaml
@@ -46,6 +46,24 @@ drr_summary_text_summary_left:
       {{#if drr_indicators_not_available}}* **{{fmt_big_int drr_indicators_not_available}}** (**{{fmt_percentage1 (divide drr_indicators_not_available drr_past_total)}}**) {{gl_tt "n’ont pas de résultat disponible" "RESULTS_NOT_AVAILABLE"}}{{/if}}
     {{/if}}
 
+
+new_drr_summary_text_summary:
+  transform: [handlebars,markdown]
+  en: |
+    Of the **{{fmt_big_int drr_total}}** indicators reported:
+      {{#if drr_indicators_met}}* **{{fmt_big_int drr_indicators_met}}** (**{{fmt_percentage1 (divide drr_indicators_met drr_total)}}**) {{gl_tt "met" "RESULTS_MET"}} their target{{/if}}
+      {{#if drr_indicators_not_met}}* **{{fmt_big_int drr_indicators_not_met}}** (**{{fmt_percentage1 (divide drr_indicators_not_met drr_total)}}**) did {{gl_tt "not meet" "RESULTS_NOT_MET"}} their target{{/if}}
+      {{#if drr_indicators_not_available}}* **{{fmt_big_int drr_indicators_not_available}}** (**{{fmt_percentage1 (divide drr_indicators_not_available drr_total)}}**) have {{gl_tt "no result available" "RESULTS_NOT_AVAILABLE"}}{{/if}}
+      {{#if drr_indicators_future}}* **{{fmt_big_int drr_indicators_future}}** (**{{fmt_percentage1 (divide drr_indicators_future drr_total)}}**) are {{gl_tt "to be achieved in the future" "RESULTS_ONGOING"}}{{/if}}
+  fr: |
+    {{#if drr_total}}
+    TODO TODO TODO needs to match the english text
+    De ces **{{fmt_big_int drr_past_total}}** indicateurs qui devaient atteindre leur cible au plus tard le 31 mars {{target_year}}:
+      {{#if drr_indicators_met}}* **{{fmt_big_int drr_indicators_met}}** (**{{fmt_percentage1 (divide drr_indicators_met drr_past_total)}}**) {{gl_tt "ont atteint" "RESULTS_MET"}} leur cible{{/if}}
+      {{#if drr_indicators_not_met}}* **{{fmt_big_int drr_indicators_not_met}}** (**{{fmt_percentage1 (divide drr_indicators_not_met drr_past_total)}}**) {{gl_tt "n’ont pas atteint" "RESULTS_NOT_MET"}} leur cible{{/if}}
+      {{#if drr_indicators_not_available}}* **{{fmt_big_int drr_indicators_not_available}}** (**{{fmt_percentage1 (divide drr_indicators_not_available drr_past_total)}}**) {{gl_tt "n’ont pas de résultat disponible" "RESULTS_NOT_AVAILABLE"}}{{/if}}
+    {{/if}}
+
 gov_drr_summary_org_table_text:
   transform: [handlebars,markdown]
   en: |
@@ -62,3 +80,9 @@ results_icon_array_title:
     {{year}} Performance Indicators
   fr: |
     Indicateurs de performance {{year}}
+
+graph_legend_instructions:
+  en: |
+    Click to change which results are counted in the full set:
+  fr: |
+    TODO

--- a/client/src/panels/panel_declarations/results/drr_summary_text.yaml
+++ b/client/src/panels/panel_declarations/results/drr_summary_text.yaml
@@ -30,14 +30,14 @@ drr_summary_text_intro:
 new_drr_summary_text_summary:
   transform: [handlebars,markdown]
   en: |
-    In **{{year}}**, of the **{{fmt_big_int drr_total}}** indicators reported:
+    In **{{year}}**, of the **{{fmt_big_int drr_subset}}** indicators (out of **{{fmt_big_int drr_total}}** total reported):
       {{#if drr_indicators_met}}* **{{fmt_big_int drr_indicators_met}}** (**{{fmt_percentage1 (divide drr_indicators_met drr_total)}}**) {{gl_tt "met" "RESULTS_MET"}} their target{{/if}}
       {{#if drr_indicators_not_met}}* **{{fmt_big_int drr_indicators_not_met}}** (**{{fmt_percentage1 (divide drr_indicators_not_met drr_total)}}**) did {{gl_tt "not meet" "RESULTS_NOT_MET"}} their target{{/if}}
       {{#if drr_indicators_not_available}}* **{{fmt_big_int drr_indicators_not_available}}** (**{{fmt_percentage1 (divide drr_indicators_not_available drr_total)}}**) have {{gl_tt "no result available" "RESULTS_NOT_AVAILABLE"}}{{/if}}
       {{#if drr_indicators_future}}* **{{fmt_big_int drr_indicators_future}}** (**{{fmt_percentage1 (divide drr_indicators_future drr_total)}}**) are {{gl_tt "to be achieved in the future" "RESULTS_ONGOING"}}{{/if}}
   fr: |
     {{#if drr_total}}
-    En **{{year}}**, de ces **{{fmt_big_int drr_total}}** indicateurs rapportés:
+    En **{{year}}**, de ces **{{fmt_big_int drr_subset}}** indicateurs (sur **{{fmt_big_int drr_total}}** au total rapportés):
       {{#if drr_indicators_met}}* **{{fmt_big_int drr_indicators_met}}** (**{{fmt_percentage1 (divide drr_indicators_met drr_total)}}**) {{gl_tt "ont atteint" "RESULTS_MET"}} leur cible{{/if}}
       {{#if drr_indicators_not_met}}* **{{fmt_big_int drr_indicators_not_met}}** (**{{fmt_percentage1 (divide drr_indicators_not_met drr_total)}}**) {{gl_tt "n’ont pas atteint" "RESULTS_NOT_MET"}} leur cible{{/if}}
       {{#if drr_indicators_not_available}}* **{{fmt_big_int drr_indicators_not_available}}** (**{{fmt_percentage1 (divide drr_indicators_not_available drr_total)}}**) {{gl_tt "n’ont pas de résultat disponible" "RESULTS_NOT_AVAILABLE"}}{{/if}}

--- a/client/src/panels/panel_declarations/results/drr_summary_text.yaml
+++ b/client/src/panels/panel_declarations/results/drr_summary_text.yaml
@@ -15,37 +15,15 @@ drr_summary_text_intro:
     {{else}}
       In **{{year}}**, {{subj_name subject}} sought to achieve **{{fmt_big_int drr_results}}** results.
     {{/if}}
-    Progress towards meeting these results was measured using **{{fmt_big_int drr_total}}** {{gl_tt "indicators" "IND_RESULT"}}, {{#if drr_past_total}} **{{fmt_big_int drr_past_total}}**
-    of which were seeking to achieve their target **by March 31, {{target_year}}**{{#if drr_future_total}} and{{else}}.{{/if}}
-    {{/if}}{{#if drr_future_total}} **{{fmt_big_int drr_future_total}}** of which are seeking to achieve their target **after March 31, {{target_year}}**
-    or **on an ongoing basis**.{{/if}}
+    Progress towards meeting these results was measured using **{{fmt_big_int drr_total}}** indicators, and a {{gl_tt "Result Status" "RESULTS_STATUS"}} was assigned to each indicator
+    based on the measured outcome of the indicator's target.
   fr: |
     {{#if is_gov}}
       En **{{year}}**, **{{num_depts}}** organisations ont cherché à obtenir **{{fmt_big_int drr_results}}** résultats.
     {{else}}
       En **{{year}}**, {{subj_name subject}} a cherché à atteindre **{{fmt_big_int drr_results}}** résultats.
     {{/if}}
-    Les progrès accomplis dans l'atteinte de ces résultats ont été mesurés à l’aide de **{{fmt_big_int drr_total}}** {{gl_tt "indicateurs" "IND_RESULT"}}, {{#if drr_past_total}} dont
-    **{{fmt_big_int drr_past_total}}** avaient des cibles à **atteindre au plus tard le 31 mars {{target_year}}**{{#if drr_future_total}} et{{else}}.{{/if}}
-    {{/if}}{{#if drr_future_total}} dont **{{fmt_big_int drr_future_total}}** visaient à atteindre leurs cibles **continuellement** ou **après mars 31
-    {{target_year}}**.{{/if}}
-drr_summary_text_summary_left:
-  transform: [handlebars,markdown]
-  en: |
-    {{#if drr_past_total}}
-    Of the **{{fmt_big_int drr_past_total}}** indicators that sought to achieve their target by March 31, {{target_year}}:
-      {{#if drr_indicators_met}}* **{{fmt_big_int drr_indicators_met}}** (**{{fmt_percentage1 (divide drr_indicators_met drr_past_total)}}**) {{gl_tt "met" "RESULTS_MET"}} their target{{/if}}
-      {{#if drr_indicators_not_met}}* **{{fmt_big_int drr_indicators_not_met}}** (**{{fmt_percentage1 (divide drr_indicators_not_met drr_past_total)}}**) did {{gl_tt "not meet" "RESULTS_NOT_MET"}} their target{{/if}}
-      {{#if drr_indicators_not_available}}* **{{fmt_big_int drr_indicators_not_available}}** (**{{fmt_percentage1 (divide drr_indicators_not_available drr_past_total)}}**) have {{gl_tt "no result available" "RESULTS_NOT_AVAILABLE"}}{{/if}}
-    {{/if}}
-  fr: |
-    {{#if drr_past_total}}
-    De ces **{{fmt_big_int drr_past_total}}** indicateurs qui devaient atteindre leur cible au plus tard le 31 mars {{target_year}}:
-      {{#if drr_indicators_met}}* **{{fmt_big_int drr_indicators_met}}** (**{{fmt_percentage1 (divide drr_indicators_met drr_past_total)}}**) {{gl_tt "ont atteint" "RESULTS_MET"}} leur cible{{/if}}
-      {{#if drr_indicators_not_met}}* **{{fmt_big_int drr_indicators_not_met}}** (**{{fmt_percentage1 (divide drr_indicators_not_met drr_past_total)}}**) {{gl_tt "n’ont pas atteint" "RESULTS_NOT_MET"}} leur cible{{/if}}
-      {{#if drr_indicators_not_available}}* **{{fmt_big_int drr_indicators_not_available}}** (**{{fmt_percentage1 (divide drr_indicators_not_available drr_past_total)}}**) {{gl_tt "n’ont pas de résultat disponible" "RESULTS_NOT_AVAILABLE"}}{{/if}}
-    {{/if}}
-
+    TODO: need french translation for this bit
 
 new_drr_summary_text_summary:
   transform: [handlebars,markdown]
@@ -84,5 +62,17 @@ results_icon_array_title:
 graph_legend_instructions:
   en: |
     Click to change which results are counted in the full set:
+  fr: |
+    TODO
+
+result_status_explanation:
+  transform: [handlebars,markdown]
+  en: |
+    The result status depends on how the target was defined, e.g. a minimum target requires a measured outcome (actual result) greater than the target.
+    
+    * If the measured outcome satisfies the target, the indicator is assigned a status of {{gl_tt "Target met" "RESULTS_MET"}}.
+    * If the measured outcome is outside the range or standard established by the the target, the indicator's status is {{gl_tt "Target not met" "RESULTS_NOT_MET"}}.
+    * Indicators for which no target was set, or for which data was unavailable, are assigned the status {{gl_tt "No result available" "RESULTS_NOT_AVAILABLE"}}.
+    * If the date to achieve the target is after the end of the fiscal year (March 31), or if there is no date to achieve the target the status is {{gl_tt "Result to be achieved in the future" "RESULTS_ONGOING"}}.
   fr: |
     TODO

--- a/client/src/panels/panel_declarations/results/result_components.js
+++ b/client/src/panels/panel_declarations/results/result_components.js
@@ -221,7 +221,7 @@ const result_status_icon_components = (status, width) => {
     met: <IconCheck
       key="met"
       title={result_simple_statuses.met.text}
-      color={color_defs.successDarkColor}
+      color={"#206BBD"}
       width={width}
       vertical_align={"0em"}
       alternate_color={false}
@@ -230,7 +230,7 @@ const result_status_icon_components = (status, width) => {
     not_met: <IconAttention
       key="not_met"
       title={result_simple_statuses.not_met.text}
-      color={color_defs.failDarkColor}
+      color={"#4abbc4"}
       width={width}
       vertical_align={"0em"}
       alternate_color={false}
@@ -239,7 +239,7 @@ const result_status_icon_components = (status, width) => {
     not_available: <IconNotApplicable
       key="not_available"
       title={result_simple_statuses.not_available.text}
-      color={color_defs.warnDarkColor}
+      color={"#e89a40"}
       width={width}
       vertical_align={"0em"}
       alternate_color={false}
@@ -248,7 +248,7 @@ const result_status_icon_components = (status, width) => {
     future: <IconClock
       key="future"
       title={result_simple_statuses.future.text}
-      color={color_defs.tertiaryColor}
+      color={"#919bd4"}
       width={width}
       vertical_align={"0em"}
       alternate_color={false}

--- a/client/src/panels/panel_declarations/results/result_components.js
+++ b/client/src/panels/panel_declarations/results/result_components.js
@@ -13,6 +13,7 @@ import {
   indicator_text_functions,
   get_result_doc_keys,
   result_docs,
+  result_color_scale,
 } from './results_common.js';
 import {
   IconCheck,
@@ -221,7 +222,7 @@ const result_status_icon_components = (status, width) => {
     met: <IconCheck
       key="met"
       title={result_simple_statuses.met.text}
-      color={"#206BBD"}
+      color={result_color_scale("met")}
       width={width}
       vertical_align={"0em"}
       alternate_color={false}
@@ -230,7 +231,7 @@ const result_status_icon_components = (status, width) => {
     not_met: <IconAttention
       key="not_met"
       title={result_simple_statuses.not_met.text}
-      color={"#4abbc4"}
+      color={result_color_scale("not_met")}
       width={width}
       vertical_align={"0em"}
       alternate_color={false}
@@ -239,7 +240,7 @@ const result_status_icon_components = (status, width) => {
     not_available: <IconNotApplicable
       key="not_available"
       title={result_simple_statuses.not_available.text}
-      color={"#e89a40"}
+      color={result_color_scale("not_available")}
       width={width}
       vertical_align={"0em"}
       alternate_color={false}
@@ -248,7 +249,7 @@ const result_status_icon_components = (status, width) => {
     future: <IconClock
       key="future"
       title={result_simple_statuses.future.text}
-      color={"#919bd4"}
+      color={result_color_scale("future")}
       width={width}
       vertical_align={"0em"}
       alternate_color={false}

--- a/client/src/panels/panel_declarations/results/result_components.js
+++ b/client/src/panels/panel_declarations/results/result_components.js
@@ -21,7 +21,6 @@ import {
   IconNotApplicable,
   IconClock,
 } from '../../../icons/icons.js';
-import * as color_defs from '../../../core/color_defs.js';
 
 const {
   indicator_target_text,

--- a/client/src/panels/panel_declarations/results/results_common.js
+++ b/client/src/panels/panel_declarations/results/results_common.js
@@ -4,6 +4,7 @@ import {
   infograph_href_template,
   businessConstants,
   formats,
+  newIBCategoryColors,
 } from '../shared.js';
 
 import { get_resources_for_subject } from '../../../explorer_common/resource_explorer_common.js';
@@ -185,6 +186,16 @@ const filter_and_genericize_doc_counts = (counts, doc_key) => {
   return doc_counts_with_generic_keys;
 };
 
+const result_color_scale = d3.scaleOrdinal()
+  .domain(["met","not_met","not_available","future"])
+  .range([
+    newIBCategoryColors[0],
+    newIBCategoryColors[1],
+    newIBCategoryColors[2],
+    newIBCategoryColors[3],
+  ]);
+
+
 export {
   Result,
   Indicator,
@@ -206,6 +217,6 @@ export {
   result_simple_statuses,
 
   indicator_text_functions,
-
+  result_color_scale,
   filter_and_genericize_doc_counts,
 };

--- a/client/src/panels/panel_declarations/results/results_common.js
+++ b/client/src/panels/panel_declarations/results/results_common.js
@@ -186,14 +186,9 @@ const filter_and_genericize_doc_counts = (counts, doc_key) => {
   return doc_counts_with_generic_keys;
 };
 
-const result_color_scale = d3.scaleOrdinal()
+const result_color_scale = d3.scaleOrdinal() // this is a d3 scale to allow seamless slotting into a nivo graph
   .domain(["met","not_met","not_available","future"])
-  .range([
-    newIBCategoryColors[0],
-    newIBCategoryColors[1],
-    newIBCategoryColors[2],
-    newIBCategoryColors[3],
-  ]);
+  .range(_.take(newIBCategoryColors, 4));
 
 
 export {

--- a/client/src/panels/panel_declarations/results/results_intro_text.yaml
+++ b/client/src/panels/panel_declarations/results/results_intro_text.yaml
@@ -65,6 +65,7 @@ drr_summary_text:
       à l'aide de **{{fmt_big_int drr_indicators}}** indicateurs, et un état du résultat a été associé à chaque indicateur
       selon la mesure du résultat prévu pour la cible de l'indicateur.
     {{/if}}
+    TODO: need french translation for this bit
 
 
 reports_links_text:

--- a/client/src/panels/panel_declarations/results/results_intro_text.yaml
+++ b/client/src/panels/panel_declarations/results/results_intro_text.yaml
@@ -52,20 +52,20 @@ drr_summary_text:
     {{else}}
       In its **{{year}}** {{gl_tt "Departmental Results Report" "DRR"}}, {{subj_name subject}} sought to achieve **{{fmt_big_int drr_results}}** results.
     {{/if}}
+
     Progress towards meeting these results was measured using **{{fmt_big_int drr_indicators}}** indicators, and a {{gl_tt "Result Status" "RESULTS_STATUS"}} was assigned to each indicator
     based on the measured outcome of the indicator's target.
   fr: |
     {{#if is_gov}}
       En **{{year}}**, **{{fmt_big_int depts_with_drrs}}** organisations ont cherché à atteindre **{{fmt_big_int drr_results}}** résultats. 
       Les progrès vers l'atteinte de ces résultats ont été mesurés à l'aide de **{{fmt_big_int drr_indicators}}** indicateurs, et
-      un état du résultat a été associé à chaque indicateur selon la mesure du résultat prévu pour la cible de l'indicateur.
+      un {{gl_tt "état du résultat" "RESULTS_STATUS"}} a été associé à chaque indicateur selon la mesure du résultat prévu pour la cible de l'indicateur.
     {{else}}
       Dans son {{gl_tt "rapport sur les résultats ministériel" "DRR"}} de **{{year}}**, {{subj_name subject}}
       a cherché à obtenir **{{fmt_big_int drr_results}}** résultats. On a mesuré les progrès vers l'atteinte de ces résultats
-      à l'aide de **{{fmt_big_int drr_indicators}}** indicateurs, et un état du résultat a été associé à chaque indicateur
+      à l'aide de **{{fmt_big_int drr_indicators}}** indicateurs, et un {{gl_tt "état du résultat" "RESULTS_STATUS"}} a été associé à chaque indicateur
       selon la mesure du résultat prévu pour la cible de l'indicateur.
     {{/if}}
-    TODO: need french translation for this bit
 
 
 reports_links_text:


### PR DESCRIPTION
One possibility for improving the results summary.

Adds a donut plot to the main DRR summary, controllable with a graph legend in the usable way, that lets a user decide what the denominator should be for calculating result status %s.

