### PR TITLE
Refinements to last minute gov result panel banners

### DIFF
--- a/client/src/components/AlertBanner.js
+++ b/client/src/components/AlertBanner.js
@@ -1,0 +1,18 @@
+import './AlertBanner.scss';
+
+import classNames from 'classnames';
+
+const banner_classes = ['info', 'success', 'warning', 'danger'];
+export const AlertBanner = ({children, banner_class, additional_class_names, style}) => {
+  if ( banner_class && !_.includes(banner_classes, banner_class) ){
+    throw `AlertBanner received invalid banner_class prop of ${banner_class}`;
+  }
+
+  const banner_class_name = `alert-${banner_class || 'info'}`;
+
+  return (
+    <div className={classNames('ib-alert alert alert-no-symbol alert--is-bordered', banner_class_name, additional_class_names)} style={style}>
+      { children }
+    </div>
+  );
+};

--- a/client/src/components/AlertBanner.scss
+++ b/client/src/components/AlertBanner.scss
@@ -1,0 +1,7 @@
+.ib-alert {
+  // paragraph default bottom margin throws off alert padding, clobber it
+  & > p,
+  & > * > p {
+    margin: 0px;
+  }
+}

--- a/client/src/components/index.js
+++ b/client/src/components/index.js
@@ -33,6 +33,7 @@ export { WellList } from './WellList.js';
 export { DisplayTable } from './DisplayTable.js';
 export { LabeledTable } from './LabeledTable.js';
 export { FootnoteList } from './FootnoteList.js';
+export { AlertBanner } from './AlertBanner.js';
 
 export { StatelessModal, FixedPopover } from './modals_and_popovers';
 
@@ -47,7 +48,6 @@ export {
   lang,
   create_text_maker_component,
   DlItem,
-  AlertBanner,
   MultiColumnList,
 } from './misc_util_components.js';
 

--- a/client/src/components/misc_util_components.js
+++ b/client/src/components/misc_util_components.js
@@ -64,7 +64,7 @@ const AlertBanner = ({children, banner_class, additional_class_names, style}) =>
   const banner_class_name = `alert-${banner_class || 'info'}`;
 
   return (
-    <div className={ `alert alert-no-symbol alert--is-bordered ${banner_class_name} ${additional_class_names}` } style={style}>
+    <div className={classNames('alert alert-no-symbol alert--is-bordered', banner_class_name, additional_class_names)} style={style}>
       { children }
     </div>
   );

--- a/client/src/components/misc_util_components.js
+++ b/client/src/components/misc_util_components.js
@@ -55,21 +55,6 @@ const DlItem = ({ term, def }) => (
   </Fragment>
 );
 
