### PR TITLE
Fix DRR table percentages

### DIFF
--- a/client/src/charts/wrapped_nivo/nivo_pie.js
+++ b/client/src/charts/wrapped_nivo/nivo_pie.js
@@ -32,6 +32,7 @@ export class NivoResponsivePie extends React.Component {
       display_horizontal,
       disable_table_view,
       table_name,
+      show_legend,
     } = this.props;
 
     const color_scale = infobase_colors_smart(
@@ -141,22 +142,24 @@ export class NivoResponsivePie extends React.Component {
         <div className="infobase-pie__legend">
           <div className="centerer">
             <div className="centerer-IE-fix">
-              <TabularLegend
-                items={legend_items}
-                get_right_content={(item) => (
-                  <div>
-                    <span className="infobase-pie__legend-data">
-                      <Format type="compact1" content={item.value} />
-                    </span>
-                    <span className="infobase-pie__legend-data">
-                      <Format
-                        type="percentage1"
-                        content={item.value / graph_total}
-                      />
-                    </span>
-                  </div>
-                )}
-              />
+              {show_legend && (
+                <TabularLegend
+                  items={legend_items}
+                  get_right_content={(item) => (
+                    <div>
+                      <span className="infobase-pie__legend-data">
+                        <Format type="compact1" content={item.value} />
+                      </span>
+                      <span className="infobase-pie__legend-data">
+                        <Format
+                          type="percentage1"
+                          content={item.value / graph_total}
+                        />
+                      </span>
+                    </div>
+                  )}
+                />
+              )}
             </div>
           </div>
         </div>

--- a/client/src/charts/wrapped_nivo/nivo_pie.js
+++ b/client/src/charts/wrapped_nivo/nivo_pie.js
@@ -57,15 +57,15 @@ export class NivoResponsivePie extends React.Component {
       original_value: data.value,
     }));
 
