### PR TITLE
Move GCFs to node 10 runtimes

### DIFF
--- a/email_backend/.babelrc
+++ b/email_backend/.babelrc
@@ -1,9 +1,8 @@
 {
   "plugins": [
-    "@babel/plugin-proposal-object-rest-spread",
     "@babel/plugin-transform-modules-commonjs"
   ],
   "presets": [
-      ["@babel/preset-env", { "targets": { "node": "8.15.0" } }]
+      ["@babel/preset-env", { "targets": { "node": "10.18.1" } }]
     ]
 }

--- a/email_backend/deploy_scripts/prod_deploy_email_backend_function.sh
+++ b/email_backend/deploy_scripts/prod_deploy_email_backend_function.sh
@@ -7,7 +7,7 @@ npm run build
 source deploy_scripts/set_prod_env_vars.sh
 source deploy_scripts/set_transient_secrets.sh # these trap EXIT to handle their own cleanup
 
-gcloud beta functions deploy prod-email-backend --max-instances 1 --project ${PROJECT} --region us-central1 --entry-point email_backend --stage-bucket email-backend-staging-bucket --runtime nodejs8 --trigger-http --env-vars-file $scratch/envs.yaml > /dev/null
+gcloud beta functions deploy prod-email-backend --max-instances 1 --project ${PROJECT} --region us-central1 --entry-point email_backend --stage-bucket email-backend-staging-bucket --runtime nodejs10 --trigger-http --env-vars-file $scratch/envs.yaml > /dev/null
 
 source deploy_scripts/unset_prod_env_vars.sh
 

