### PR TITLE
Fix server logs

### DIFF
--- a/client/src/graphql_utils/graphql_utils.js
+++ b/client/src/graphql_utils/graphql_utils.js
@@ -36,9 +36,11 @@ export const get_api_url = async () => {
 // Makes our GET requests tolerant of long queries, sufficient but may not work for arbitrarily long queries
 export const query_length_tolerant_fetch = async (uri, options) => {
 
-  // important, this regex lazy matches up to and including FIRST ? occurence, although I hope there aren't ?'s in our queries...
+  // important, this regex lazy matches up to and including FIRST ? occurence, which (in a URI)
+  // should be where the query string starts. I've complicated it slightly just in case there's ever a ? IN
+  // the query string (well, that'd be an encoding error anyway)
   const url_encoded_query = uri.replace(/^(.*?)\?/, '');
-  
+
   const query_string_hash = string_hash(url_encoded_query);
 
   const short_uri = `${await get_api_url()}?v=${window.sha}&queryHash=${query_string_hash}`;

--- a/client/src/graphql_utils/graphql_utils.js
+++ b/client/src/graphql_utils/graphql_utils.js
@@ -35,7 +35,10 @@ export const get_api_url = async () => {
 
 // Makes our GET requests tolerant of long queries, sufficient but may not work for arbitrarily long queries
 export const query_length_tolerant_fetch = async (uri, options) => {
-  const url_encoded_query = uri.split("?query=")[1];
+
+  // important, this regex lazy matches up to and including FIRST ? occurence, although I hope there aren't ?'s in our queries...
+  const url_encoded_query = uri.replace(/^(.*?)\?/, '');
+  
   const query_string_hash = string_hash(url_encoded_query);
 
   const short_uri = `${await get_api_url()}?v=${window.sha}&queryHash=${query_string_hash}`;

--- a/server/src/server_utils.js
+++ b/server/src/server_utils.js
@@ -4,9 +4,9 @@ import md5 from 'md5';
 
 import _ from 'lodash';
   
-const quiet_failing_json_parse = (json_String) => {
+const quiet_failing_json_parse = (json_string) => {
   try {
-    return JSON.parse(json_String);
+    return JSON.parse(json_string);
   } catch(erro){
     return {};
   }

--- a/server/src/server_utils.js
+++ b/server/src/server_utils.js
@@ -1,4 +1,5 @@
 import { decompressFromBase64 } from 'lz-string';
+import { decode } from 'querystring';
 import md5 from 'md5';
 
 import _ from 'lodash';
@@ -6,8 +7,8 @@ import _ from 'lodash';
 // Side effect alert: this function mutates the suplied request object so that the conversion persists to subsequent server midleware
 // ... bit of a hack, and I'm not just talking about a function having side effects
 export const convert_GET_with_compressed_query_to_POST = (req) => {
-  const decoded_decompressed_query = decompressFromBase64(req.headers['encoded-compressed-query']);
-  const [query, variables] = decoded_decompressed_query.split("&variables=");
+  const decompressed_query = decompressFromBase64(req.headers['encoded-compressed-query']);
+  const {query, variables} = decode(decompressed_query);
 
   req.method = "POST";
   req.body = {

--- a/server/src/server_utils.unit-test.js
+++ b/server/src/server_utils.unit-test.js
@@ -36,7 +36,7 @@ describe("convert_GET_with_compressed_query_to_POST", function(){
       },
       body: { 
         query,
-        variables: variable_string,
+        variables: JSON.parse(variable_string),
         operationName: null,
       },
     };

--- a/server/src/server_utils.unit-test.js
+++ b/server/src/server_utils.unit-test.js
@@ -52,7 +52,7 @@ describe("get_log_object_for_request", function(){
       headers: {
         origin: "test",
       },
-      query_object,
+      query: query_object,
     };
 
     const log_object = get_log_object_for_request(GET_request);


### PR DESCRIPTION
Those messy hotfixes on master last Friday didn't fix anything.

This code's always been a real headache because, it turns out, I've had an inconsistent picture of what/how these request objects should look in practice (doesn't help that there are so many dang cases, and hacky things going on with the compressed GET requests).

Should probably rethink all of this, or at least capture and normalize all the special cases in a single place, instead of juggling every special case in every different util function/test. That's out of scope for this PR though.