-    const legend_total = _.reduce(
-      legend_data,
+    const graph_total = _.reduce(
+      data,
       (sum, { value }) => sum + Math.abs(value),
       0
     );
 
     const table_data = _.map(data, (row) => ({
       label: row.label,
-      percentage: row.value / legend_total,
+      percentage: row.value / graph_total,
       value: row.value,
     }));
     const column_configs = {
@@ -152,7 +152,7 @@ export class NivoResponsivePie extends React.Component {
                     <span className="infobase-pie__legend-data">
                       <Format
                         type="percentage1"
-                        content={item.value / legend_total}
+                        content={item.value / graph_total}
                       />
                     </span>
                   </div>

--- a/client/src/charts/wrapped_nivo/nivo_pie.js
+++ b/client/src/charts/wrapped_nivo/nivo_pie.js
@@ -180,4 +180,5 @@ NivoResponsivePie.defaultProps = {
     left: 50,
   },
   include_percent: true,
+  show_legend: true,
 };

--- a/client/src/charts/wrapped_nivo/nivo_pie.js
+++ b/client/src/charts/wrapped_nivo/nivo_pie.js
@@ -20,7 +20,6 @@ export class NivoResponsivePie extends React.Component {
   render() {
     const {
       data,
-      legend_data,
       graph_height,
       colors,
       colorBy,
@@ -40,7 +39,7 @@ export class NivoResponsivePie extends React.Component {
     );
     const color_func = colorBy || ((d) => color_scale(d.label));
 
-    const legend_items = _.chain(legend_data)
+    const legend_items = _.chain(data)
       .sortBy("value")
       .reverse()
       .map(({ value, label }) => ({

--- a/client/src/panels/panel_declarations/finances/drr_dp_resources/spending_in_perspective.js
+++ b/client/src/panels/panel_declarations/finances/drr_dp_resources/spending_in_perspective.js
@@ -98,6 +98,7 @@ class SpendInTagPerspective extends React.Component {
           <NivoResponsivePie
             data={data}
             colorBy={(obj) => color_scale(obj.label)}
+            show_legend={true}
           />
         </div>
       </div>

--- a/client/src/panels/panel_declarations/finances/drr_dp_resources/spending_in_perspective.js
+++ b/client/src/panels/panel_declarations/finances/drr_dp_resources/spending_in_perspective.js
@@ -97,7 +97,6 @@ class SpendInTagPerspective extends React.Component {
           )}
           <NivoResponsivePie
             data={data}
-            legend_data={data}
             colorBy={(obj) => color_scale(obj.label)}
           />
         </div>

--- a/client/src/panels/panel_declarations/finances/drr_dp_resources/spending_in_perspective.js
+++ b/client/src/panels/panel_declarations/finances/drr_dp_resources/spending_in_perspective.js
@@ -98,7 +98,6 @@ class SpendInTagPerspective extends React.Component {
           <NivoResponsivePie
             data={data}
             colorBy={(obj) => color_scale(obj.label)}
-            show_legend={true}
           />
         </div>
       </div>

--- a/client/src/panels/panel_declarations/finances/sobj/top_spending_areas.js
+++ b/client/src/panels/panel_declarations/finances/sobj/top_spending_areas.js
@@ -80,7 +80,11 @@ const render_w_options = ({ text_key }) => ({
             }}
           />
         ) : (
-          <NivoResponsivePie data={graph_data} graph_height="450px" />
+          <NivoResponsivePie
+            data={graph_data}
+            graph_height="450px"
+            show_legend={true}
+          />
         )}
       </Col>
     </StdPanel>

--- a/client/src/panels/panel_declarations/finances/sobj/top_spending_areas.js
+++ b/client/src/panels/panel_declarations/finances/sobj/top_spending_areas.js
@@ -80,11 +80,7 @@ const render_w_options = ({ text_key }) => ({
             }}
           />
         ) : (
-          <NivoResponsivePie
-            data={graph_data}
-            graph_height="450px"
-            show_legend={true}
-          />
+          <NivoResponsivePie data={graph_data} graph_height="450px" />
         )}
       </Col>
     </StdPanel>

--- a/client/src/panels/panel_declarations/finances/sobj/top_spending_areas.js
+++ b/client/src/panels/panel_declarations/finances/sobj/top_spending_areas.js
@@ -80,11 +80,7 @@ const render_w_options = ({ text_key }) => ({
             }}
           />
         ) : (
-          <NivoResponsivePie
-            data={graph_data}
-            legend_data={graph_data}
-            graph_height="450px"
-          />
+          <NivoResponsivePie data={graph_data} graph_height="450px" />
         )}
       </Col>
     </StdPanel>

--- a/client/src/panels/panel_declarations/finances/vote_stat/in_year_vote_stat_split.js
+++ b/client/src/panels/panel_declarations/finances/vote_stat/in_year_vote_stat_split.js
@@ -29,7 +29,7 @@ const render_w_options = ({ graph_col, text_col, text_key }) => ({
       </Col>
       {!window.is_a11y_mode && (
         <Col isGraph size={graph_col}>
-          <NivoResponsivePie data={data} legend_data={data} />
+          <NivoResponsivePie data={data} />
         </Col>
       )}
     </StdPanel>

--- a/client/src/panels/panel_declarations/finances/vote_stat/in_year_vote_stat_split.js
+++ b/client/src/panels/panel_declarations/finances/vote_stat/in_year_vote_stat_split.js
@@ -29,7 +29,7 @@ const render_w_options = ({ graph_col, text_col, text_key }) => ({
       </Col>
       {!window.is_a11y_mode && (
         <Col isGraph size={graph_col}>
-          <NivoResponsivePie data={data} />
+          <NivoResponsivePie data={data} show_legend={true} />
         </Col>
       )}
     </StdPanel>

--- a/client/src/panels/panel_declarations/finances/vote_stat/in_year_vote_stat_split.js
+++ b/client/src/panels/panel_declarations/finances/vote_stat/in_year_vote_stat_split.js
@@ -29,7 +29,7 @@ const render_w_options = ({ graph_col, text_col, text_key }) => ({
       </Col>
       {!window.is_a11y_mode && (
         <Col isGraph size={graph_col}>
-          <NivoResponsivePie data={data} show_legend={true} />
+          <NivoResponsivePie data={data} />
         </Col>
       )}
     </StdPanel>

--- a/client/src/panels/panel_declarations/finances/vote_stat/last_year_vote_stat_split.js
+++ b/client/src/panels/panel_declarations/finances/vote_stat/last_year_vote_stat_split.js
@@ -29,7 +29,7 @@ const render_w_options = ({ text_key, graph_col, text_col }) => ({
       </Col>
       {!window.is_a11y_mode && (
         <Col isGraph size={graph_col}>
-          <NivoResponsivePie data={data} show_legend={true} />
+          <NivoResponsivePie data={data} />
         </Col>
       )}
     </StdPanel>

--- a/client/src/panels/panel_declarations/finances/vote_stat/last_year_vote_stat_split.js
+++ b/client/src/panels/panel_declarations/finances/vote_stat/last_year_vote_stat_split.js
@@ -29,7 +29,7 @@ const render_w_options = ({ text_key, graph_col, text_col }) => ({
       </Col>
       {!window.is_a11y_mode && (
         <Col isGraph size={graph_col}>
-          <NivoResponsivePie data={data} legend_data={data} />
+          <NivoResponsivePie data={data} />
         </Col>
       )}
     </StdPanel>

--- a/client/src/panels/panel_declarations/finances/vote_stat/last_year_vote_stat_split.js
+++ b/client/src/panels/panel_declarations/finances/vote_stat/last_year_vote_stat_split.js
@@ -29,7 +29,7 @@ const render_w_options = ({ text_key, graph_col, text_col }) => ({
       </Col>
       {!window.is_a11y_mode && (
         <Col isGraph size={graph_col}>
-          <NivoResponsivePie data={data} />
+          <NivoResponsivePie data={data} show_legend={true} />
         </Col>
       )}
     </StdPanel>

--- a/client/src/panels/panel_declarations/results/drr_summary.js
+++ b/client/src/panels/panel_declarations/results/drr_summary.js
@@ -264,7 +264,6 @@ class PercentageViz extends React.Component {
           <div className="fcol-md-6 fcol-xs-12 medium_panel_text">
             <NivoResponsivePie
               data={graph_data}
-              legend_data={graph_data}
               graph_height="300px"
               is_money={false}
               colorBy={colorBy}

--- a/client/src/panels/panel_declarations/results/drr_summary.js
+++ b/client/src/panels/panel_declarations/results/drr_summary.js
@@ -273,6 +273,7 @@ class PercentageViz extends React.Component {
                 bottom: 30,
                 left: 30,
               }}
+              show_legend={false}
             />
           </div>
         </div>

--- a/client/src/panels/panel_declarations/results/drr_summary.js
+++ b/client/src/panels/panel_declarations/results/drr_summary.js
@@ -264,6 +264,7 @@ class PercentageViz extends React.Component {
           <div className="fcol-md-6 fcol-xs-12 medium_panel_text">
             <NivoResponsivePie
               data={graph_data}
+              legend_data={graph_data}
               graph_height="300px"
               is_money={false}
               colorBy={colorBy}


### PR DESCRIPTION
closes #612 
![image](https://user-images.githubusercontent.com/9831482/81826258-99724780-9505-11ea-8040-85c2540403d0.png)


The code responsible for creating the table percentage values is this snippet of code from the NivoResponsivePie component:

```
const table_data = _.map(data, (row) => ({
    label: row.label,
    percentage: row.value / legend_total,
    value: row.value,
}));
```

`legend_total` is calculated using the `legend_data` prop to the component. DRR summary was never passing this prop to its NivoResponsivePie so there was a division by zero. Passing in the `legend_data` prop fixes the percentage calculation however this has the added effect of putting a legend below the pie charts on results pages.
![image](https://user-images.githubusercontent.com/9831482/81826027-5021f800-9505-11ea-8175-2718bb3beaa3.png)

If this is a problem it shouldn't be too hard to change NivoResponsivePie to use the graph data instead of the legend data for calculating table data.