### PR TITLE
Update single drr indicator look

### DIFF
--- a/client/src/panels/panel_declarations/results/drr_summary.js
+++ b/client/src/panels/panel_declarations/results/drr_summary.js
@@ -97,7 +97,7 @@ const StatusGrid = (props) => {
   );
 
   const data = _.chain(props)
-    .pickBy((val, key) => key)
+    .pickBy((val, key) => (key && val > 0) || future === total)
     .toPairs()
     .groupBy(([key, val]) => key)
     .map((amounts, status_key) => {
@@ -192,7 +192,7 @@ class PercentageViz extends React.Component {
       .value();
 
     const default_selected =
-      _.without(present_ids, "future").length > 1
+      _.reject(present_ids, (value, key) => key === "future").length > 0
         ? _.without(all_ids, "future")
         : all_ids;
 

--- a/client/src/panels/panel_declarations/results/drr_summary.js
+++ b/client/src/panels/panel_declarations/results/drr_summary.js
@@ -96,8 +96,10 @@ const StatusGrid = (props) => {
     total < 100 && "IconArrayItem__Large"
   );
 
+  const is_single_indicator = _.some(props, (value) => value === total);
+
   const data = _.chain(props)
-    .pickBy((val, key) => (key && val > 0) || future === total)
+    .pickBy((val, key) => val > 0 || is_single_indicator)
     .toPairs()
     .groupBy(([key, val]) => key)
     .map((amounts, status_key) => {


### PR DESCRIPTION
Noticed that my changes made future results always be selected by default. The status grid would also always show the full legend. I've made some changes so that only when a single indicator is present, that the visual changes are made.

Now, matching what is shown on the live site:
![image](https://user-images.githubusercontent.com/25855114/89906906-f25f8380-dbb9-11ea-86e6-d16b504c8a98.png)

Before: 
![image](https://user-images.githubusercontent.com/25855114/89906992-0f945200-dbba-11ea-8537-30a953d0470e.png)

Single indicator remains the same:
![image](https://user-images.githubusercontent.com/25855114/89907185-54b88400-dbba-11ea-90f9-077fcd57e287.png)
