### PR TITLE
Remove reduce population by from titles

### DIFF
--- a/client/src/panels/panel_declarations/people/employee_executive_level.yaml
+++ b/client/src/panels/panel_declarations/people/employee_executive_level.yaml
@@ -1,7 +1,7 @@
 employee_executive_level_title:
   transform: [handlebars]
   en: Executive Level ({{ppl_last_year_5}} to {{ppl_last_year}})
-  fr: Population selon les niveaux des cadres supérieurs ({{ppl_last_year_5}} à {{ppl_last_year}})
+  fr: Niveaux des cadres supérieurs ({{ppl_last_year_5}} à {{ppl_last_year}})
 
 gov_employee_executive_level_text:
   transform: [handlebars,markdown]

--- a/client/src/panels/panel_declarations/people/employee_executive_level.yaml
+++ b/client/src/panels/panel_declarations/people/employee_executive_level.yaml
@@ -1,6 +1,6 @@
 employee_executive_level_title:
   transform: [handlebars]
-  en: Population by Executive Level ({{ppl_last_year_5}} to {{ppl_last_year}})
+  en: Executive Level ({{ppl_last_year_5}} to {{ppl_last_year}})
   fr: Population selon les niveaux des cadres supérieurs ({{ppl_last_year_5}} à {{ppl_last_year}})
 
 gov_employee_executive_level_text:

--- a/client/src/panels/panel_declarations/people/employee_fol.yaml
+++ b/client/src/panels/panel_declarations/people/employee_fol.yaml
@@ -1,7 +1,7 @@
 employee_fol_title:
   transform: [handlebars]
   en: First Official Language ({{ppl_last_year_5}} to {{ppl_last_year}})
-  fr: Population selon la première langue officielle ({{ppl_last_year_5}} to {{ppl_last_year}})
+  fr: Première langue officielle ({{ppl_last_year_5}} to {{ppl_last_year}})
 
 gov_employee_fol_text:
   transform: [handlebars,markdown]

--- a/client/src/panels/panel_declarations/people/employee_fol.yaml
+++ b/client/src/panels/panel_declarations/people/employee_fol.yaml
@@ -1,6 +1,6 @@
 employee_fol_title:
   transform: [handlebars]
-  en: Population by First Official Language ({{ppl_last_year_5}} to {{ppl_last_year}})
+  en: First Official Language ({{ppl_last_year_5}} to {{ppl_last_year}})
   fr: Population selon la première langue officielle ({{ppl_last_year_5}} to {{ppl_last_year}})
 
 gov_employee_fol_text:

--- a/client/src/panels/panel_declarations/people/employee_gender.yaml
+++ b/client/src/panels/panel_declarations/people/employee_gender.yaml
@@ -1,6 +1,6 @@
 employee_gender_title:
   transform: [handlebars]
-  en: Population by Gender ({{ppl_last_year_5}} to {{ppl_last_year}})
+  en: Gender ({{ppl_last_year_5}} to {{ppl_last_year}})
   fr: Population selon le sexe ({{ppl_last_year_5}} à {{ppl_last_year}})
 
 gov_employee_gender_text:

--- a/client/src/panels/panel_declarations/people/employee_gender.yaml
+++ b/client/src/panels/panel_declarations/people/employee_gender.yaml
@@ -1,7 +1,7 @@
 employee_gender_title:
   transform: [handlebars]
-  en: Gender ({{ppl_last_year_5}} to {{ppl_last_year}})
-  fr: Sexe ({{ppl_last_year_5}} à {{ppl_last_year}})
+  en: Employee Gender ({{ppl_last_year_5}} to {{ppl_last_year}})
+  fr: Sexe des employés ({{ppl_last_year_5}} à {{ppl_last_year}})
 
 gov_employee_gender_text:
   transform: [handlebars,markdown]

--- a/client/src/panels/panel_declarations/people/employee_gender.yaml
+++ b/client/src/panels/panel_declarations/people/employee_gender.yaml
@@ -1,7 +1,7 @@
 employee_gender_title:
   transform: [handlebars]
   en: Gender ({{ppl_last_year_5}} to {{ppl_last_year}})
