### PR TITLE
Nivo tooltips should use name, not id

### DIFF
--- a/client/src/charts/NivoCharts.js
+++ b/client/src/charts/NivoCharts.js
@@ -45,21 +45,21 @@ const get_scale_bounds = (stacked, raw_data, zoomed) => {
 
 const smalldevice_tooltip_content = (tooltip_item, formatter) => (
   <td>
-    <div className="nivo-tooltip__content"> {tooltip_item.id} </div>
+    <div className="nivo-tooltip__content"> {tooltip_item.name || tooltip_item.id} </div>
     <div className="nivo-tooltip__content" dangerouslySetInnerHTML={{__html: formatter(tooltip_item.value)}} />
   </td>
 );
 
 const tooltip_content = (tooltip_item, formatter) => (
   <Fragment>
-    <td className="nivo-tooltip__content"> {tooltip_item.id} </td>
+    <td className="nivo-tooltip__content"> {tooltip_item.name || tooltip_item.id} </td>
     <td className="nivo-tooltip__content" dangerouslySetInnerHTML={{__html: formatter(tooltip_item.value)}} />
   </Fragment>
 );
 
 const smalldevice_percent_tooltip_content = (tooltip_item, formatter, total) => (
   <td>
-    <div className="nivo-tooltip__content">{tooltip_item.id}</div>
+    <div className="nivo-tooltip__content">{tooltip_item.name || tooltip_item.id}</div>
     <div className="nivo-tooltip__content" dangerouslySetInnerHTML = {{__html: formatter(tooltip_item.value)}}/>
     <div className="nivo-tooltip__content" dangerouslySetInnerHTML = {{__html: formats.percentage1(Math.abs(tooltip_item.value)/total)}}/>
   </td>
@@ -67,7 +67,7 @@ const smalldevice_percent_tooltip_content = (tooltip_item, formatter, total) => 
 
 const percent_tooltip_content = (tooltip_item, formatter, total) => (
   <Fragment>
-    <td className="nivo-tooltip__content">{tooltip_item.id}</td>
+    <td className="nivo-tooltip__content">{tooltip_item.name || tooltip_item.id}</td>
     <td className="nivo-tooltip__content" dangerouslySetInnerHTML = {{__html: formatter(tooltip_item.value)}}/>
     <td className="nivo-tooltip__content" dangerouslySetInnerHTML = {{__html: formats.percentage1(Math.abs(tooltip_item.value)/total)}}/>
   </Fragment>


### PR DESCRIPTION
I don't know why it was set up this way but the default behaviour is for tooltips to use the `id` of the data slice instead of the `name`. All (most?) graphs have dealt with this by setting the `id` to be the human-friendly, bilingual `name` but that's awkward for some purposes, especially graph interactions with external components like the legend.

In an ideal world all tooltips would use the `name` and completely ignore the `id`, but I don't want to manually check that every single graph has set the name properly, so for a fix I use the `name` if it's set or fallback to the `id`.