### PR TITLE
Add text align property to column config

### DIFF
--- a/client/src/charts/wrapped_nivo/nivo_bar.js
+++ b/client/src/charts/wrapped_nivo/nivo_bar.js
@@ -33,7 +33,7 @@ const bar_table = (
           formatter: (value) =>
             _.isUndefined(value) ? "" : table_view_format(value),
           text_align: (value) => {
-            const onlyAlphanum = value.replace(/[^W]+/g, "")
+            const onlyAlphanum = value.replace(/[\W]+/g, "")
             if (!isNaN(onlyAlphanum)) {
               return "right"
             } else {

--- a/client/src/charts/wrapped_nivo/nivo_bar.js
+++ b/client/src/charts/wrapped_nivo/nivo_bar.js
@@ -32,10 +32,19 @@ const bar_table = (
           header: key,
           formatter: (value) =>
             _.isUndefined(value) ? "" : table_view_format(value),
+          text_align: (value) => {
+            const onlyAlphanum = value.replace(/[^W]+/g, "")
+            if (!isNaN(onlyAlphanum)) {
+              return "right"
+            } else {
+              return "left"
+            }
+          },
         },
       ])
       .fromPairs()
       .value(),
+      
   };
 
   return (

--- a/client/src/components/DisplayTable/DisplayTable.js
+++ b/client/src/components/DisplayTable/DisplayTable.js
@@ -251,7 +251,11 @@ export class DisplayTable extends React.Component {
             {_.map(sorted_filtered_data, (row, i) => (
               <tr key={i}>
                 {_.map(ordered_column_keys, (col_key) => (
-                  <td style={{ fontSize: "14px" }} key={col_key}>
+                  <td style={{ fontSize: "14px", textAlign: 
+                    col_configs_with_defaults[col_key].text_align ? 
+                      col_configs_with_defaults[col_key].text_align(
+                        col_configs_with_defaults[col_key].formatter(row[col_key])) 
+                        : "initial" }} key={col_key}>
                     {col_configs_with_defaults[col_key].formatter ? (
                       _.isString(
                         col_configs_with_defaults[col_key].formatter

--- a/client/src/components/DisplayTable/DisplayTable.js
+++ b/client/src/components/DisplayTable/DisplayTable.js
@@ -255,7 +255,7 @@ export class DisplayTable extends React.Component {
                     col_configs_with_defaults[col_key].text_align ? 
                       col_configs_with_defaults[col_key].text_align(
                         col_configs_with_defaults[col_key].formatter(row[col_key])) 
-                        : "initial" }} key={col_key}>
+                        : col_configs_with_defaults[col_key].text_align }} key={col_key}>
                     {col_configs_with_defaults[col_key].formatter ? (
                       _.isString(
                         col_configs_with_defaults[col_key].formatter


### PR DESCRIPTION
closes #633 

This is the alternate solution from using using a style object in DisplayTable.js

Added a text align property to the column configuration settings in nivo_bar.js
This is done with regex. Regex here allows us to filter all but alphanumerical characters (the assumption is that if the final result of the filter is pure numbers, it should be right aligned)

![image](https://user-images.githubusercontent.com/25855114/84052020-fedb1c00-a97d-11ea-9db3-5f76edc5da68.png)
