### PR TITLE
Create "smart" percent formatter with flexible precision

### DIFF
--- a/client/src/core/format.js
+++ b/client/src/core/format.js
@@ -12,8 +12,8 @@ const money_formatter = {
   fr: _.map(Array(3), (val,ix) => new Intl.NumberFormat('fr-CA', {style: 'currency', currency: 'CAD', minimumFractionDigits: ix, maximumFractionDigits: ix}) ),
 };
 const percent_formatter = {
-  en: _.map(Array(3), (val,ix) => new Intl.NumberFormat('en-CA', {style: 'percent', minimumFractionDigits: ix, maximumFractionDigits: ix}) ),
-  fr: _.map(Array(3), (val,ix) => new Intl.NumberFormat('fr-CA', {style: 'percent', minimumFractionDigits: ix, maximumFractionDigits: ix}) ),
+  en: _.map(Array(4), (val,ix) => new Intl.NumberFormat('en-CA', {style: 'percent', minimumFractionDigits: ix, maximumFractionDigits: ix}) ),
+  fr: _.map(Array(4), (val,ix) => new Intl.NumberFormat('fr-CA', {style: 'percent', minimumFractionDigits: ix, maximumFractionDigits: ix}) ),
 };
 
 // results need to be displayed with the number of digits they are entered in. We don't do any rounding!
@@ -128,6 +128,19 @@ const percentage = (precision, val, lang, options) => {
   }
 };
 
