### PR TITLE
Late resource orgs footnote/banner refinement 

### DIFF
--- a/client/src/models/footnotes/dynamic_footnotes.js
+++ b/client/src/models/footnotes/dynamic_footnotes.js
@@ -46,15 +46,21 @@ const get_dynamic_footnotes = () => {
           topic_keys: result_or_resource === 'resources' ?
             ['PLANNED_EXP', 'DP_EXP'] :
             [`${_.toUpper(doc_type)}_RESULTS`],
-          text: `<p>${text_maker(`late_${result_or_resource}_warning_gov`, {result_doc_name: text_maker(`${doc_type}_name`, {year})} )}</p>${
-            `<ul>${
-              _.reduce(
-                late_orgs,
-                (elements, org_id) => `${elements}<li>${Dept.lookup(org_id).fancy_name}</li>`,
-                ''
-              )
-            }</ul>`
-          }`,
+          text: (
+            `<p>
+            ${text_maker(
+              `late_${result_or_resource}_warning_gov`,
+              {result_doc_name: text_maker(`${doc_type}_name`, {year})}
+            )}
+            </p>
+            <ul>
+            ${_.reduce(
+              late_orgs,
+              (elements, org_id) => `${elements}<li>${Dept.lookup(org_id).fancy_name}</li>`,
+              ''
+            )}
+            </ul>`
+          ),
         })
       );
 

--- a/client/src/models/footnotes/dynamic_footnotes.yaml
+++ b/client/src/models/footnotes/dynamic_footnotes.yaml
@@ -29,15 +29,15 @@ late_results_warning_crso:
   fr: Les données du {{result_doc_name}} de cette responsabilité essentielle ne sont pas encore disponibles. Une mise à jour suivra.
 
 
-late_planned_spending_warning_gov:
-  en: Planned spending data does not include values from the organizations listed below, as their data is not yet available. Updates will follow.
+late_resources_warning_gov:
+  en: Planned spending and planned FTE data does not include values from the organizations listed below, as their data is not yet available. Updates will follow.
   fr: Dépenses planifiées des organisations ci-dessous ne sont pas encore disponibles. Des mises à jour suivront au fur et à mesure de la transmission de ces données.
-late_planned_spending_warning_dept:
-  en: Planned spending for this organization is not yet available. An update will follow.
-  fr: Dépenses planifiées pour cette organisation ne sont pas encore disponibles. Une mise à jour suivra.
-late_planned_spending_warning_program:
-  en: Planned spending for this Program is not yet available. An update will follow.
-  fr: Dépenses planifiées pour ce programme ne sont pas encore disponibles. Une mise à jour suivra.
-late_planned_spending_warning_crso:
-  en: Planned spending for this Core Responsibility is not yet available. An update will follow.
-  fr: Dépenses planifiées pour cette responsabilité essentielle ne sont pas encore disponibles. Une mise à jour suivra.
+late_resources_warning_dept:
+  en: Planned spending and planned FTE for this organization is not yet available. An update will follow.
+  fr: Dépenses planifiées et ETP prévus pour cette organisation ne sont pas encore disponibles. Une mise à jour suivra.
+late_resources_warning_program:
+  en: Planned spending and planned FTE for this Program is not yet available. An update will follow.
+  fr: Dépenses planifiées et ETP prévus pour ce programme ne sont pas encore disponibles. Une mise à jour suivra.
+late_resources_warning_crso:
+  en: Planned spending and planned FTE for this Core Responsibility is not yet available. An update will follow.
+  fr: Dépenses planifiées et ETP prévus pour cette responsabilité essentielle ne sont pas encore disponibles. Une mise à jour suivra.

--- a/client/src/models/results.js
+++ b/client/src/models/results.js
@@ -342,9 +342,9 @@ const build_doc_info_objects = (doc_type, docs) => _.chain(docs)
         resource_years,
       } = doc_properties;
 
