### PR TITLE
write out FTE in results drilldown

### DIFF
--- a/client/src/common_text/common_lang.yaml
+++ b/client/src/common_text/common_lang.yaml
@@ -993,7 +993,7 @@ planned_spending_header:
 planned_ftes_header:
   transform: [handlebars]
   en: |
-    {{year}} Number of Planned FTEs
+    {{year}} Number of Planned Full Time Equivalents
   fr: |
     Nombre d'ETP prévus pour {{year}} 
 
@@ -1007,7 +1007,7 @@ actual_spending_header:
 actual_ftes_header:
   transform: [handlebars]
   en: |
-    {{year}} Number of FTEs
+    {{year}} Number of Full Time Equivalents
   fr: |
     Nombre d'ETP pour {{year}} 
 

--- a/client/src/panels/panel_declarations/results/result_drilldown/result_drilldown.js
+++ b/client/src/panels/panel_declarations/results/result_drilldown/result_drilldown.js
@@ -67,7 +67,7 @@ const get_non_col_content_func = createSelector(_.property("doc"), (doc) => {
       result_docs[doc].has_resources && (
         <DlItem
           key={1}
-          term={<span className="nowrap">{spending_header(doc)}</span>}
+          term={<span>{spending_header(doc)}</span>}
           def={
             <Format
               type="compact1"
@@ -79,7 +79,7 @@ const get_non_col_content_func = createSelector(_.property("doc"), (doc) => {
       result_docs[doc].has_resources && (
         <DlItem
           key={2}
-          term={<span className="nowrap">{fte_header(doc)}</span>}
+          term={<span>{fte_header(doc)}</span>}
           def={
             <Format
               type="big_int"


### PR DESCRIPTION
I genuinely went through whole IB and actually couldn't find much acronyms other than FTEs. Which was written out fully with tooltip definition somewhere in the same panel (like welcome mat).

This was the only place where I found an acronym (FTE) that's not defined or fully written out. Didn't wanna put tooltip definition for performance concerns here. I think this PR closes #644 but this is probably a bold overstatement so let me know if my findings aren't correct