### PR TITLE
Indicator status graph fix

### DIFF
--- a/client/src/panels/panel_declarations/results/drr_summary.js
+++ b/client/src/panels/panel_declarations/results/drr_summary.js
@@ -201,14 +201,14 @@ class PercentageViz extends React.Component {
     const { counts } = this.props;
     const { selected } = this.state;
 
-    const all_data = _.map(
-      counts,
-      (value, key) => ({
+    const all_data = _.chain(counts)
+      .map( (value, key) => ({
         name: result_statuses[key].text,
         id: key,
         value,
-      })
-    );
+      }) )
+      .filter( status => status.value > 0 )
+      .value();
     
     const all_data_total = _.sumBy(all_data, 'value');
 

--- a/client/src/panels/panel_declarations/results/drr_summary.js
+++ b/client/src/panels/panel_declarations/results/drr_summary.js
@@ -209,7 +209,7 @@ class PercentageViz extends React.Component {
       .filter( status => status.value > 0 )
       .value();
 
-    const selected = !(all_data.length === 1 && all_data[0].id === "future") ? this.state.selected : _.keys(counts); // override selected if there are only future indicators
+    const selected = _.some(all_data, ({id}) => id !== "future") ? this.state.selected : _.keys(counts); // override selected if there are only future indicators
 
     const all_data_total = _.sumBy(all_data, 'value');
 

--- a/client/src/panels/panel_declarations/results/drr_summary.js
+++ b/client/src/panels/panel_declarations/results/drr_summary.js
@@ -199,7 +199,6 @@ class PercentageViz extends React.Component {
 
   render(){
     const { counts } = this.props;
-    const { selected } = this.state;
 
     const all_data = _.chain(counts)
       .map( (value, key) => ({
@@ -209,7 +208,9 @@ class PercentageViz extends React.Component {
       }) )
       .filter( status => status.value > 0 )
       .value();
-    
+
+    const selected = !(all_data.length === 1 && all_data[0].id === "future") ? this.state.selected : _.keys(counts); // override selected if there are only future indicators
+
     const all_data_total = _.sumBy(all_data, 'value');
 
     const graph_data = _.filter(all_data, d=>_.includes(selected,d.id));


### PR DESCRIPTION
- only show legend items that are in the data
- if there are only future indicators, default to future is selected (instead of everything but future)

Useful test cases:

- [Office of the Public Sector Integrity Commissioner -- only NA](http://dev.ea-ad.ca/results_graph_fix/index-eng.html#orgs/dept/250/infograph/results)
- [Dairy Programs (AGR) -- only future](http://dev.ea-ad.ca/results_graph_fix/index-eng.html#orgs/program/AGR-BWN04/infograph/results)