+// 'smart' percent formatter that scales decimal places (up to 3) based on the value
+const percentage_smart = (min_precision, val, lang, options) => {
+  const smart_precision = val < 0.001 ? 3 :
+    (val < 0.01 ? 2 : 1);
+  const precision = (min_precision && min_precision > smart_precision) ? min_precision : smart_precision;
+  const rtn = percent_formatter[lang][precision].format(val);
+  if (options.raw){
+    return rtn;
+  }else {
+    return `<span class='text-nowrap'>${rtn}</span>`;
+  }
+};
+
 const types_to_format = {
   "compact": (val, lang, options) => compact(options.precision, val, lang, options),
   "compact1": _.curry(compact)(1),
@@ -138,6 +151,8 @@ const types_to_format = {
   "percentage": (val, lang, options) => percentage(options.precision, val, lang, options),
   "percentage1": _.curry(percentage)(1),
   "percentage2": _.curry(percentage)(2),
+  "smart_percentage1": _.curry(percentage_smart)(1),
+  "smart_percentage2": _.curry(percentage_smart)(2),
   "result_percentage": (val, lang) => result_percent_formatter[lang].format(val/100),
   "result_num": (val, lang) => result_number_formatter[lang].format(val),
   "decimal1": (val, lang, options) => number_formatter[lang][1].format(val),

--- a/client/src/panels/panel_declarations/finances/transfer_payments/gnc-text.yaml
+++ b/client/src/panels/panel_declarations/finances/transfer_payments/gnc-text.yaml
@@ -18,11 +18,11 @@ last_year_g_and_c_perspective_title:
 dept_last_year_g_and_c_perspective_text:
   transform: [handlebars,markdown]
   en: |
-   In {{pa_last_year}}, **{{subj_name subject}}** spent **{{fmt_compact1_written dept_tp_exp_pa_last_year}}** (or **{{fmt_percentage1 dept_tp_exp_ratio_pa_last_year}}** of total spending) on transfer payments. 
-   Transfer payment made by **{{subj_name subject}}** accounted for **{{fmt_percentage1 dept_tp_exp_ratio_gov_pa_last_year}}** of the total of **{{fmt_compact1_written gov_tp_exp_pa_last_year}}** spent on transfer payments by the government as a whole.
+   In {{pa_last_year}}, **{{subj_name subject}}** spent **{{fmt_compact1_written dept_tp_exp_pa_last_year}}** (or **{{fmt_smart_percentage1 dept_tp_exp_ratio_pa_last_year}}** of total spending) on transfer payments. 
+   Transfer payment made by **{{subj_name subject}}** accounted for **{{fmt_smart_percentage1 dept_tp_exp_ratio_gov_pa_last_year}}** of the total of **{{fmt_compact1_written gov_tp_exp_pa_last_year}}** spent on transfer payments by the government as a whole.
   fr: |
-   En {{pa_last_year}}, **{{subj_name subject}}** a dépensé **{{fmt_compact1_written dept_tp_exp_pa_last_year}}** (ou **{{fmt_percentage1 dept_tp_exp_ratio_pa_last_year}}** des dépenses totales) en paiements de transfert. 
-   Ce montant représentait **{{fmt_percentage1 dept_tp_exp_ratio_gov_pa_last_year}}** des dépenses totales du gouvernement en paiements de transfert de **{{fmt_compact1_written gov_tp_exp_pa_last_year}}**.
+   En {{pa_last_year}}, **{{subj_name subject}}** a dépensé **{{fmt_compact1_written dept_tp_exp_pa_last_year}}** (ou **{{fmt_smart_percentage1 dept_tp_exp_ratio_pa_last_year}}** des dépenses totales) en paiements de transfert. 
+   Ce montant représentait **{{fmt_smart_percentage1 dept_tp_exp_ratio_gov_pa_last_year}}** des dépenses totales du gouvernement en paiements de transfert de **{{fmt_compact1_written gov_tp_exp_pa_last_year}}**.
 
 gov_historical_g_and_c_text:
   transform: [handlebars,markdown]

--- a/client/src/panels/panel_declarations/finances/vote_stat/vote_stat_text.yaml
+++ b/client/src/panels/panel_declarations/finances/vote_stat/vote_stat_text.yaml
@@ -139,7 +139,7 @@ estimates_perspective_text:
   transform: [handlebars,markdown]
   en: |
    As of the {{est_in_year}} {{last_estimates}}, the government has presented Parliament with planned {{gl_tt "budgetary" 'BUD_EXP'}} expenditure estimates
-   totaling **{{fmt_compact1_written gov_tabled_est_in_year}}**. Of this amount, **{{fmt_compact1_written dept_tabled_est_in_year_estimates}}** (or **{{fmt_percentage1 (divide dept_tabled_est_in_year_estimates gov_tabled_est_in_year)}}**) will be allocated to **{{subj_name subject}}**.
+   totaling **{{fmt_compact1_written gov_tabled_est_in_year}}**. Of this amount, **{{fmt_compact1_written dept_tabled_est_in_year_estimates}}** (or **{{fmt_smart_percentage1 (divide dept_tabled_est_in_year_estimates gov_tabled_est_in_year)}}**) will be allocated to **{{subj_name subject}}**.
 
    {{! only to be used near year end when a main estimates for the following year has been tabled}}
    {{#if false}}

--- a/client/src/panels/panel_declarations/finances/vote_stat/vote_stat_text.yaml
+++ b/client/src/panels/panel_declarations/finances/vote_stat/vote_stat_text.yaml
@@ -150,7 +150,7 @@ estimates_perspective_text:
    {{/if}}
 
   fr: |
-   En date du {{last_estimates}} {{est_in_year}}, le gouvernement a présenté au Parlement des dépenses budgétaires prévues d'un total de **{{fmt_compact1_written gov_tabled_est_in_year}}**. De ce montant, **{{fmt_compact1_written dept_tabled_est_in_year_estimates}}** (ou **{{fmt_percentage1 (divide dept_tabled_est_in_year_estimates gov_tabled_est_in_year)}}**) seront attribués à **{{subj_name subject}}**. 
+   En date du {{last_estimates}} {{est_in_year}}, le gouvernement a présenté au Parlement des dépenses budgétaires prévues d'un total de **{{fmt_compact1_written gov_tabled_est_in_year}}**. De ce montant, **{{fmt_compact1_written dept_tabled_est_in_year_estimates}}** (ou **{{fmt_smart_percentage1 (divide dept_tabled_est_in_year_estimates gov_tabled_est_in_year)}}**) seront attribués à **{{subj_name subject}}**. 
 
 
    {{! only to be used near year end when a main estimates for the following year has been tabled}}

--- a/client/src/panels/panel_declarations/people/employee_last_year_totals.yaml
+++ b/client/src/panels/panel_declarations/people/employee_last_year_totals.yaml
@@ -7,7 +7,8 @@ dept_employee_last_year_totals_text:
   transform: [handlebars,markdown]
   en: |
     In **{{ppl_last_year}}**, **{{fmt_big_int dept_head_count_ppl_last_year}}**  {{gl_tt "people" "HEAD"}} were employed by **{{subj_name subject}}**, 
-    representing **{{fmt_percentage1 dept_head_count_dept_share_last_year}}** of the total {{gl_tt "Federal Public Service" "FPS"}} population. 
+    representing **{{fmt_smart_percentage1 dept_head_count_dept_share_last_year}}** of the total {{gl_tt "Federal Public Service" "FPS"}} population. 
 
   fr: |
-    En **{{ppl_last_year}}**, **{{fmt_big_int dept_head_count_ppl_last_year}}** {{gl_tt "personnes" "HEAD"}}  étaient à l’emploi **{{de_dept dept}}**, soit **{{fmt_percentage1 dept_head_count_dept_share_last_year}}** de l’effectif de la {{gl_tt "fonction publique fédérale" "FPS"}}.
+    En **{{ppl_last_year}}**, **{{fmt_big_int dept_head_count_ppl_last_year}}** {{gl_tt "personnes" "HEAD"}}  étaient à l’emploi **{{de_dept dept}}**,
+    soit **{{fmt_smart_percentage1 dept_head_count_dept_share_last_year}}** de l’effectif de la {{gl_tt "fonction publique fédérale" "FPS"}}.


### PR DESCRIPTION
To improve things for smaller orgs where rounding tends to screw up percentages.

Before:
(note that the LiquidFillGauge text doesn't use our formatter, so formats incorrectly in French, whoops. Look at the text, not the graph.)

![Screen Shot 2020-03-25 at 11 21 43 AM](https://user-images.githubusercontent.com/10406459/77553192-dd908680-6e8a-11ea-9d6c-da86d767d1ba.png)

After:

![Screen Shot 2020-03-25 at 11 21 51 AM](https://user-images.githubusercontent.com/10406459/77553201-e1240d80-6e8a-11ea-9690-60c81b30c81b.png)