-  fr: Population selon le sexe ({{ppl_last_year_5}} à {{ppl_last_year}})
+  fr: Sexe ({{ppl_last_year_5}} à {{ppl_last_year}})
 
 gov_employee_gender_text:
   transform: [handlebars,markdown]

--- a/client/src/panels/panel_declarations/people/employee_prov.yaml
+++ b/client/src/panels/panel_declarations/people/employee_prov.yaml
@@ -21,7 +21,7 @@ gov_employee_prov_text:
     
 employee_prov_title: 
   transform: [handlebars]
-  en: Population by Geographic Region ({{ppl_last_year_5}} to {{ppl_last_year}})
+  en: Geographic Region ({{ppl_last_year_5}} to {{ppl_last_year}})
   fr: Population selon la région géographique ({{ppl_last_year_5}} à {{ppl_last_year}})
 
 

--- a/client/src/panels/panel_declarations/people/employee_prov.yaml
+++ b/client/src/panels/panel_declarations/people/employee_prov.yaml
@@ -22,7 +22,7 @@ gov_employee_prov_text:
 employee_prov_title: 
   transform: [handlebars]
   en: Geographic Region ({{ppl_last_year_5}} to {{ppl_last_year}})
-  fr: Population selon la région géographique ({{ppl_last_year_5}} à {{ppl_last_year}})
+  fr: Région géographique ({{ppl_last_year_5}} à {{ppl_last_year}})
 
 
 dept_employee_prov_text:

--- a/client/src/panels/panel_declarations/people/employee_type.yaml
+++ b/client/src/panels/panel_declarations/people/employee_type.yaml
@@ -1,6 +1,6 @@
 employee_type_title:
   transform: [handlebars]
-  en: Population by Employee Type ({{ppl_last_year_5}} to {{ppl_last_year}})
+  en: Employee Type ({{ppl_last_year_5}} to {{ppl_last_year}})
   fr: Population selon le type d’employé ({{ppl_last_year_5}} à {{ppl_last_year}})
 
 gov_employee_type_text:

--- a/client/src/panels/panel_declarations/people/employee_type.yaml
+++ b/client/src/panels/panel_declarations/people/employee_type.yaml
@@ -1,7 +1,7 @@
 employee_type_title:
   transform: [handlebars]
   en: Employee Type ({{ppl_last_year_5}} to {{ppl_last_year}})
-  fr: Population selon le type d’employé ({{ppl_last_year_5}} à {{ppl_last_year}})
+  fr: Type d’employé ({{ppl_last_year_5}} à {{ppl_last_year}})
 
 gov_employee_type_text:
   transform: [handlebars,markdown]