-      const primary_resource_year = doc_type === "drr" ? 
-        _.last(resource_years) :
-        _.first(resource_years);
+      const is_drr = doc_type === "drr";
+
+      const primary_resource_year = is_drr ? _.last(resource_years) : _.first(resource_years);
 
       return {
         doc_type,
@@ -357,6 +357,9 @@ const build_doc_info_objects = (doc_type, docs) => _.chain(docs)
         has_resources: !_.isEmpty(resource_years),
         could_have_previous: index > 0,
         ...doc_properties,
+        ...( // "DRR resources" are fully decoupled from DRR tabling, come from public accounts. Don't allow late_resources_orgs to be populated on a DRR
+          is_drr && {late_resources_orgs: []} 
+        ),
       };
     }
   )
@@ -372,7 +375,7 @@ const drr_docs = build_doc_info_objects(
       resource_years: ["{{pa_last_year}}"],
       doc_url_en: "https://www.canada.ca/en/treasury-board-secretariat/services/departmental-performance-reports/2018-19-departmental-results-reports.html",
       doc_url_fr: "https://www.canada.ca/fr/secretariat-conseil-tresor/services/rapports-ministeriels-rendement/rapport-resultats-ministeriels-2018-2019.html",
-      late_departments: [],
+      late_results_orgs: [],
     },
   ]
 );
@@ -384,14 +387,16 @@ const dp_docs = build_doc_info_objects(
       resource_years: [],
       doc_url_en: "https://www.canada.ca/en/treasury-board-secretariat/services/planned-government-spending/reports-plans-priorities/2019-20-departmental-plans.html",
       doc_url_fr: "https://www.canada.ca/fr/secretariat-conseil-tresor/services/depenses-prevues/rapports-plans-priorites/plans-ministeriels-2019-2020.html",
-      late_departments: [],
+      late_results_orgs: [],
+      late_resources_orgs: [],
     },
     {
       year_short: "2020",
       resource_years: ["{{planning_year_1}}", "{{planning_year_2}}", "{{planning_year_3}}"],
       doc_url_en: "https://www.canada.ca/en/treasury-board-secretariat/services/planned-government-spending/reports-plans-priorities/2020-21-departmental-plans.html",
       doc_url_fr: "https://www.canada.ca/fr/secretariat-conseil-tresor/services/depenses-prevues/rapports-plans-priorites/plans-ministeriels-2020-2021.html",
-      late_departments: [241],
+      late_results_orgs: [241],
+      late_resources_orgs: [],
     },
   ]
 );