-const banner_classes = ['info', 'success', 'warning', 'danger'];
-const AlertBanner = ({children, banner_class, additional_class_names, style}) => {
-  if ( banner_class && !_.includes(banner_classes, banner_class) ){
-    throw `AlertBanner received invalid banner_class prop of ${banner_class}`;
-  }
-
-  const banner_class_name = `alert-${banner_class || 'info'}`;
-
-  return (
-    <div className={classNames('alert alert-no-symbol alert--is-bordered', banner_class_name, additional_class_names)} style={style}>
-      { children }
-    </div>
-  );
-};
-
 const MultiColumnList = ({list_items, column_count=2, ul_class, li_class}) => (
   <div
     className={ul_class}
@@ -107,6 +92,5 @@ export {
   lang,
   create_text_maker_component,
   DlItem,
-  AlertBanner,
   MultiColumnList,
 };

--- a/client/src/panels/panel_declarations/results/gov_dp.js
+++ b/client/src/panels/panel_declarations/results/gov_dp.js
@@ -7,12 +7,10 @@ import {
   create_text_maker_component,
   InfographicPanel,
   get_source_links,
-  util_components,
 
   declare_panel,
 } from "../shared.js";
 const { Dept } = Subject;
-const { AlertBanner } = util_components;
 
 import {
   ResultCounts,
@@ -20,7 +18,10 @@ import {
   current_dp_key,
   result_docs,
 } from './results_common.js';
-import { HorizontalStatusTable } from './result_components.js';
+import {
+  HorizontalStatusTable,
+  LateDepartmentsBanner,
+} from './result_components.js';
 
 const { text_maker, TM } = create_text_maker_component(text);
 
@@ -34,14 +35,7 @@ const DpSummary = ({counts, verbose_gov_counts, counts_by_dept, late_dept_count}
   return (
     <Fragment>
       <div className="fcol-md-12 medium_panel_text">
-        { late_dept_count &&
-          <AlertBanner>
-            <TM 
-              k="gov_dp_late_dept_warning"
-              args={{late_dept_count}}
-            />
-          </AlertBanner>
-        }
+        { late_dept_count && <LateDepartmentsBanner late_dept_count={late_dept_count} /> }
         <TM 
           k="gov_dp_text"
           args={{

--- a/client/src/panels/panel_declarations/results/gov_dp.js
+++ b/client/src/panels/panel_declarations/results/gov_dp.js
@@ -35,7 +35,7 @@ const DpSummary = ({counts, verbose_gov_counts, counts_by_dept, late_dept_count}
   return (
     <Fragment>
       <div className="fcol-md-12 medium_panel_text">
-        { !!late_dept_count && <LateDepartmentsBanner late_dept_count={late_dept_count} /> }
+        { late_dept_count > 0 && <LateDepartmentsBanner late_dept_count={late_dept_count} /> }
         <TM 
           k="gov_dp_text"
           args={{

--- a/client/src/panels/panel_declarations/results/gov_dp.js
+++ b/client/src/panels/panel_declarations/results/gov_dp.js
@@ -35,7 +35,7 @@ const DpSummary = ({counts, verbose_gov_counts, counts_by_dept, late_dept_count}
   return (
     <Fragment>
       <div className="fcol-md-12 medium_panel_text">
-        { late_dept_count && <LateDepartmentsBanner late_dept_count={late_dept_count} /> }
+        { late_dept_count && late_dept_count > 0 && <LateDepartmentsBanner late_dept_count={late_dept_count} /> }
         <TM 
           k="gov_dp_text"
           args={{

--- a/client/src/panels/panel_declarations/results/gov_dp.js
+++ b/client/src/panels/panel_declarations/results/gov_dp.js
@@ -35,7 +35,7 @@ const DpSummary = ({counts, verbose_gov_counts, counts_by_dept, late_dept_count}
   return (
     <Fragment>
       <div className="fcol-md-12 medium_panel_text">
-        { late_dept_count && late_dept_count > 0 && <LateDepartmentsBanner late_dept_count={late_dept_count} /> }
+        { !!late_dept_count && <LateDepartmentsBanner late_dept_count={late_dept_count} /> }
         <TM 
           k="gov_dp_text"
           args={{

--- a/client/src/panels/panel_declarations/results/gov_dp.yaml
+++ b/client/src/panels/panel_declarations/results/gov_dp.yaml
@@ -12,11 +12,6 @@ gov_dp_text:
   fr: |
     En **{{year}}**, **{{fmt_big_int depts_with_dps}}** organisations comptent atteindre **{{fmt_big_int dp_results}}** résultats, mesurés par **{{fmt_big_int dp_indicators}}** indicateurs. L'évaluation du rendement par rapport à ces indicateurs fera l’objet d’un rapport à **l’automne {{drr_tabling_year}}**.
 
-gov_dp_late_dept_warning:
-  transform: [handlebars,markdown]
-  en: Totals below are incomplete, data is not yet available for **{{late_dept_count}}** organizations. Updates will follow.
-  fr: Les totaux ci-dessous sont incomplets, les données ne sont pas encore disponibles pour **{{late_dept_count}}** organisations. Des mises à jour suivront.
-
 gov_dp_above_search_bar_text:
   transform: [handlebars,markdown]
   en: |

--- a/client/src/panels/panel_declarations/results/gov_drr.js
+++ b/client/src/panels/panel_declarations/results/gov_drr.js
@@ -14,7 +14,10 @@ import {
   current_drr_key,
 } from './results_common.js';
 import { DrrSummary } from './drr_summary.js';
-import { HorizontalStatusTable } from './result_components.js';
+import {
+  HorizontalStatusTable,
+  LateDepartmentsBanner,
+} from './result_components.js';
 
 const { Gov, Dept } = Subject;
 
@@ -24,11 +27,17 @@ class GovDRR extends React.Component {
       counts_by_dept,
       gov_counts,
       num_depts,
-      verbose_gov_counts, 
+      verbose_gov_counts,
+      late_dept_count, 
     } = this.props;
 
     return (
       <div>
+        { late_dept_count && late_dept_count > 0 && 
+          <div className="medium_panel_text">
+            <LateDepartmentsBanner late_dept_count={late_dept_count} />
+          </div>
+        }
         <DrrSummary
           subject={Gov}
           verbose_counts={verbose_gov_counts}
@@ -84,12 +93,14 @@ export const declare_gov_drr_panel = () => declare_panel({
         .map( obj => ({...obj, total: d3.sum(_.values(obj.counts)) } ) )
         .value();
   
+      const late_dept_count = result_docs[current_drr_key].late_departments.length;
   
       return {
         gov_counts,
         counts_by_dept,
         verbose_gov_counts,
         num_depts,
+        late_dept_count,
       };
     },
   

--- a/client/src/panels/panel_declarations/results/gov_drr.js
+++ b/client/src/panels/panel_declarations/results/gov_drr.js
@@ -33,7 +33,7 @@ class GovDRR extends React.Component {
 
     return (
       <div>
-        { !!late_dept_count &&
+        { late_dept_count > 0 &&
           <div className="medium_panel_text">
             <LateDepartmentsBanner late_dept_count={late_dept_count} />
           </div>

--- a/client/src/panels/panel_declarations/results/gov_drr.js
+++ b/client/src/panels/panel_declarations/results/gov_drr.js
@@ -33,7 +33,7 @@ class GovDRR extends React.Component {
 
     return (
       <div>
-        { late_dept_count && late_dept_count > 0 && 
+        { !!late_dept_count &&
           <div className="medium_panel_text">
             <LateDepartmentsBanner late_dept_count={late_dept_count} />
           </div>

--- a/client/src/panels/panel_declarations/results/result_components.js
+++ b/client/src/panels/panel_declarations/results/result_components.js
@@ -551,9 +551,11 @@ const NewBadge = () => (
 );
 
 const LateDepartmentsBanner = ({late_dept_count}) => (
-  <AlertBanner>
+  <AlertBanner
+    style={{textAlign: 'center'}}
+  >
     <TM 
-      k="result_late_depts_warning"
+      k='result_late_depts_warning'
       args={{late_dept_count}}
     />
   </AlertBanner>

--- a/client/src/panels/panel_declarations/results/result_components.js
+++ b/client/src/panels/panel_declarations/results/result_components.js
@@ -33,6 +33,7 @@ const {
   HeightClipper,
   FilterTable,
   SortDirections,
+  AlertBanner,
 } = util_components;
 const { sanitized_marked } = general_utils;
 
@@ -543,13 +544,20 @@ class HorizontalStatusTable extends React.Component {
   }
 }
 
-const NewBadge = () => {
-  return (
-    <span className="badge badge--is-new-indicator">
-      {text_maker("new")}
-    </span>
-  );
-};
+const NewBadge = () => (
+  <span className="badge badge--is-new-indicator">
+    {text_maker("new")}
+  </span>
+);
+
+const LateDepartmentsBanner = ({late_dept_count}) => (
+  <AlertBanner>
+    <TM 
+      k="result_late_depts_warning"
+      args={{late_dept_count}}
+    />
+  </AlertBanner>
+);
 
 export {
   IndicatorDisplay,
@@ -563,4 +571,5 @@ export {
   HorizontalStatusTable,
   NewBadge,
   IndicatorResultDisplay,
+  LateDepartmentsBanner,
 }; 

--- a/client/src/panels/panel_declarations/results/result_components.yaml
+++ b/client/src/panels/panel_declarations/results/result_components.yaml
@@ -29,3 +29,8 @@ indicator_display_desc:
 report:
   en: Report
   fr: Rapport
+
+result_late_depts_warning:
+  transform: [handlebars,markdown]
+  en: Totals below are incomplete, data is not yet available for **{{late_dept_count}}** {{plural_branch late_dept_count "organization" "organizations"}}. Updates will follow.
+  fr: Les totaux ci-dessous sont incomplets, les données ne sont pas encore disponibles pour **{{late_dept_count}}** {{plural_branch late_dept_count "organisation" "organisations"}}. Des mises à jour suivront.


### PR DESCRIPTION
Wanted short banners INSIDE the gov level results panels, to re-state that totals are not final when any departments are late. Slapped together in master to release with the DP, but refined and made automatic (for both DRR and DP) here. 