--- a/client/src/tables/orgEmployeeAgeGroup.js
+++ b/client/src/tables/orgEmployeeAgeGroup.js
@@ -29,13 +29,13 @@ export default {
   },
 
   name: {
-    en: "Population by Employee Age Group",
-    fr: "Population selon le groupe d’âge",
+    en: "Employee Age Group",
+    fr: "Groupe d’âge",
   },
 
   title: {
-    en: "Population by Employee Age Group",
-    fr: "Population selon le groupe d’âge",
+    en: "Employee Age Group",
+    fr: "Groupe d’âge",
   },
 
   add_cols: function () {

--- a/client/src/tables/orgEmployeeExLvl.js
+++ b/client/src/tables/orgEmployeeExLvl.js
@@ -27,13 +27,13 @@ export default {
   },
 
   name: {
-    en: "Population by Executive Level",
-    fr: "Population selon les niveaux des cadres supérieurs",
+    en: "Executive Level",
+    fr: "Niveaux des cadres supérieurs",
   },
 
   title: {
-    en: "Population by Executive Level",
-    fr: "Population selon les niveaux des cadres supérieurs",
+    en: "Executive Level",
+    fr: "Niveaux des cadres supérieurs",
   },
 
   add_cols: function () {

--- a/client/src/tables/orgEmployeeExLvl.yaml
+++ b/client/src/tables/orgEmployeeExLvl.yaml
@@ -1,7 +1,7 @@
 orgEmployeeExLvl_title:
   transform: [handlebars]
-  en: Population by Executive Level
-  fr: Population selon les niveaux des cadres supérieurs
+  en: Executive Level
+  fr: Nveaux des cadres supérieurs
 
 orgEmployeeExLvl_short:
   transform: [handlebars,embeded-markdown, markdown]

--- a/client/src/tables/orgEmployeeFol.js
+++ b/client/src/tables/orgEmployeeFol.js
@@ -27,13 +27,13 @@ export default {
   },
 
   name: {
-    en: "Population by First Official Language",
-    fr: "Population selon la première langue officielle",
+    en: "First Official Language",
+    fr: "Première langue officielle",
   },
 
   title: {
-    en: "Population by First Official Language",
-    fr: "Population selon la première langue officielle",
+    en: "First Official Language",
+    fr: "Première langue officielle",
   },
 
   add_cols: function () {

--- a/client/src/tables/orgEmployeeFol.yaml
+++ b/client/src/tables/orgEmployeeFol.yaml
@@ -1,7 +1,7 @@
 orgEmployeeFol_title:
   transform: [handlebars]
-  en: Population by First Official Language
-  fr: Population selon la première langue officielle
+  en: First Official Language
+  fr: Première langue officielle
 
 orgEmployeeFol_short:
   transform: [handlebars,embeded-markdown,markdown]

--- a/client/src/tables/orgEmployeeGender.js
+++ b/client/src/tables/orgEmployeeGender.js
@@ -27,13 +27,13 @@ export default {
   },
 
   name: {
-    en: "Population by Employee Gender",
-    fr: "Population selon le sexe",
+    en: "Employee Gender",
+    fr: "Sexe",
   },
 
   title: {
-    en: "Population by Employee Gender",
-    fr: "Population selon le sexe",
+    en: "Employee Gender",
+    fr: "Sexe",
   },
 
   add_cols: function () {

--- a/client/src/tables/orgEmployeeGender.js
+++ b/client/src/tables/orgEmployeeGender.js
@@ -28,12 +28,12 @@ export default {
 
   name: {
     en: "Employee Gender",
-    fr: "Sexe",
+    fr: "Sexe des employés",
   },
 
   title: {
     en: "Employee Gender",
-    fr: "Sexe",
+    fr: "Sexe des employés",
   },
 
   add_cols: function () {

--- a/client/src/tables/orgEmployeeGender.yaml
+++ b/client/src/tables/orgEmployeeGender.yaml
@@ -1,7 +1,7 @@
 orgEmployeeGender_title:
   transform: [handlebars]
-  en: Population by Gender
-  fr: Population selon le sexe
+  en: Gender
+  fr: Sexe
 
 orgEmployeeGender_short:
   transform: [handlebars,embeded-markdown,markdown]

--- a/client/src/tables/orgEmployeeGender.yaml
+++ b/client/src/tables/orgEmployeeGender.yaml
@@ -1,7 +1,7 @@
 orgEmployeeGender_title:
   transform: [handlebars]
-  en: Gender
-  fr: Sexe
+  en: Employee Gender
+  fr: Sexe des employés
 
 orgEmployeeGender_short:
   transform: [handlebars,embeded-markdown,markdown]

--- a/client/src/tables/orgEmployeeRegion.js
+++ b/client/src/tables/orgEmployeeRegion.js
@@ -29,13 +29,13 @@ export default {
   },
 
   name: {
-    en: "Population by Geographic Region",
-    fr: "Population selon la région géographique",
+    en: "Geographic Region",
+    fr: "Région géographique",
   },
 
   title: {
-    en: "Population by Geographic Region",
-    fr: "Population selon la région géographique",
+    en: "Geographic Region",
+    fr: "Région géographique",
   },
 
   add_cols: function () {

--- a/client/src/tables/orgEmployeeType.js
+++ b/client/src/tables/orgEmployeeType.js
@@ -27,13 +27,13 @@ export default {
   },
 
   name: {
-    en: "Population by Employee Type",
-    fr: "Population selon le type d’employé",
+    en: "Employee Type",
+    fr: "Type d’employé",
   },
 
   title: {
-    en: "Population by Employee Type",
-    fr: "Population selon le type d’employé",
+    en: "Employee Type",
+    fr: "Type d’employé",
   },
 
   add_cols: function () {


### PR DESCRIPTION
Closes #655 

Removes the term "population by" from panel titles.

Haven't made the change for the french version yet. I did also notice a few other yaml files but I couldn't figure out exactly where they were being used so for now I didn't change them.