### PR TITLE
Expand/collapse all

### DIFF
--- a/client/src/explorer_common/state_and_memoizing.js
+++ b/client/src/explorer_common/state_and_memoizing.js
@@ -70,8 +70,6 @@ function root_reducer(state = initial_root_state, action) {
       const { root } = payload;
       const shouldExpand = !payload.is_expanded;
 
-      const { userExpanded: oldExpanded, userCollapsed: oldCollapsed } = state;
-
       let nodes = [];
       let search_nodes = (parent) => {
         if (parent.children.length === 0) {

--- a/client/src/explorer_common/state_and_memoizing.js
+++ b/client/src/explorer_common/state_and_memoizing.js
@@ -66,7 +66,6 @@ function root_reducer(state = initial_root_state, action) {
     }
 
     case "toggle_all": {
-      // TODO
       const { root } = payload;
       const shouldExpand = !payload.is_expanded;
 

--- a/client/src/explorer_common/state_and_memoizing.js
+++ b/client/src/explorer_common/state_and_memoizing.js
@@ -70,21 +70,21 @@ function root_reducer(state = initial_root_state, action) {
       const shouldExpand = !payload.is_expanded;
 
       let nodes = [];
-      let search_nodes = (parent) => {
-        if (parent.children.length === 0) {
+      let search_nodes = (source) => {
+        if (source.children.length === 0) {
           return;
         }
-        _.forEach(parent.children, (child) => {
+        _.forEach(source.children, (node) => {
           if (shouldExpand) {
-            if (!child.isExpanded) {
-              nodes.push(child.id);
+            if (!node.isExpanded) {
+              nodes.push(node.id);
             }
           } else {
-            if (child.isExpanded) {
-              nodes.push(child.id);
+            if (node.isExpanded) {
+              nodes.push(node.id);
             }
           }
-          search_nodes(child);
+          search_nodes(node);
         });
       };
       search_nodes(root);
@@ -92,7 +92,7 @@ function root_reducer(state = initial_root_state, action) {
       if (shouldExpand) {
         return { ...state, userExpanded: nodes, userCollapsed: [] };
       } else {
-        return { ...state, userCollapsed: nodes, userExpanded: [] };
+        return { ...state, userExpanded: [], userCollapsed: nodes };
       }
     }
 

--- a/client/src/explorer_common/state_and_memoizing.js
+++ b/client/src/explorer_common/state_and_memoizing.js
@@ -95,6 +95,14 @@ function root_reducer(state = initial_root_state, action) {
       };
     }
 
+    case "clear_expanded_collapsed": {
+      return {
+        ...state,
+        userExpanded: [],
+        userCollapsed: [],
+      };
+    }
+
     default: {
       return state;
     }
@@ -132,6 +140,10 @@ const map_dispatch_to_root_props = (dispatch) => {
       payload: { node },
     });
 
+  const clear_query = () => dispatch({ type: "clear_query" });
+
+  const enable_loading = () => dispatch({ type: "enable_loading" });
+
   const expand_all = (root) =>
     dispatch({
       type: "expand_all",
@@ -144,9 +156,10 @@ const map_dispatch_to_root_props = (dispatch) => {
       payload: { root },
     });
 
-  const clear_query = () => dispatch({ type: "clear_query" });
-
-  const enable_loading = () => dispatch({ type: "enable_loading" });
+  const clear_expanded_collapsed = () =>
+    dispatch({
+      type: "clear_expanded_collapsed",
+    });
 
   return {
     set_query,
@@ -155,6 +168,7 @@ const map_dispatch_to_root_props = (dispatch) => {
     enable_loading,
     expand_all,
     collapse_all,
+    clear_expanded_collapsed,
   };
 };
 

--- a/client/src/explorer_common/state_and_memoizing.js
+++ b/client/src/explorer_common/state_and_memoizing.js
@@ -65,32 +65,38 @@ function root_reducer(state = initial_root_state, action) {
       }
     }
 
-    case "toggle_all": {
+    case "expand_all": {
       const { root } = payload;
-      const shouldExpand = !payload.is_expanded;
-      const { userExpanded: oldExpanded, userCollapsed: oldCollapsed } = state;
+      const { userExpanded: oldExpanded } = state;
 
       const get_ids_to_update = ({ isExpanded, id, children }) => [
-        (shouldExpand && !isExpanded) || (!shouldExpand && isExpanded)
-          ? id
-          : [],
+        !isExpanded ? id : [],
         _.map(children, get_ids_to_update),
       ];
       const ids_to_update = _.flattenDeep(get_ids_to_update(root));
 
-      if (shouldExpand) {
-        return {
-          ...state,
-          userExpanded: oldExpanded.concat(ids_to_update),
-          userCollapsed: [],
-        };
-      } else {
-        return {
-          ...state,
-          userExpanded: [],
-          userCollapsed: oldCollapsed.concat(ids_to_update),
-        };
-      }
+      return {
+        ...state,
+        userExpanded: oldExpanded.concat(ids_to_update),
+        userCollapsed: [],
+      };
+    }
+
+    case "collapse_all": {
+      const { root } = payload;
+      const { userCollapsed: oldCollapsed } = state;
+
+      const get_ids_to_update = ({ isExpanded, id, children }) => [
+        isExpanded ? id : [],
+        _.map(children, get_ids_to_update),
+      ];
+      const ids_to_update = _.flattenDeep(get_ids_to_update(root));
+
+      return {
+        ...state,
+        userExpanded: [],
+        userCollapsed: oldCollapsed.concat(ids_to_update),
+      };
     }
 
     default: {
@@ -130,10 +136,16 @@ const map_dispatch_to_root_props = (dispatch) => {
       payload: { node },
     });
 
-  const toggle_all = (root, is_expanded) =>
+  const expand_all = (root) =>
     dispatch({
-      type: "toggle_all",
-      payload: { root, is_expanded },
+      type: "expand_all",
+      payload: { root },
+    });
+
+  const collapse_all = (root) =>
+    dispatch({
+      type: "collapse_all",
+      payload: { root },
     });
 
   const clear_query = () => dispatch({ type: "clear_query" });
@@ -145,7 +157,8 @@ const map_dispatch_to_root_props = (dispatch) => {
     toggle_node,
     clear_query,
     enable_loading,
-    toggle_all,
+    expand_all,
+    collapse_all,
   };
 };
 

--- a/client/src/explorer_common/state_and_memoizing.js
+++ b/client/src/explorer_common/state_and_memoizing.js
@@ -68,28 +68,28 @@ function root_reducer(state = initial_root_state, action) {
     case "toggle_all": {
       const { root } = payload;
       const shouldExpand = !payload.is_expanded;
+      const { userExpanded: oldExpanded, userCollapsed: oldCollapsed } = state;
 
-      let nodes = [];
-      let search_nodes = (source) => {
-        if (source.children.length === 0) {
-          return;
-        }
-        _.forEach(source.children, (node) => {
-          if (
-            (shouldExpand && !node.isExpanded) ||
-            (!shouldExpand && node.isExpanded)
-          ) {
-            nodes.push(node.id);
-          }
-          search_nodes(node);
-        });
-      };
-      search_nodes(root);
+      const get_ids_to_update = ({ isExpanded, id, children }) => [
+        (shouldExpand && !isExpanded) || (!shouldExpand && isExpanded)
+          ? id
+          : [],
+        _.map(children, get_ids_to_update),
+      ];
+      const ids_to_update = _.flattenDeep(get_ids_to_update(root));
 
       if (shouldExpand) {
-        return { ...state, userExpanded: nodes, userCollapsed: [] };
+        return {
+          ...state,
+          userExpanded: oldExpanded.concat(ids_to_update),
+          userCollapsed: [],
+        };
       } else {
-        return { ...state, userExpanded: [], userCollapsed: nodes };
+        return {
+          ...state,
+          userExpanded: [],
+          userCollapsed: oldCollapsed.concat(ids_to_update),
+        };
       }
     }
 

--- a/client/src/explorer_common/state_and_memoizing.js
+++ b/client/src/explorer_common/state_and_memoizing.js
@@ -67,7 +67,36 @@ function root_reducer(state = initial_root_state, action) {
 
     case "toggle_all": {
       // TODO
-      return state;
+      const { root } = payload;
+      const shouldExpand = !payload.is_expanded;
+
+      const { userExpanded: oldExpanded, userCollapsed: oldCollapsed } = state;
+
+      let nodes = [];
+      let search_nodes = (parent) => {
+        if (parent.children.length === 0) {
+          return;
+        }
+        _.forEach(parent.children, (child) => {
+          if (shouldExpand) {
+            if (!child.isExpanded) {
+              nodes.push(child.id);
+            }
+          } else {
+            if (child.isExpanded) {
+              nodes.push(child.id);
+            }
+          }
+          search_nodes(child);
+        });
+      };
+      search_nodes(root);
+
+      if (shouldExpand) {
+        return { ...state, userExpanded: nodes, userCollapsed: [] };
+      } else {
+        return { ...state, userCollapsed: nodes, userExpanded: [] };
+      }
     }
 
     default: {
@@ -107,7 +136,11 @@ const map_dispatch_to_root_props = (dispatch) => {
       payload: { node },
     });
 
-  const toggle_all = () => dispatch({ type: "toggle_all" });
+  const toggle_all = (root, is_expanded) =>
+    dispatch({
+      type: "toggle_all",
+      payload: { root, is_expanded },
+    });
 
   const clear_query = () => dispatch({ type: "clear_query" });
 

--- a/client/src/explorer_common/state_and_memoizing.js
+++ b/client/src/explorer_common/state_and_memoizing.js
@@ -79,7 +79,7 @@ function root_reducer(state = initial_root_state, action) {
             (shouldExpand && !node.isExpanded) ||
             (!shouldExpand && node.isExpanded)
           ) {
-            nodes.push(node);
+            nodes.push(node.id);
           }
           search_nodes(node);
         });

--- a/client/src/explorer_common/state_and_memoizing.js
+++ b/client/src/explorer_common/state_and_memoizing.js
@@ -15,6 +15,14 @@ const initial_root_state = {
   userCollapsed: [],
 };
 
+function ids_to_update(root, should_expand) {
+  const get_ids_to_update = ({ isExpanded, id, children }) => [
+    (should_expand && !isExpanded) || (!should_expand && isExpanded) ? id : [],
+    _.map(children, get_ids_to_update),
+  ];
+  return _.flattenDeep(get_ids_to_update(root));
+}
+
 function root_reducer(state = initial_root_state, action) {
   const { type, payload } = action;
 
@@ -69,15 +77,9 @@ function root_reducer(state = initial_root_state, action) {
       const { root } = payload;
       const { userExpanded: oldExpanded } = state;
 
-      const get_ids_to_update = ({ isExpanded, id, children }) => [
-        !isExpanded ? id : [],
-        _.map(children, get_ids_to_update),
-      ];
-      const ids_to_update = _.flattenDeep(get_ids_to_update(root));
-
       return {
         ...state,
-        userExpanded: oldExpanded.concat(ids_to_update),
+        userExpanded: oldExpanded.concat(ids_to_update(root, true)),
         userCollapsed: [],
       };
     }
@@ -86,16 +88,10 @@ function root_reducer(state = initial_root_state, action) {
       const { root } = payload;
       const { userCollapsed: oldCollapsed } = state;
 
-      const get_ids_to_update = ({ isExpanded, id, children }) => [
-        isExpanded ? id : [],
-        _.map(children, get_ids_to_update),
-      ];
-      const ids_to_update = _.flattenDeep(get_ids_to_update(root));
-
       return {
         ...state,
         userExpanded: [],
-        userCollapsed: oldCollapsed.concat(ids_to_update),
+        userCollapsed: oldCollapsed.concat(ids_to_update(root, false)),
       };
     }
 

--- a/client/src/explorer_common/state_and_memoizing.js
+++ b/client/src/explorer_common/state_and_memoizing.js
@@ -65,6 +65,11 @@ function root_reducer(state = initial_root_state, action) {
       }
     }
 
+    case "toggle_all": {
+      // TODO
+      return state;
+    }
+
     default: {
       return state;
     }
@@ -102,6 +107,8 @@ const map_dispatch_to_root_props = (dispatch) => {
       payload: { node },
     });
 
+  const toggle_all = () => dispatch({ type: "toggle_all" });
+
   const clear_query = () => dispatch({ type: "clear_query" });
 
   const enable_loading = () => dispatch({ type: "enable_loading" });
@@ -111,6 +118,7 @@ const map_dispatch_to_root_props = (dispatch) => {
     toggle_node,
     clear_query,
     enable_loading,
+    toggle_all,
   };
 };
 

--- a/client/src/explorer_common/state_and_memoizing.js
+++ b/client/src/explorer_common/state_and_memoizing.js
@@ -75,14 +75,11 @@ function root_reducer(state = initial_root_state, action) {
           return;
         }
         _.forEach(source.children, (node) => {
-          if (shouldExpand) {
-            if (!node.isExpanded) {
-              nodes.push(node.id);
-            }
-          } else {
-            if (node.isExpanded) {
-              nodes.push(node.id);
-            }
+          if (
+            (shouldExpand && !node.isExpanded) ||
+            (!shouldExpand && node.isExpanded)
+          ) {
+            nodes.push(node.id);
           }
           search_nodes(node);
         });
@@ -90,9 +87,19 @@ function root_reducer(state = initial_root_state, action) {
       search_nodes(root);
 
       if (shouldExpand) {
-        return { ...state, userExpanded: nodes, userCollapsed: [] };
+        return {
+          ...state,
+          userExpanded: nodes,
+          userCollapsed: [],
+          loading: false,
+        };
       } else {
-        return { ...state, userExpanded: [], userCollapsed: nodes };
+        return {
+          ...state,
+          userExpanded: [],
+          userCollapsed: nodes,
+          loading: false,
+        };
       }
     }
 

--- a/client/src/explorer_common/state_and_memoizing.js
+++ b/client/src/explorer_common/state_and_memoizing.js
@@ -79,7 +79,7 @@ function root_reducer(state = initial_root_state, action) {
             (shouldExpand && !node.isExpanded) ||
             (!shouldExpand && node.isExpanded)
           ) {
-            nodes.push(node.id);
+            nodes.push(node);
           }
           search_nodes(node);
         });
@@ -87,19 +87,9 @@ function root_reducer(state = initial_root_state, action) {
       search_nodes(root);
 
       if (shouldExpand) {
-        return {
-          ...state,
-          userExpanded: nodes,
-          userCollapsed: [],
-          loading: false,
-        };
+        return { ...state, userExpanded: nodes, userCollapsed: [] };
       } else {
-        return {
-          ...state,
-          userExpanded: [],
-          userCollapsed: nodes,
-          loading: false,
-        };
+        return { ...state, userExpanded: [], userCollapsed: nodes };
       }
     }
 

--- a/client/src/panels/panel_declarations/results/result_drilldown/result_drilldown.js
+++ b/client/src/panels/panel_declarations/results/result_drilldown/result_drilldown.js
@@ -314,42 +314,48 @@ class SingleSubjExplorer extends React.Component {
                 onChange={(evt) => this.handleQueryChange(evt.target.value)}
                 value={query}
               />
-              <button
-                type="button"
-                className="btn btn-ib-light"
-                style={{
-                  height: "40px",
-                  width: "50%",
-                  margin: "5px 0px",
-                }}
-                onClick={() => {
-                  this.setState({ loading_query: true });
-                  this.expandTimout = setTimeout(() => {
-                    expand_all(root);
-                    this.setState({ loading_query: false });
-                  }, 0);
-                }}
-              >
-                <span>{text_maker("expand_all")}</span>
-              </button>
-              <button
-                type="button"
-                className="btn btn-ib-light"
-                style={{
-                  height: "40px",
-                  width: "50%",
-                  margin: "5px 0px",
-                }}
-                onClick={() => {
-                  this.setState({ loading_query: true });
-                  this.collapseTimout = setTimeout(() => {
-                    collapse_all(root);
-                    this.setState({ loading_query: false });
-                  }, 0);
-                }}
-              >
-                <span>{text_maker("collapse_all")}</span>
-              </button>
+              <div style={{ display: "flex" }}>
+                <button
+                  type="button"
+                  className="btn btn-ib-light"
+                  style={{
+                    height: "40px",
+                    width: "50%",
+                    margin: "5px 2px",
+                  }}
+                  onClick={() => {
+                    // Inside an event handler setState batches all state changes asychronously,
+                    // to ensure the spinner shows when we want it to, we need to use setTimeout to force the code
+                    // to act asynchronously
+                    this.setState({ loading_query: true });
+                    this.expandTimout = setTimeout(() => {
+                      expand_all(root);
+                      this.setState({ loading_query: false });
+                    }, 0);
+                  }}
+                >
+                  <span>{text_maker("expand_all")}</span>
+                </button>
+                <button
+                  type="button"
+                  className="btn btn-ib-light"
+                  style={{
+                    height: "40px",
+                    width: "50%",
+                    margin: "5px 2px",
+                  }}
+                  onClick={() => {
+                    // Same explanation as the expand all button
+                    this.setState({ loading_query: true });
+                    this.collapseTimout = setTimeout(() => {
+                      collapse_all(root);
+                      this.setState({ loading_query: false });
+                    }, 0);
+                  }}
+                >
+                  <span>{text_maker("collapse_all")}</span>
+                </button>
+              </div>
               {window.is_a11y_mode && (
                 <input
                   type="submit"

--- a/client/src/panels/panel_declarations/results/result_drilldown/result_drilldown.js
+++ b/client/src/panels/panel_declarations/results/result_drilldown/result_drilldown.js
@@ -312,8 +312,12 @@ class SingleSubjExplorer extends React.Component {
               />
               <button
                 type="button"
-                className="btn btn-primary"
-                style={{ width: "100%" }}
+                className="btn btn-ib-light"
+                style={{
+                  height: "40px",
+                  width: "100%",
+                  margin: "5px 0px",
+                }}
                 onClick={() => {
                   toggle_all(root, this.state.is_expanded);
                   this.setState({
@@ -321,9 +325,11 @@ class SingleSubjExplorer extends React.Component {
                   });
                 }}
               >
-                {this.state.is_expanded
-                  ? text_maker("collapse_all")
-                  : text_maker("expand_all")}
+                <span>
+                  {this.state.is_expanded
+                    ? text_maker("collapse_all")
+                    : text_maker("expand_all")}
+                </span>
               </button>
               {window.is_a11y_mode && (
                 <input

--- a/client/src/panels/panel_declarations/results/result_drilldown/result_drilldown.js
+++ b/client/src/panels/panel_declarations/results/result_drilldown/result_drilldown.js
@@ -314,7 +314,12 @@ class SingleSubjExplorer extends React.Component {
                 type="button"
                 className="btn btn-primary"
                 style={{ width: "100%" }}
-                onClick={toggle_all}
+                onClick={() => {
+                  toggle_all(root);
+                  this.setState({
+                    is_expanded: !this.state.is_expanded,
+                  });
+                }}
               >
                 {this.state.is_expanded
                   ? text_maker("collapse_all")

--- a/client/src/panels/panel_declarations/results/result_drilldown/result_drilldown.js
+++ b/client/src/panels/panel_declarations/results/result_drilldown/result_drilldown.js
@@ -216,6 +216,8 @@ class SingleSubjExplorer extends React.Component {
       this.debounced_set_query.cancel();
     !_.isUndefined(this.timedOutStateChange) &&
       clearTimeout(this.timedOutStateChange);
+    !_.isUndefined(this.expandTimout) && clearTimeout(this.expandTimout);
+    !_.isUndefined(this.collapseTimout) && clearTimeout(this.collapseTimout);
   }
   render() {
     const {
@@ -321,7 +323,7 @@ class SingleSubjExplorer extends React.Component {
                 }}
                 onClick={() => {
                   this.setState({ loading_query: true });
-                  setTimeout(() => {
+                  this.expandTimout = setTimeout(() => {
                     expand_all(root);
                     this.setState({ loading_query: false });
                   }, 0);
@@ -339,7 +341,7 @@ class SingleSubjExplorer extends React.Component {
                 }}
                 onClick={() => {
                   this.setState({ loading_query: true });
-                  setTimeout(() => {
+                  this.collapseTimout = setTimeout(() => {
                     collapse_all(root);
                     this.setState({ loading_query: false });
                   }, 0);

--- a/client/src/panels/panel_declarations/results/result_drilldown/result_drilldown.js
+++ b/client/src/panels/panel_declarations/results/result_drilldown/result_drilldown.js
@@ -226,6 +226,7 @@ class SingleSubjExplorer extends React.Component {
 
       set_query,
       toggle_node,
+      toggle_all,
 
       subject,
 

--- a/client/src/panels/panel_declarations/results/result_drilldown/result_drilldown.js
+++ b/client/src/panels/panel_declarations/results/result_drilldown/result_drilldown.js
@@ -315,7 +315,7 @@ class SingleSubjExplorer extends React.Component {
                 className="btn btn-ib-light"
                 style={{
                   height: "40px",
-                  width: "100%",
+                  width: "50%",
                   margin: "5px 0px",
                 }}
                 onClick={() => {
@@ -325,11 +325,24 @@ class SingleSubjExplorer extends React.Component {
                   });
                 }}
               >
-                <span>
-                  {this.state.is_expanded
-                    ? text_maker("collapse_all")
-                    : text_maker("expand_all")}
-                </span>
+                <span>{text_maker("expand_all")}</span>
+              </button>
+              <button
+                type="button"
+                className="btn btn-ib-light"
+                style={{
+                  height: "40px",
+                  width: "50%",
+                  margin: "5px 0px",
+                }}
+                onClick={() => {
+                  toggle_all(root, this.state.is_expanded);
+                  this.setState({
+                    is_expanded: !this.state.is_expanded,
+                  });
+                }}
+              >
+                <span>{text_maker("collapse_all")}</span>
               </button>
               {window.is_a11y_mode && (
                 <input

--- a/client/src/panels/panel_declarations/results/result_drilldown/result_drilldown.js
+++ b/client/src/panels/panel_declarations/results/result_drilldown/result_drilldown.js
@@ -189,7 +189,7 @@ const get_col_defs = createSelector(
 class SingleSubjExplorer extends React.Component {
   constructor() {
     super();
-    this.state = { query: "", is_expanded: false };
+    this.state = { query: "" };
     this.debounced_set_query = _.debounce(this.debounced_set_query, 500);
   }
   handleQueryChange(new_query) {
@@ -226,7 +226,8 @@ class SingleSubjExplorer extends React.Component {
 
       set_query,
       toggle_node,
-      toggle_all,
+      expand_all,
+      collapse_all,
 
       subject,
 
@@ -318,12 +319,7 @@ class SingleSubjExplorer extends React.Component {
                   width: "50%",
                   margin: "5px 0px",
                 }}
-                onClick={() => {
-                  toggle_all(root, this.state.is_expanded);
-                  this.setState({
-                    is_expanded: !this.state.is_expanded,
-                  });
-                }}
+                onClick={() => expand_all(root)}
               >
                 <span>{text_maker("expand_all")}</span>
               </button>
@@ -335,12 +331,7 @@ class SingleSubjExplorer extends React.Component {
                   width: "50%",
                   margin: "5px 0px",
                 }}
-                onClick={() => {
-                  toggle_all(root, this.state.is_expanded);
-                  this.setState({
-                    is_expanded: !this.state.is_expanded,
-                  });
-                }}
+                onClick={() => collapse_all(root)}
               >
                 <span>{text_maker("collapse_all")}</span>
               </button>

--- a/client/src/panels/panel_declarations/results/result_drilldown/result_drilldown.js
+++ b/client/src/panels/panel_declarations/results/result_drilldown/result_drilldown.js
@@ -321,8 +321,10 @@ class SingleSubjExplorer extends React.Component {
                 }}
                 onClick={() => {
                   this.setState({ loading_query: true });
-                  expand_all(root);
-                  this.setState({ loading_query: false });
+                  setTimeout(() => {
+                    expand_all(root);
+                    this.setState({ loading_query: false });
+                  }, 0);
                 }}
               >
                 <span>{text_maker("expand_all")}</span>
@@ -337,8 +339,10 @@ class SingleSubjExplorer extends React.Component {
                 }}
                 onClick={() => {
                   this.setState({ loading_query: true });
-                  collapse_all(root);
-                  this.setState({ loading_query: false });
+                  setTimeout(() => {
+                    collapse_all(root);
+                    this.setState({ loading_query: false });
+                  }, 0);
                 }}
               >
                 <span>{text_maker("collapse_all")}</span>

--- a/client/src/panels/panel_declarations/results/result_drilldown/result_drilldown.js
+++ b/client/src/panels/panel_declarations/results/result_drilldown/result_drilldown.js
@@ -319,7 +319,11 @@ class SingleSubjExplorer extends React.Component {
                   width: "50%",
                   margin: "5px 0px",
                 }}
-                onClick={() => expand_all(root)}
+                onClick={() => {
+                  this.setState({ loading_query: true });
+                  expand_all(root);
+                  this.setState({ loading_query: false });
+                }}
               >
                 <span>{text_maker("expand_all")}</span>
               </button>
@@ -331,7 +335,11 @@ class SingleSubjExplorer extends React.Component {
                   width: "50%",
                   margin: "5px 0px",
                 }}
-                onClick={() => collapse_all(root)}
+                onClick={() => {
+                  this.setState({ loading_query: true });
+                  collapse_all(root);
+                  this.setState({ loading_query: false });
+                }}
               >
                 <span>{text_maker("collapse_all")}</span>
               </button>

--- a/client/src/panels/panel_declarations/results/result_drilldown/result_drilldown.js
+++ b/client/src/panels/panel_declarations/results/result_drilldown/result_drilldown.js
@@ -315,7 +315,7 @@ class SingleSubjExplorer extends React.Component {
                 className="btn btn-primary"
                 style={{ width: "100%" }}
                 onClick={() => {
-                  toggle_all(root);
+                  toggle_all(root, this.state.is_expanded);
                   this.setState({
                     is_expanded: !this.state.is_expanded,
                   });

--- a/client/src/panels/panel_declarations/results/result_drilldown/result_drilldown.js
+++ b/client/src/panels/panel_declarations/results/result_drilldown/result_drilldown.js
@@ -231,6 +231,7 @@ class SingleSubjExplorer extends React.Component {
       toggle_node,
       expand_all,
       collapse_all,
+      clear_expanded_collapsed,
 
       subject,
 
@@ -396,7 +397,8 @@ class SingleSubjExplorer extends React.Component {
       );
     }
 
-    const tab_on_click = (doc) => set_doc !== doc && set_doc(doc, subject);
+    const tab_on_click = (doc) =>
+      set_doc !== doc && clear_expanded_collapsed() && set_doc(doc, subject);
     return (
       <div className="tabbed-content">
         <TabbedControls

--- a/client/src/panels/panel_declarations/results/result_drilldown/result_drilldown.js
+++ b/client/src/panels/panel_declarations/results/result_drilldown/result_drilldown.js
@@ -318,7 +318,7 @@ class SingleSubjExplorer extends React.Component {
               <div style={{ display: "flex" }}>
                 <button
                   type="button"
-                  className="btn btn-ib-light"
+                  className="btn btn-ib-primary"
                   style={{
                     height: "40px",
                     width: "50%",
@@ -339,7 +339,7 @@ class SingleSubjExplorer extends React.Component {
                 </button>
                 <button
                   type="button"
-                  className="btn btn-ib-light"
+                  className="btn btn-ib-primary"
                   style={{
                     height: "40px",
                     width: "50%",

--- a/client/src/panels/panel_declarations/results/result_drilldown/result_drilldown.js
+++ b/client/src/panels/panel_declarations/results/result_drilldown/result_drilldown.js
@@ -189,7 +189,7 @@ const get_col_defs = createSelector(
 class SingleSubjExplorer extends React.Component {
   constructor() {
     super();
-    this.state = { query: "" };
+    this.state = { query: "", is_expanded: false };
     this.debounced_set_query = _.debounce(this.debounced_set_query, 500);
   }
   handleQueryChange(new_query) {
@@ -310,6 +310,16 @@ class SingleSubjExplorer extends React.Component {
                 onChange={(evt) => this.handleQueryChange(evt.target.value)}
                 value={query}
               />
+              <button
+                type="button"
+                className="btn btn-primary"
+                style={{ width: "100%" }}
+                onClick={toggle_all}
+              >
+                {this.state.is_expanded
+                  ? text_maker("collapse_all")
+                  : text_maker("expand_all")}
+              </button>
               {window.is_a11y_mode && (
                 <input
                   type="submit"

--- a/client/src/panels/panel_declarations/results/result_drilldown/result_drilldown.js
+++ b/client/src/panels/panel_declarations/results/result_drilldown/result_drilldown.js
@@ -31,6 +31,7 @@ import redux_promise_middleware from "redux-promise-middleware";
 import { Provider, connect } from "react-redux";
 
 import { Explorer } from "../../../../explorer_common/explorer_components.js";
+import "../../../../explorer_common/explorer-styles.scss";
 import { get_root } from "../../../../explorer_common/hierarchy_tools.js";
 import {
   get_memoized_funcs,

--- a/client/src/panels/panel_declarations/results/result_drilldown/result_drilldown.js
+++ b/client/src/panels/panel_declarations/results/result_drilldown/result_drilldown.js
@@ -231,7 +231,6 @@ class SingleSubjExplorer extends React.Component {
       toggle_node,
       expand_all,
       collapse_all,
-      clear_expanded_collapsed,
 
       subject,
 
@@ -397,8 +396,7 @@ class SingleSubjExplorer extends React.Component {
       );
     }
 
-    const tab_on_click = (doc) =>
-      set_doc !== doc && clear_expanded_collapsed() && set_doc(doc, subject);
+    const tab_on_click = (doc) => set_doc !== doc && set_doc(doc, subject);
     return (
       <div className="tabbed-content">
         <TabbedControls


### PR DESCRIPTION
closes #615 

Adds an expand/collapse all button to the result drill down. There may potentially be a way to optimize the `toggle_all` action as on drill downs with more elements it can take a second or two for all of them to open. The button could also potentially use some styling.