--- a/client/src/panels/get_panels_for_subject/get_crso_panels.js
+++ b/client/src/panels/get_panels_for_subject/get_crso_panels.js
@@ -8,7 +8,7 @@ import {
   // shared gov, dept, crso, program
   declare_results_key_concepts_panel,
   declare_late_results_warning_panel,
-  declare_late_planned_spending_panel,
+  declare_late_resources_panel,
   declare_budget_measures_panel,
 
   // shared dept, crso, program, tag
@@ -41,7 +41,7 @@ export const get_crso_panels = subject => ensure_loaded({
     declare_crso_in_gov_panel(),
   ],
   financial: [
-    declare_late_planned_spending_panel(),
+    declare_late_resources_panel(),
     declare_dead_crso_warning_panel(),
     declare_financial_key_concepts_panel(),
     declare_welcome_mat_panel(),

--- a/client/src/panels/get_panels_for_subject/get_dept_panels.js
+++ b/client/src/panels/get_panels_for_subject/get_dept_panels.js
@@ -8,7 +8,7 @@ import {
   // shared gov, dept, crso, program
   declare_results_key_concepts_panel,
   declare_late_results_warning_panel,
-  declare_late_planned_spending_panel,
+  declare_late_resources_panel,
   declare_budget_measures_panel,
 
   // shared dept, crso, program, tag
@@ -64,7 +64,7 @@ export const get_dept_panels = subject => ensure_loaded({
     declare_portfolio_structure_intro_panel(),
   ],
   financial: _.includes(subject.tables, 'programSpending') && [
-    declare_late_planned_spending_panel(),
+    declare_late_resources_panel(),
     declare_financial_key_concepts_panel(),
     declare_welcome_mat_panel(),
     // RTP_TODO: declare_tp_by_region_panel(),

--- a/client/src/panels/get_panels_for_subject/get_gov_panels.js
+++ b/client/src/panels/get_panels_for_subject/get_gov_panels.js
@@ -6,7 +6,7 @@ import {
   // shared gov, dept, crso, program
   declare_results_key_concepts_panel,
   declare_late_results_warning_panel,
-  declare_late_planned_spending_panel,
+  declare_late_resources_panel,
   declare_budget_measures_panel,
 
   // shared gov, dept
@@ -42,7 +42,7 @@ export const get_gov_panels = subject => ({
     declare_simplographic_panel(),
   ],
   financial: [
-    declare_late_planned_spending_panel(),
+    declare_late_resources_panel(),
     declare_financial_key_concepts_panel(),
     declare_welcome_mat_panel(),
     // RTP_TODO: declare_tp_by_region_panel(),

--- a/client/src/panels/get_panels_for_subject/get_program_panels.js
+++ b/client/src/panels/get_panels_for_subject/get_program_panels.js
@@ -8,7 +8,7 @@ import {
   // shared gov, dept, crso, program
   declare_results_key_concepts_panel,
   declare_late_results_warning_panel,
-  declare_late_planned_spending_panel,
+  declare_late_resources_panel,
   declare_budget_measures_panel,
 
   // shared dept, crso, program, tag
@@ -45,7 +45,7 @@ export const get_program_panels = subject => ensure_loaded({
     declare_program_fed_structure_panel(),
   ],
   financial: [
-    declare_late_planned_spending_panel(),
+    declare_late_resources_panel(),
     declare_dead_program_warning_panel(),
     declare_financial_key_concepts_panel(),
     declare_welcome_mat_panel(),

--- a/client/src/panels/panel_declarations/index.js
+++ b/client/src/panels/panel_declarations/index.js
@@ -46,7 +46,7 @@ export {
   declare_crso_in_gov_panel,
   declare_crso_links_to_other_crso_panel,
   declare_late_results_warning_panel,
-  declare_late_planned_spending_panel,
+  declare_late_resources_panel,
   declare_m2m_tag_warning_panel,
   declare_dead_program_warning_panel,
   declare_dead_crso_warning_panel,

--- a/client/src/panels/panel_declarations/misc/index.js
+++ b/client/src/panels/panel_declarations/misc/index.js
@@ -23,7 +23,7 @@ export {
   declare_dead_crso_warning_panel,
   declare_m2m_tag_warning_panel,
   declare_late_results_warning_panel,
-  declare_late_planned_spending_panel,
+  declare_late_resources_panel,
 } from './warning_panels.js';
 
 export { declare_resource_structure_panel } from './resource_structure/resource_structure.js';

--- a/client/src/panels/panel_declarations/results/gov_dp.js
+++ b/client/src/panels/panel_declarations/results/gov_dp.js
@@ -77,7 +77,7 @@ export const declare_gov_dp_panel = () => declare_panel({
         .map( obj => ({...obj, total: d3.sum(_.values(obj.counts)) } ) )
         .value();
   
-      const late_dept_count = result_docs[current_dp_key].late_departments.length;
+      const late_dept_count = result_docs[current_dp_key].late_results_orgs.length;
 
       return { 
         verbose_gov_counts,

--- a/client/src/panels/panel_declarations/results/gov_drr.js
+++ b/client/src/panels/panel_declarations/results/gov_drr.js
@@ -93,7 +93,7 @@ export const declare_gov_drr_panel = () => declare_panel({
         .map( obj => ({...obj, total: d3.sum(_.values(obj.counts)) } ) )
         .value();
   
-      const late_dept_count = result_docs[current_drr_key].late_departments.length;
+      const late_dept_count = result_docs[current_drr_key].late_results_orgs.length;
   
       return {
         gov_counts,


### PR DESCRIPTION
More chasing down of this that I had to rush for the DP update. Arguably, the only necessary change here was correcting "late planned spending data" to "late planned spending and planned FTE data". Everything else was just coding principles.