### PR TITLE
Right aligning numbers in tables

### DIFF
--- a/client/src/components/DisplayTable/DisplayTable.js
+++ b/client/src/components/DisplayTable/DisplayTable.js
@@ -251,7 +251,15 @@ export class DisplayTable extends React.Component {
             {_.map(sorted_filtered_data, (row, i) => (
               <tr key={i}>
                 {_.map(ordered_column_keys, (col_key) => (
-                  <td style={{ fontSize: "14px" }} key={col_key}>
+                  <td style={{ fontSize: "14px", textAlign: 
+                    col_configs_with_defaults[col_key].formatter ? 
+                      _.isString(col_configs_with_defaults[col_key].formatter) ?
+                        !isNaN(row[col_key]) ? "right" : undefined
+                      : _.isString(col_configs_with_defaults[col_key].formatter(row[col_key])) ?
+                        !isNaN(_.replace(col_configs_with_defaults[col_key].formatter(row[col_key]), /[\W]+/g, "")) ?
+                          "right" : undefined
+                      : undefined
+                    : undefined }} key={col_key}>
                     {col_configs_with_defaults[col_key].formatter ? (
                       _.isString(
                         col_configs_with_defaults[col_key].formatter


### PR DESCRIPTION
closes #633 

Pure numbers in tables should now be right aligned in their table cells.

![image](https://user-images.githubusercontent.com/25855114/84196207-e5b19880-aa6d-11ea-945e-ad418e46e8e1.png)

![image](https://user-images.githubusercontent.com/25855114/84196234-eea26a00-aa6d-11ea-9551-269fd3778c14.png)

![image](https://user-images.githubusercontent.com/25855114/84196248-f4984b00-aa6d-11ea-86b6-156bf6b0bf78.png)

![image](https://user-images.githubusercontent.com/25855114/84196284-fcf08600-aa6d-11ea-8758-4a03865424d3.png)

This solution still does not implement classes as to avoid the issue of easy to "abuse" styling of the columns. However, it can easily be implemented if desired.

The original solution was re-implemented without the usage of style objects to avoid the same issue above.

Regex corrections have been made and all "pure numbers" should align to the right (as to allow for easy comparison of values). Non-right aligned styling will be left to default using javascript falsey values.

Config is not longer used (the assumption is that all tables containing "pure numbers" should always have the "pure numbers" right aligned)