### PR TITLE
Fix Gross and Net Planned Spending

### DIFF
--- a/client/src/panels/panel_declarations/finances/drr_dp_resources/dp_rev_split.js
+++ b/client/src/panels/panel_declarations/finances/drr_dp_resources/dp_rev_split.js
@@ -73,13 +73,13 @@ export const declare_dp_rev_split_panel = () =>
           },
           net: {
             index: 1,
-            header: text_maker("dp_gross"),
+            header: text_maker("dp_net"),
             is_summable: true,
             formatter: "dollar",
           },
           gross: {
             index: 2,
-            header: text_maker("dp_revenue"),
+            header: text_maker("dp_gross"),
             is_summable: true,
             formatter: "dollar",
           },
@@ -91,7 +91,7 @@ export const declare_dp_rev_split_panel = () =>
           },
           rev: {
             index: 4,
-            header: text_maker("dp_net"),
+            header: text_maker("dp_revenue"),
             is_summable: true,
             formatter: "dollar",
           },


### PR DESCRIPTION
closes #674 

![image](https://user-images.githubusercontent.com/25855114/86632839-e4f12100-bf9d-11ea-8081-524efe857577.png)

Taken from JUS. I've verified the numbers for year 1 of spa, gross, and rev and now seem to be correct (that is, it now matches program_spending.csv).

It seems like the header was put in the wrong place rather than there being a miscalculation.