--- a/email_backend/package-lock.json
+++ b/email_backend/package-lock.json
@@ -3443,8 +3443,7 @@
         },
         "handlebars": {
           "version": "4.5.1",
-          "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.1.tgz",
-          "integrity": "sha512-C29UoFzHe9yM61lOsIlCE5/mQVGrnIOrOq7maQl76L7tYPCgC1og0Ajt6uWnX4ZTxBPnjw+CUvawphwCfJgUnA==",
+          "resolved": "",
           "dev": true,
           "requires": {
             "neo-async": "^2.6.0",
@@ -3679,8 +3678,7 @@
         },
         "istanbul-reports": {
           "version": "2.2.6",
-          "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.2.6.tgz",
-          "integrity": "sha512-SKi4rnMyLBKe0Jy2uUdx28h8oG7ph2PPuQPvIAh31d+Ci+lSiEu4C+h3oBPuJ9+mPKhOyW0M8gY4U5NM1WLeXA==",
+          "resolved": "",
           "dev": true,
           "requires": {
             "handlebars": "^4.1.2"
@@ -4341,8 +4339,7 @@
         },
         "yargs-parser": {
           "version": "15.0.0",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.0.tgz",
-          "integrity": "sha512-xLTUnCMc4JhxrPEPUYD5IBR1mWCK/aT6+RJ/K29JY2y1vD+FhtgKK0AXRWvI262q3QSffAQuTouFIKUuHX89wQ==",
+          "resolved": "",
           "dev": true,
           "requires": {
             "camelcase": "^5.0.0",

--- a/email_backend/package.json
+++ b/email_backend/package.json
@@ -2,7 +2,7 @@
   "name": "infobase-email-backend",
   "main": "transpiled_build/index.js",
   "engines": {
-    "node": "^9.0"
+    "node": "^10.0"
   },
   "dependencies": {
     "body-parser": "^1.18.2",
@@ -17,7 +17,6 @@
     "@babel/cli": "^7.8.4",
     "@babel/core": "^7",
     "@babel/node": "^7",
-    "@babel/plugin-proposal-object-rest-spread": "^7.3.1",
     "@babel/plugin-transform-modules-commonjs": "^7.3.1",
     "@babel/preset-env": "^7.3.1",
     "axios": "^0.19.0",

--- a/server/.babelrc
+++ b/server/.babelrc
@@ -1,9 +1,8 @@
 {
   "plugins": [
-    "@babel/plugin-proposal-object-rest-spread",
     "@babel/plugin-transform-modules-commonjs"
   ],
   "presets": [
-      ["@babel/preset-env", { "targets": { "node": "8.15.0" } }]
+      ["@babel/preset-env", { "targets": { "node": "10.18.1" } }]
     ]
 }

--- a/server/deploy_scripts/ci_deploy_function.sh
+++ b/server/deploy_scripts/ci_deploy_function.sh
@@ -11,7 +11,7 @@ echo "USE_REMOTE_DB: '1'" >> ./envs.yaml
 
 source ../scripts/ci_scripts/redact_env_vars_from_logging.sh "redact-start"
 
-gcloud functions deploy $CIRCLE_BRANCH --entry-point app --stage-bucket api-staging-bucket --runtime nodejs8 --trigger-http --env-vars-file ./envs.yaml
+gcloud functions deploy $CIRCLE_BRANCH --entry-point app --stage-bucket api-staging-bucket --runtime nodejs10 --trigger-http --env-vars-file ./envs.yaml
 gcloud alpha functions add-iam-policy-binding $CIRCLE_BRANCH --member allUsers --role roles/cloudfunctions.invoker
 
 source ../scripts/ci_scripts/redact_env_vars_from_logging.sh "redact-end"

--- a/server/deploy_scripts/prod_deploy_function.sh
+++ b/server/deploy_scripts/prod_deploy_function.sh
@@ -7,7 +7,7 @@ npm run build
 source deploy_scripts/set_prod_env_vars.sh
 source deploy_scripts/set_transient_function_secrets.sh # these trap EXIT to handle their own cleanup
 
-gcloud functions deploy prod-api-${CURRENT_SHA} --project ${PROJECT} --region us-central1 --entry-point app --stage-bucket prod-api-staging-bucket --runtime nodejs8 --trigger-http --env-vars-file $scratch/envs.yaml > /dev/null
+gcloud functions deploy prod-api-${CURRENT_SHA} --project ${PROJECT} --region us-central1 --entry-point app --stage-bucket prod-api-staging-bucket --runtime nodejs10 --trigger-http --env-vars-file $scratch/envs.yaml > /dev/null
 gcloud alpha functions add-iam-policy-binding prod-api-${CURRENT_SHA} --project ${PROJECT} --region us-central1 --member allUsers --role roles/cloudfunctions.invoker
 
 source deploy_scripts/unset_prod_env_vars.sh

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -2256,6 +2256,16 @@
       "dev": true,
       "optional": true
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "bluebird": {
       "version": "3.5.1",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
@@ -3062,8 +3072,7 @@
         },
         "handlebars": {
           "version": "4.5.1",
-          "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.1.tgz",
-          "integrity": "sha512-C29UoFzHe9yM61lOsIlCE5/mQVGrnIOrOq7maQl76L7tYPCgC1og0Ajt6uWnX4ZTxBPnjw+CUvawphwCfJgUnA==",
+          "resolved": "",
           "dev": true,
           "requires": {
             "neo-async": "^2.6.0",
@@ -3204,8 +3213,7 @@
         },
         "istanbul-reports": {
           "version": "2.2.6",
-          "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.2.6.tgz",
-          "integrity": "sha512-SKi4rnMyLBKe0Jy2uUdx28h8oG7ph2PPuQPvIAh31d+Ci+lSiEu4C+h3oBPuJ9+mPKhOyW0M8gY4U5NM1WLeXA==",
+          "resolved": "",
           "dev": true,
           "requires": {
             "handlebars": "^4.1.2"
@@ -3532,8 +3540,7 @@
         },
         "yargs-parser": {
           "version": "15.0.0",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.0.tgz",
-          "integrity": "sha512-xLTUnCMc4JhxrPEPUYD5IBR1mWCK/aT6+RJ/K29JY2y1vD+FhtgKK0AXRWvI262q3QSffAQuTouFIKUuHX89wQ==",
+          "resolved": "",
           "dev": true,
           "requires": {
             "camelcase": "^5.0.0",
@@ -4652,6 +4659,13 @@
         "object-assign": "^4.0.1"
       }
     },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
+      "optional": true
+    },
     "fill-range": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
@@ -4782,6 +4796,8 @@
       "dev": true,
       "optional": true,
       "requires": {
+        "bindings": "^1.5.0",
+        "nan": "^2.12.1",
         "node-pre-gyp": "*"
       },
       "dependencies": {
@@ -8583,6 +8599,13 @@
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
       "dev": true
+    },
+    "nan": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
+      "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==",
+      "dev": true,
+      "optional": true
     },
     "nanomatch": {
       "version": "1.2.13",

--- a/server/package.json
+++ b/server/package.json
@@ -7,7 +7,7 @@
     "build": "transpilied_build"
   },
   "engines": {
-    "node": "^9.0"
+    "node": "^10.0"
   },
   "dependencies": {
     "body-parser": "^1.19.0",
@@ -29,7 +29,6 @@
     "@babel/cli": "^7.8.4",
     "@babel/core": "^7.6.2",
     "@babel/node": "^7.6.2",
-    "@babel/plugin-proposal-object-rest-spread": "^7.6.2",
     "@babel/plugin-transform-modules-commonjs": "^7.6.0",
     "@babel/preset-env": "^7.6.2",
     "babel-core": "^7.0.0-bridge.0",


### PR DESCRIPTION
Wasn't in any rush, still going to be transpiling these until we finally get node 12 in google cloud functions. Node 8 GCFs are getting deprecated in August though (Node 8's end-of-life, no more security patches), so gotta bump up now. 