### PR TITLE
Glossary nesting warning fix

### DIFF
--- a/client/src/glossary/glossary.js
+++ b/client/src/glossary/glossary.js
@@ -128,7 +128,7 @@ const Glossary_ = ({ active_key, items_by_letter }) => (
 
                   {table_links_by_tag[item.id] && (
                     <span>
-                      {text_maker("glossary_related_data")}{" "}
+                      {text_maker("glossary_related_data")}
                       {table_links_by_tag[item.id]}
                     </span>
                   )}

--- a/client/src/glossary/glossary.js
+++ b/client/src/glossary/glossary.js
@@ -127,10 +127,10 @@ const Glossary_ = ({ active_key, items_by_letter }) => (
                   </p>
 
                   {table_links_by_tag[item.id] && (
-                    <p>
+                    <span>
                       {text_maker("glossary_related_data")}{" "}
                       {table_links_by_tag[item.id]}
-                    </p>
+                    </span>
                   )}
 
                   <div className="glossary-top-link-container">


### PR DESCRIPTION
\<p> should only contain inline elements.

![image](https://user-images.githubusercontent.com/25855114/90155734-a9463580-dd59-11ea-8604-67abb62b21c9.png)
