### PR TITLE
fix text bug in CR result drilldowns

### DIFF
--- a/client/src/panels/panel_declarations/misc/warning_panels.yaml
+++ b/client/src/panels/panel_declarations/misc/warning_panels.yaml
@@ -5,7 +5,7 @@ dead_crso_warning:
 dead_program_warning_text:
   transform: [handlebars, markdown]
   en: |
-    Unless you're here for historical financial data, select the 'Where can I go from here?' topic above to see all of **{{subject.name.dept}}**'s Programs.
+    Unless you're here for historical financial data, select the 'Where can I go from here?' topic above to see all of **{{subject.dept.name}}**'s Programs.
   fr: |
     À moins que vous voulez des donées financières historiques, sélectionnez le sujet «Où puis-je aller à partir d'ici?» ci-dessus pour voir tous les Programmes **{{de_dept subject.dept}}**.
 dead_program_warning:

--- a/client/src/panels/panel_declarations/results/result_drilldown/result_drilldown.yaml
+++ b/client/src/panels/panel_declarations/results/result_drilldown/result_drilldown.yaml
@@ -66,9 +66,9 @@ result_counts_dp_dept:
 result_counts_dp_cr:
   transform: [handlebars,markdown]
   en: |
-    In {{doc_year}}, **{{subject.name.dept}}** is seeking to achieve **{{fmt_big_int num_results}}** {{plural_branch num_results "result" "results"}} under the {{gl_tt "Core Responsibility" "CR"}} **"{{subject.name}}"** comprised of **{{fmt_big_int num_programs}}** {{plural_branch num_programs "program" "programs"}}. {{> "future_tense_results_progress_fragment_en"}}
+    In {{doc_year}}, **{{subject.dept.name}}** is seeking to achieve **{{fmt_big_int num_results}}** {{plural_branch num_results "result" "results"}} under the {{gl_tt "Core Responsibility" "CR"}} **"{{subject.name}}"** comprised of **{{fmt_big_int num_programs}}** {{plural_branch num_programs "program" "programs"}}. {{> "future_tense_results_progress_fragment_en"}}
   fr: |
-    En {{doc_year}}, **{{subject.name.dept}}** cherche à rencontrer **{{fmt_big_int num_results}}** {{plural_branch num_results "résultat" "résultats"}} sous la {{gl_tt "responsabilité essentielle" "CR"}} **«{{subject.name}}»** appuyé par **{{fmt_big_int num_programs}}** {{plural_branch num_programs "programme" "programmes"}}. {{> "future_tense_results_progress_fragment_fr"}}
+    En {{doc_year}}, **{{subject.dept.name}}** cherche à rencontrer **{{fmt_big_int num_results}}** {{plural_branch num_results "résultat" "résultats"}} sous la {{gl_tt "responsabilité essentielle" "CR"}} **«{{subject.name}}»** appuyé par **{{fmt_big_int num_programs}}** {{plural_branch num_programs "programme" "programmes"}}. {{> "future_tense_results_progress_fragment_fr"}}
 result_counts_dp_prog:
   transform: [handlebars,markdown]
   en: |


### PR DESCRIPTION
Fixes this:
<img width="1242" alt="Screen Shot 2020-08-31 at 7 45 04 PM" src="https://user-images.githubusercontent.com/7769215/91779139-ae610c80-ebc2-11ea-93d5-b2d4522d73ba.png">
