### PR TITLE
add import linting and sorting

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -14,7 +14,7 @@
         "commonjs": true,
         "es6": true
     },
-    "extends": [ "eslint:recommended" ],
+    "extends": [ "eslint:recommended" , "plugin:import/warnings", "plugin:import/errors"],
     "rules": {
         "no-unused-vars": [
             "warn",

--- a/client/.eslintrc.json
+++ b/client/.eslintrc.json
@@ -50,18 +50,19 @@
           },
           {
             "pattern": "src/components/**/*.js",
-            "group": "external",
-            "position": "after"
+            "group": "internal",
+            "position": "before"
           },
           {
             "pattern": "src/models/**/*.js",
-            "group": "external",
-            "position": "after"
+            "group": "internal",
+            "position": "before"
+
           },
           {
             "pattern": "src/core/**/*.js",
-            "group": "external",
-            "position": "after"
+            "group": "internal",
+            "position": "before"
           }
         ]          
       }

--- a/client/.eslintrc.json
+++ b/client/.eslintrc.json
@@ -49,17 +49,17 @@
             "position": "after"
           },
           {
-            "pattern": "components/**/*.js",
+            "pattern": "src/components/**/*.js",
             "group": "external",
             "position": "after"
           },
           {
-            "pattern": "models/**/*.js",
+            "pattern": "src/models/**/*.js",
             "group": "external",
             "position": "after"
           },
           {
-            "pattern": "core/**/*.js",
+            "pattern": "src/core/**/*.js",
             "group": "external",
             "position": "after"
           }
@@ -73,7 +73,7 @@
     },
     "import/resolver":{
       "node": {
-        "moduleDirectory": ["src/","node_modules/"]
+        "moduleDirectory": ["./","node_modules/"]
       }
     }
   },

--- a/client/.eslintrc.json
+++ b/client/.eslintrc.json
@@ -1,6 +1,7 @@
 {
   "plugins": [
-    "react"
+    "react",
+    "import"
   ],
   "parser": "babel-eslint",
   "parserOptions": {

--- a/client/.eslintrc.json
+++ b/client/.eslintrc.json
@@ -26,11 +26,55 @@
       "react/no-string-refs": [ "off" ],
       "react/display-name": [ "off" ],
       "react/no-find-dom-node": [ "off" ],
-      "react/no-children-prop": [ "off" ]
+      "react/no-children-prop": [ "off" ],
+    "import/order": [
+      "warn", { 
+        "newlines-between": "always-and-inside-groups",
+        "alphabetize": {
+          "order": "asc",
+          "caseInsensitive": true 
+        },
+        "groups": [
+          "builtin",
+          "external",
+          "internal",
+          "parent",
+          ["sibling", "index"]
+        ],
+        // We can group imports further by adding rules here, the order they're defined in breaks ties when group and position are equal
+        "pathGroups":[
+          {
+            "pattern": "./*.yaml",
+            "group": "index",
+            "position": "after"
+          },
+          {
+            "pattern": "components/**/*.js",
+            "group": "external",
+            "position": "after"
+          },
+          {
+            "pattern": "models/**/*.js",
+            "group": "external",
+            "position": "after"
+          },
+          {
+            "pattern": "core/**/*.js",
+            "group": "external",
+            "position": "after"
+          }
+        ]          
+      }
+    ]
   },
   "settings": {
     "react": {
       "version": "16"
+    },
+    "import/resolver":{
+      "node": {
+        "moduleDirectory": ["src/","node_modules/"]
+      }
     }
   },
   "globals": {

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -3416,6 +3416,11 @@
         "@types/node": "*"
       }
     },
+    "@types/json5": {
+      "version": "0.0.29",
+      "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
+      "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4="
+    },
     "@types/lodash": {
       "version": "4.14.149",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.149.tgz",
@@ -3939,6 +3944,92 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
       "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
+    },
+    "array.prototype.flat": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.2.3.tgz",
+      "integrity": "sha512-gBlRZV0VSmfPIeWfuuy56XZMvbVfbEUnOXUvt3F/eUUUSyzlgLxhEX4YAEpxNAogRGehPSnfXyPtYyKAhkzQhQ==",
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.1"
+      },
+      "dependencies": {
+        "define-properties": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+          "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+          "requires": {
+            "object-keys": "^1.0.12"
+          }
+        },
+        "es-abstract": {
+          "version": "1.17.6",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
+          "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.2.0",
+            "is-regex": "^1.1.0",
+            "object-inspect": "^1.7.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.0",
+            "string.prototype.trimend": "^1.0.1",
+            "string.prototype.trimstart": "^1.0.1"
+          }
+        },
+        "es-to-primitive": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+          "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+          "requires": {
+            "is-callable": "^1.1.4",
+            "is-date-object": "^1.0.1",
+            "is-symbol": "^1.0.2"
+          }
+        },
+        "has": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+          "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+          "requires": {
+            "function-bind": "^1.1.1"
+          }
+        },
+        "has-symbols": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+          "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
+        },
+        "is-callable": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.0.tgz",
+          "integrity": "sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw=="
+        },
+        "is-regex": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.1.tgz",
+          "integrity": "sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==",
+          "requires": {
+            "has-symbols": "^1.0.1"
+          }
+        },
+        "is-symbol": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
+          "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
+          "requires": {
+            "has-symbols": "^1.0.1"
+          }
+        },
+        "object-keys": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+          "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
+        }
+      }
     },
     "arrify": {
       "version": "1.0.1",
@@ -6842,6 +6933,11 @@
       "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
       "integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U="
     },
+    "contains-path": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
+      "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo="
+    },
     "convert-source-map": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
@@ -7971,6 +8067,25 @@
         }
       }
     },
+    "eslint-import-resolver-node": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.4.tgz",
+      "integrity": "sha512-ogtf+5AB/O+nM6DIeBUNr2fuT7ot9Qg/1harBfBtaP13ekEWFQEEMP94BCB7zaNW3gyY+8SHYF00rnqYwXKWOA==",
+      "requires": {
+        "debug": "^2.6.9",
+        "resolve": "^1.13.1"
+      },
+      "dependencies": {
+        "resolve": {
+          "version": "1.17.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
+          "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+          "requires": {
+            "path-parse": "^1.0.6"
+          }
+        }
+      }
+    },
     "eslint-loader": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/eslint-loader/-/eslint-loader-2.1.1.tgz",
@@ -7981,6 +8096,273 @@
         "object-assign": "^4.0.1",
         "object-hash": "^1.1.4",
         "rimraf": "^2.6.1"
+      }
+    },
+    "eslint-module-utils": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.6.0.tgz",
+      "integrity": "sha512-6j9xxegbqe8/kZY8cYpcp0xhbK0EgJlg3g9mib3/miLaExuuwc3n5UEfSnU6hWMbT0FAYVvDbL9RrRgpUeQIvA==",
+      "requires": {
+        "debug": "^2.6.9",
+        "pkg-dir": "^2.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "requires": {
+            "locate-path": "^2.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+          "requires": {
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+          "requires": {
+            "p-try": "^1.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+          "requires": {
+            "p-limit": "^1.1.0"
+          }
+        },
+        "p-try": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
+        },
+        "pkg-dir": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
+          "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
+          "requires": {
+            "find-up": "^2.1.0"
+          }
+        }
+      }
+    },
+    "eslint-plugin-import": {
+      "version": "2.22.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.22.0.tgz",
+      "integrity": "sha512-66Fpf1Ln6aIS5Gr/55ts19eUuoDhAbZgnr6UxK5hbDx6l/QgQgx61AePq+BV4PP2uXQFClgMVzep5zZ94qqsxg==",
+      "requires": {
+        "array-includes": "^3.1.1",
+        "array.prototype.flat": "^1.2.3",
+        "contains-path": "^0.1.0",
+        "debug": "^2.6.9",
+        "doctrine": "1.5.0",
+        "eslint-import-resolver-node": "^0.3.3",
+        "eslint-module-utils": "^2.6.0",
+        "has": "^1.0.3",
+        "minimatch": "^3.0.4",
+        "object.values": "^1.1.1",
+        "read-pkg-up": "^2.0.0",
+        "resolve": "^1.17.0",
+        "tsconfig-paths": "^3.9.0"
+      },
+      "dependencies": {
+        "array-includes": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.1.tgz",
+          "integrity": "sha512-c2VXaCHl7zPsvpkFsw4nxvFie4fh1ur9bpcgsVkIjqn0H/Xwdg+7fv3n2r/isyS8EBj5b06M9kHyZuIr4El6WQ==",
+          "requires": {
+            "define-properties": "^1.1.3",
+            "es-abstract": "^1.17.0",
+            "is-string": "^1.0.5"
+          }
+        },
+        "define-properties": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+          "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+          "requires": {
+            "object-keys": "^1.0.12"
+          }
+        },
+        "doctrine": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
+          "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
+          "requires": {
+            "esutils": "^2.0.2",
+            "isarray": "^1.0.0"
+          }
+        },
+        "es-abstract": {
+          "version": "1.17.6",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
+          "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.2.0",
+            "is-regex": "^1.1.0",
+            "object-inspect": "^1.7.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.0",
+            "string.prototype.trimend": "^1.0.1",
+            "string.prototype.trimstart": "^1.0.1"
+          }
+        },
+        "es-to-primitive": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+          "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+          "requires": {
+            "is-callable": "^1.1.4",
+            "is-date-object": "^1.0.1",
+            "is-symbol": "^1.0.2"
+          }
+        },
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "requires": {
+            "locate-path": "^2.0.0"
+          }
+        },
+        "has": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+          "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+          "requires": {
+            "function-bind": "^1.1.1"
+          }
+        },
+        "has-symbols": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+          "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
+        },
+        "is-callable": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.0.tgz",
+          "integrity": "sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw=="
+        },
+        "is-regex": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.1.tgz",
+          "integrity": "sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==",
+          "requires": {
+            "has-symbols": "^1.0.1"
+          }
+        },
+        "is-symbol": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
+          "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
+          "requires": {
+            "has-symbols": "^1.0.1"
+          }
+        },
+        "load-json-file": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+          "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "strip-bom": "^3.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+          "requires": {
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "object-keys": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+          "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
+        },
+        "p-limit": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+          "requires": {
+            "p-try": "^1.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+          "requires": {
+            "p-limit": "^1.1.0"
+          }
+        },
+        "p-try": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
+        },
+        "path-type": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+          "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+          "requires": {
+            "pify": "^2.0.0"
+          }
+        },
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+        },
+        "read-pkg": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+          "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+          "requires": {
+            "load-json-file": "^2.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^2.0.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+          "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+          "requires": {
+            "find-up": "^2.0.0",
+            "read-pkg": "^2.0.0"
+          }
+        },
+        "resolve": {
+          "version": "1.17.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
+          "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+          "requires": {
+            "path-parse": "^1.0.6"
+          }
+        },
+        "strip-bom": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
+        }
       }
     },
     "eslint-plugin-react": {
@@ -9647,6 +10029,11 @@
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
     },
+    "is-string": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.5.tgz",
+      "integrity": "sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ=="
+    },
     "is-symbol": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
@@ -11261,6 +11648,11 @@
       "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-1.3.0.tgz",
       "integrity": "sha512-05KzQ70lSeGSrZJQXE5wNDiTkBJDlUT/myi6RX9dVIvz7a7Qh4oH93BQdiPMn27nldYvVQCKMUaM83AfizZlsQ=="
     },
+    "object-inspect": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.8.0.tgz",
+      "integrity": "sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA=="
+    },
     "object-keys": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
@@ -11272,6 +11664,17 @@
       "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
       "requires": {
         "isobject": "^3.0.0"
+      }
+    },
+    "object.assign": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+      "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+      "requires": {
+        "define-properties": "^1.1.2",
+        "function-bind": "^1.1.1",
+        "has-symbols": "^1.0.0",
+        "object-keys": "^1.0.11"
       }
     },
     "object.fromentries": {
@@ -11353,6 +11756,94 @@
       "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
       "requires": {
         "isobject": "^3.0.1"
+      }
+    },
+    "object.values": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.1.tgz",
+      "integrity": "sha512-WTa54g2K8iu0kmS/us18jEmdv1a4Wi//BZ/DTVYEcH0XhLM5NYdpDHja3gt57VrZLcNAO2WGA+KpWsDBaHt6eA==",
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.1",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3"
+      },
+      "dependencies": {
+        "define-properties": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+          "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+          "requires": {
+            "object-keys": "^1.0.12"
+          }
+        },
+        "es-abstract": {
+          "version": "1.17.6",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
+          "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.2.0",
+            "is-regex": "^1.1.0",
+            "object-inspect": "^1.7.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.0",
+            "string.prototype.trimend": "^1.0.1",
+            "string.prototype.trimstart": "^1.0.1"
+          }
+        },
+        "es-to-primitive": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+          "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+          "requires": {
+            "is-callable": "^1.1.4",
+            "is-date-object": "^1.0.1",
+            "is-symbol": "^1.0.2"
+          }
+        },
+        "has": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+          "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+          "requires": {
+            "function-bind": "^1.1.1"
+          }
+        },
+        "has-symbols": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+          "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
+        },
+        "is-callable": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.0.tgz",
+          "integrity": "sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw=="
+        },
+        "is-regex": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.1.tgz",
+          "integrity": "sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==",
+          "requires": {
+            "has-symbols": "^1.0.1"
+          }
+        },
+        "is-symbol": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
+          "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
+          "requires": {
+            "has-symbols": "^1.0.1"
+          }
+        },
+        "object-keys": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+          "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
+        }
       }
     },
     "omggif": {
@@ -15042,6 +15533,178 @@
         }
       }
     },
+    "string.prototype.trimend": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.1.tgz",
+      "integrity": "sha512-LRPxFUaTtpqYsTeNKaFOw3R4bxIzWOnbQ837QfBylo8jIxtcbK/A/sMV7Q+OAV/vWo+7s25pOE10KYSjaSO06g==",
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5"
+      },
+      "dependencies": {
+        "define-properties": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+          "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+          "requires": {
+            "object-keys": "^1.0.12"
+          }
+        },
+        "es-abstract": {
+          "version": "1.17.6",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
+          "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.2.0",
+            "is-regex": "^1.1.0",
+            "object-inspect": "^1.7.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.0",
+            "string.prototype.trimend": "^1.0.1",
+            "string.prototype.trimstart": "^1.0.1"
+          }
+        },
+        "es-to-primitive": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+          "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+          "requires": {
+            "is-callable": "^1.1.4",
+            "is-date-object": "^1.0.1",
+            "is-symbol": "^1.0.2"
+          }
+        },
+        "has": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+          "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+          "requires": {
+            "function-bind": "^1.1.1"
+          }
+        },
+        "has-symbols": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+          "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
+        },
+        "is-callable": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.0.tgz",
+          "integrity": "sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw=="
+        },
+        "is-regex": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.1.tgz",
+          "integrity": "sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==",
+          "requires": {
+            "has-symbols": "^1.0.1"
+          }
+        },
+        "is-symbol": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
+          "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
+          "requires": {
+            "has-symbols": "^1.0.1"
+          }
+        },
+        "object-keys": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+          "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
+        }
+      }
+    },
+    "string.prototype.trimstart": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.1.tgz",
+      "integrity": "sha512-XxZn+QpvrBI1FOcg6dIpxUPgWCPuNXvMD72aaRaUQv1eD4e/Qy8i/hFTe0BUmD60p/QA6bh1avmuPTfNjqVWRw==",
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5"
+      },
+      "dependencies": {
+        "define-properties": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+          "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+          "requires": {
+            "object-keys": "^1.0.12"
+          }
+        },
+        "es-abstract": {
+          "version": "1.17.6",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
+          "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.2.0",
+            "is-regex": "^1.1.0",
+            "object-inspect": "^1.7.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.0",
+            "string.prototype.trimend": "^1.0.1",
+            "string.prototype.trimstart": "^1.0.1"
+          }
+        },
+        "es-to-primitive": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+          "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+          "requires": {
+            "is-callable": "^1.1.4",
+            "is-date-object": "^1.0.1",
+            "is-symbol": "^1.0.2"
+          }
+        },
+        "has": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+          "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+          "requires": {
+            "function-bind": "^1.1.1"
+          }
+        },
+        "has-symbols": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+          "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
+        },
+        "is-callable": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.0.tgz",
+          "integrity": "sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw=="
+        },
+        "is-regex": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.1.tgz",
+          "integrity": "sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==",
+          "requires": {
+            "has-symbols": "^1.0.1"
+          }
+        },
+        "is-symbol": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
+          "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
+          "requires": {
+            "has-symbols": "^1.0.1"
+          }
+        },
+        "object-keys": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+          "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
+        }
+      }
+    },
     "string_decoder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
@@ -16418,6 +17081,32 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz",
       "integrity": "sha1-OTvnMKlEb9Hq1tpZoBQwjzbCics="
+    },
+    "tsconfig-paths": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz",
+      "integrity": "sha512-dRcuzokWhajtZWkQsDVKbWyY+jgcLC5sqJhg2PSgf4ZkH2aHPvaOY8YWGhmjb68b5qqTfasSsDO9k7RUiEmZAw==",
+      "requires": {
+        "@types/json5": "^0.0.29",
+        "json5": "^1.0.1",
+        "minimist": "^1.2.0",
+        "strip-bom": "^3.0.0"
+      },
+      "dependencies": {
+        "json5": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+          "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+          "requires": {
+            "minimist": "^1.2.0"
+          }
+        },
+        "strip-bom": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
+        }
+      }
     },
     "tslib": {
       "version": "1.9.3",

--- a/client/package.json
+++ b/client/package.json
@@ -56,6 +56,7 @@
     "dompurify": "^2.0.7",
     "eslint": "^4.19.1",
     "eslint-loader": "^2.1.1",
+    "eslint-plugin-import": "^2.22.0",
     "eslint-plugin-react": "^7.12.4",
     "filter-chunk-webpack-plugin": "^2.1.0",
     "fs-extra": "^0.26.5",

--- a/client/src/EstimatesComparison/EstimatesComparison.js
+++ b/client/src/EstimatesComparison/EstimatesComparison.js
@@ -1,9 +1,10 @@
-import "./EstimatesComparison.scss";
-import { text_maker, TM } from "./utils.js";
-import { StandardRouteContainer } from "../core/NavComponents";
 import { SpinnerWrapper } from "../components/index.js";
 import { ensure_loaded } from "../core/lazy_loader.js";
+import { StandardRouteContainer } from "../core/NavComponents";
+
 import { EstimatesExplorer } from "./scheme.js";
+import { text_maker, TM } from "./utils.js";
+import "./EstimatesComparison.scss";
 
 export default class EstimatesComparison extends React.Component {
   constructor(props) {

--- a/client/src/EstimatesComparison/EstimatesExplorerComponent.js
+++ b/client/src/EstimatesComparison/EstimatesExplorerComponent.js
@@ -1,7 +1,5 @@
 import classNames from "classnames";
 
-import { infograph_href_template, rpb_link } from "src/link_utils.js";
-import { sources } from "src/metadata/data_sources.js";
 
 import {
   SpinnerWrapper,
@@ -16,6 +14,11 @@ import {
 
 import { Explorer } from "src/explorer_common/explorer_components.js";
 import { get_root } from "src/explorer_common/hierarchy_tools.js";
+import { infograph_href_template, rpb_link } from "src/link_utils.js";
+import { sources } from "src/metadata/data_sources.js";
+
+
+import { businessConstants } from "../models/businessConstants.js";
 
 import {
   text_maker,
@@ -23,8 +26,6 @@ import {
   current_doc_is_mains,
   current_sups_letter,
 } from "./utils.js";
-
-import { businessConstants } from "../models/businessConstants.js";
 
 const { estimates_docs } = businessConstants;
 

--- a/client/src/EstimatesComparison/scheme.js
+++ b/client/src/EstimatesComparison/scheme.js
@@ -1,28 +1,30 @@
 import { createSelector } from "reselect";
 
-import {
-  shallowEqualObjectsOverKeys,
-  cached_property,
-  bound,
-} from "src/general_utils.js";
-import { Format } from "src/components/";
 
-import { Table } from "src/core/TableClass.js";
 
 import FootNote from "src/models/footnotes/footnotes.js";
 import { GlossaryEntry } from "src/models/glossary.js";
 import { Subject } from "src/models/subject.js";
 
-import { convert_d3_hierarchy_to_explorer_hierarchy } from "src/explorer_common/hierarchy_tools.js";
-import { AbstractExplorerScheme } from "src/explorer_common/abstract_explorer_scheme.js";
+import { Table } from "src/core/TableClass.js";
 
+import { Format } from "src/components/";
+
+import { AbstractExplorerScheme } from "src/explorer_common/abstract_explorer_scheme.js";
+import { convert_d3_hierarchy_to_explorer_hierarchy } from "src/explorer_common/hierarchy_tools.js";
+import {
+  shallowEqualObjectsOverKeys,
+  cached_property,
+  bound,
+} from "src/general_utils.js";
+
+import EstimatesExplorerComponent from "./EstimatesExplorerComponent";
 import {
   text_maker,
   TM,
   current_doc_is_mains,
   current_sups_letter,
 } from "./utils.js";
-import EstimatesExplorerComponent from "./EstimatesExplorerComponent";
 
 const { Dept } = Subject;
 

--- a/client/src/EstimatesComparison/utils.js
+++ b/client/src/EstimatesComparison/utils.js
@@ -1,6 +1,7 @@
+import { create_text_maker_component } from "../components/index.js";
+
 import text from "./EstimatesComparison.yaml";
 
-import { create_text_maker_component } from "../components/index.js";
 
 export const { text_maker, TM } = create_text_maker_component(text);
 

--- a/client/src/FAQ/FAQ.js
+++ b/client/src/FAQ/FAQ.js
@@ -1,16 +1,18 @@
-import "./FAQ.scss";
-import text from "./FAQ.yaml";
-import { faq_data } from "./faq_data.js";
-
-import {
-  StandardRouteContainer,
-  ScrollToTargetContainer,
-} from "../core/NavComponents.js";
 import {
   LabeledTable,
   create_text_maker_component,
   FancyUL,
 } from "../components";
+import {
+  StandardRouteContainer,
+  ScrollToTargetContainer,
+} from "../core/NavComponents.js";
+
+import { faq_data } from "./faq_data.js";
+
+import text from "./FAQ.yaml";
+
+import "./FAQ.scss";
 
 const { text_maker, TM } = create_text_maker_component(text);
 

--- a/client/src/FAQ/faq_data.js
+++ b/client/src/FAQ/faq_data.js
@@ -1,6 +1,7 @@
+import marked from "marked";
+
 import faq_csv_string from "../../../data/faq.csv";
 
-import marked from "marked";
 
 const DISABLED_QUESTIONS = [];
 

--- a/client/src/IgocExplorer/IgocExplorer.js
+++ b/client/src/IgocExplorer/IgocExplorer.js
@@ -1,14 +1,19 @@
-import "./IgocExplorer.scss";
-import { StandardRouteContainer } from "../core/NavComponents.js";
 import { createSelector } from "reselect";
 
-//drilldown stuff
-import { create_igoc_hierarchy } from "./hierarchies.js";
-import { ExplorerForIgoc } from "./explorer_view.js";
-import { filter_hierarchy } from "../explorer_common/hierarchy_tools.js";
-import { igoc_tmf as text_maker, TM } from "./igoc_explorer_text.js";
 import { AbstractExplorerScheme } from "src/explorer_common/abstract_explorer_scheme";
+
 import { cached_property, bound } from "src/general_utils.js";
+
+import { StandardRouteContainer } from "../core/NavComponents.js";
+
+//drilldown stuff
+import { filter_hierarchy } from "../explorer_common/hierarchy_tools.js";
+
+import { ExplorerForIgoc } from "./explorer_view.js";
+import { create_igoc_hierarchy } from "./hierarchies.js";
+import { igoc_tmf as text_maker, TM } from "./igoc_explorer_text.js";
+
+import "./IgocExplorer.scss";
 
 class IgocExplorerScheme extends AbstractExplorerScheme {
   Component = ExplorerForIgoc;

--- a/client/src/IgocExplorer/explorer_view.js
+++ b/client/src/IgocExplorer/explorer_view.js
@@ -1,18 +1,18 @@
-import "../explorer_common/explorer-styles.scss";
-import { igoc_tmf as text_maker, TM } from "./igoc_explorer_text.js";
-import { grouping_options } from "./hierarchies.js";
-
+import classNames from "classnames";
 import { Fragment } from "react";
 import { createSelector } from "reselect";
-import classNames from "classnames";
 
-import { get_root } from "../explorer_common/hierarchy_tools.js";
-import { Explorer } from "../explorer_common/explorer_components.js";
-
-import { infograph_href_template } from "../link_utils.js";
-import { sanitized_dangerous_inner_html } from "../general_utils.js";
 import { SpinnerWrapper, DlItem, CheckBox } from "../components/index.js";
+import { Explorer } from "../explorer_common/explorer_components.js";
+import { get_root } from "../explorer_common/hierarchy_tools.js";
+
+import { sanitized_dangerous_inner_html } from "../general_utils.js";
+import { infograph_href_template } from "../link_utils.js";
 import { Subject } from "../models/subject.js";
+
+import { grouping_options } from "./hierarchies.js";
+import { igoc_tmf as text_maker, TM } from "./igoc_explorer_text.js";
+import "../explorer_common/explorer-styles.scss";
 
 const { InstForm } = Subject;
 

--- a/client/src/IgocExplorer/hierarchies.js
+++ b/client/src/IgocExplorer/hierarchies.js
@@ -1,6 +1,7 @@
-import { businessConstants } from "../models/businessConstants.js";
 import { convert_d3_hierarchy_to_explorer_hierarchy } from "../explorer_common/hierarchy_tools.js";
+import { businessConstants } from "../models/businessConstants.js";
 import { Subject } from "../models/subject.js";
+
 import { igoc_tmf as text_maker } from "./igoc_explorer_text.js";
 
 const { Dept, InstForm } = Subject;

--- a/client/src/IgocExplorer/igoc_explorer_text.js
+++ b/client/src/IgocExplorer/igoc_explorer_text.js
@@ -1,5 +1,6 @@
-import igoc_explorer_bundle from "./IgocExplorer.yaml";
 import { create_text_maker_component } from "../components/index.js";
+
+import igoc_explorer_bundle from "./IgocExplorer.yaml";
 
 export const { text_maker: igoc_tmf, TM } = create_text_maker_component(
   igoc_explorer_bundle

--- a/client/src/InfoBase/App.js
+++ b/client/src/InfoBase/App.js
@@ -1,16 +1,12 @@
-import "./App.scss";
 import axios from "axios";
 
 import { Suspense } from "react";
 import { Route, Switch, Redirect } from "react-router-dom";
 
+import { HeaderNotification } from "../components/HeaderNotification";
+import { PageDetails } from "../components/PageDetails.js";
+import { SpinnerWrapper } from "../components/SpinnerWrapper.js";
 import { initialize_analytics } from "../core/analytics.js";
-import { has_local_storage } from "../core/feature_detection.js";
-
-import {
-  ensure_linked_stylesheets_load,
-  retrying_react_lazy,
-} from "./common_app_component_utils.js";
 
 export const app_reducer = (
   state = { lang: window.lang },
@@ -20,16 +16,21 @@ export const app_reducer = (
   return state;
 };
 
-import { ErrorBoundary } from "../core/ErrorBoundary.js";
 import { DevFip } from "../core/DevFip.js";
-import { TooltipActivator } from "../glossary/TooltipActivator.js";
+import { EasyAccess } from "../core/EasyAccess.js";
+import { ErrorBoundary } from "../core/ErrorBoundary.js";
+import { has_local_storage } from "../core/feature_detection.js";
 import { InsertRuntimeFooterLinks } from "../core/InsertRuntimeFooterLinks.js";
 import { ReactUnmounter } from "../core/NavComponents.js";
-import { EasyAccess } from "../core/EasyAccess.js";
 import { SurveyPopup } from "../core/SurveyPopup.js";
-import { SpinnerWrapper } from "../components/SpinnerWrapper.js";
-import { HeaderNotification } from "../components/HeaderNotification";
-import { PageDetails } from "../components/PageDetails.js";
+import { TooltipActivator } from "../glossary/TooltipActivator.js";
+
+import {
+  ensure_linked_stylesheets_load,
+  retrying_react_lazy,
+} from "./common_app_component_utils.js";
+
+import "./App.scss";
 
 const Home = retrying_react_lazy(() =>
   import(/* webpackChunkName: "Home" */ "../home/home.js")

--- a/client/src/InfoBase/pre_load.js
+++ b/client/src/InfoBase/pre_load.js
@@ -1,5 +1,5 @@
-import "../components/LeafSpinner.scss";
 import leaf_loading_spinner from "../svg/leaf-loading-spinner.svg";
+import "../components/LeafSpinner.scss";
 
 export default function () {
   const app_el = document.querySelector("#app");

--- a/client/src/InfoLab/InfoLab.js
+++ b/client/src/InfoLab/InfoLab.js
@@ -1,12 +1,15 @@
 import "./InfoLab.scss";
-import { StandardRouteContainer } from "../core/NavComponents.js";
-import { create_text_maker } from "../models/text.js";
 import {
   create_text_maker_component,
   CardLeftImage,
 } from "../components/index.js";
-import lab_text from "./InfoLab.yaml";
+import { StandardRouteContainer } from "../core/NavComponents.js";
+import { create_text_maker } from "../models/text.js";
+
 import { get_static_url } from "../request_utils.js";
+
+import lab_text from "./InfoLab.yaml";
+
 
 const { TM } = create_text_maker_component(lab_text);
 const text_maker = create_text_maker(lab_text);

--- a/client/src/PrivacyStatement/PrivacyStatement.js
+++ b/client/src/PrivacyStatement/PrivacyStatement.js
@@ -1,7 +1,8 @@
-import privacy_text_bundle from "./PrivacyStatement.yaml";
-import { StandardRouteContainer } from "../core/NavComponents.js";
 import { TextMaker } from "../components/index.js";
+import { StandardRouteContainer } from "../core/NavComponents.js";
 import { create_text_maker } from "../models/text.js";
+
+import privacy_text_bundle from "./PrivacyStatement.yaml";
 
 const text_maker = create_text_maker(privacy_text_bundle);
 

--- a/client/src/TagExplorer/TagExplorer.js
+++ b/client/src/TagExplorer/TagExplorer.js
@@ -1,14 +1,14 @@
 import "src/explorer_common/explorer-styles.scss";
-
-import { StandardRouteContainer } from "src/core/NavComponents.js";
-import { ensure_loaded } from "src/core/lazy_loader.js";
 import { SpinnerWrapper } from "src/components/index.js";
 
-import { ResourceScheme } from "./resource_scheme.js";
+import { ensure_loaded } from "src/core/lazy_loader.js";
+import { StandardRouteContainer } from "src/core/NavComponents.js";
+
 import {
   hierarchy_scheme_configs,
   default_scheme_id,
 } from "./hierarchy_scheme_configs.js";
+import { ResourceScheme } from "./resource_scheme.js";
 
 import {
   text_maker,

--- a/client/src/TagExplorer/TagExplorerComponent.js
+++ b/client/src/TagExplorer/TagExplorerComponent.js
@@ -1,7 +1,6 @@
-import { Fragment } from "react";
 import classNames from "classnames";
+import { Fragment } from "react";
 
-import { infograph_href_template } from "src/link_utils.js";
 
 import { GlossaryEntry } from "src/models/glossary.js";
 import { run_template } from "src/models/text.js";
@@ -14,10 +13,12 @@ import {
   GlossaryIcon,
 } from "src/components/";
 
-import { get_col_defs } from "src/explorer_common/resource_explorer_common.js";
-import { get_root } from "src/explorer_common/hierarchy_tools.js";
 import { Explorer } from "src/explorer_common/explorer_components.js";
+import { get_root } from "src/explorer_common/hierarchy_tools.js";
+import { get_col_defs } from "src/explorer_common/resource_explorer_common.js";
+import { infograph_href_template } from "src/link_utils.js";
 
+import { hierarchy_scheme_configs } from "./hierarchy_scheme_configs.js";
 import {
   text_maker,
   TM,
@@ -25,7 +26,6 @@ import {
   actual_year,
   year_to_route_arg_map,
 } from "./utils.js";
-import { hierarchy_scheme_configs } from "./hierarchy_scheme_configs.js";
 
 const children_grouper = (node, children) => {
   if (node.root) {

--- a/client/src/TagExplorer/hierarchy_scheme_configs.js
+++ b/client/src/TagExplorer/hierarchy_scheme_configs.js
@@ -1,7 +1,7 @@
+import { get_resources_for_subject } from "../explorer_common/resource_explorer_common.js";
+import { sanitized_dangerous_inner_html } from "../general_utils.js";
 import { Subject } from "../models/subject.js";
 import { trivial_text_maker } from "../models/text.js";
-import { sanitized_dangerous_inner_html } from "../general_utils.js";
-import { get_resources_for_subject } from "../explorer_common/resource_explorer_common.js";
 
 import { related_tags_row } from "./tag_hierarchy_utils.js";
 

--- a/client/src/TagExplorer/resource_scheme.js
+++ b/client/src/TagExplorer/resource_scheme.js
@@ -1,4 +1,16 @@
 import { createSelector } from "reselect";
+
+import { trivial_text_maker as text_maker } from "src/models/text.js";
+
+import { AbstractExplorerScheme } from "src/explorer_common/abstract_explorer_scheme";
+import {
+  filter_hierarchy,
+  convert_d3_hierarchy_to_explorer_hierarchy,
+} from "src/explorer_common/hierarchy_tools.js";
+import {
+  create_sort_func_selector,
+  get_resources_for_subject,
+} from "src/explorer_common/resource_explorer_common.js";
 import {
   cached_property,
   bound,
@@ -6,21 +18,12 @@ import {
   sanitized_dangerous_inner_html,
 } from "src/general_utils";
 
-import { AbstractExplorerScheme } from "src/explorer_common/abstract_explorer_scheme";
-import {
-  create_sort_func_selector,
-  get_resources_for_subject,
-} from "src/explorer_common/resource_explorer_common.js";
-import {
-  filter_hierarchy,
-  convert_d3_hierarchy_to_explorer_hierarchy,
-} from "src/explorer_common/hierarchy_tools.js";
 
 import { infograph_href_template } from "src/link_utils.js";
-import { trivial_text_maker as text_maker } from "src/models/text.js";
 
-import { related_tags_row } from "./tag_hierarchy_utils.js";
+
 import { hierarchy_scheme_configs } from "./hierarchy_scheme_configs.js";
+import { related_tags_row } from "./tag_hierarchy_utils.js";
 import TagExplorerComponent from "./TagExplorerComponent.js";
 
 function create_resource_hierarchy({ hierarchy_scheme, year }) {

--- a/client/src/TagExplorer/tag_hierarchy_utils.js
+++ b/client/src/TagExplorer/tag_hierarchy_utils.js
@@ -1,6 +1,6 @@
-import { trivial_text_maker } from "../models/text.js";
-import { infograph_href_template } from "../link_utils.js";
 import { HeightClipper } from "../components/index.js";
+import { infograph_href_template } from "../link_utils.js";
+import { trivial_text_maker } from "../models/text.js";
 
 export const related_tags_row = (related_tags, subject_type) => {
   const term =

--- a/client/src/TextDiff/TextDiff.js
+++ b/client/src/TextDiff/TextDiff.js
@@ -1,29 +1,28 @@
-import "./TextDiff.scss";
-import diff_text from "./TextDiff.yaml";
-
-import { Fragment } from "react";
-import MediaQuery from "react-responsive";
 import classNames from "classnames";
 import * as Diff from "diff";
+import { Fragment } from "react";
+import MediaQuery from "react-responsive";
 
-import { StandardRouteContainer } from "../core/NavComponents.js";
-import { ensure_loaded } from "../core/lazy_loader.js";
-
-import { Subject } from "../models/subject";
-import { result_docs } from "../models/results.js";
-import {
-  Result,
-  indicator_text_functions,
-} from "../panels/panel_declarations/results/results_common.js";
-import result_text from "../panels/panel_declarations/results/result_components.yaml";
 import { LegendList } from "../charts/legends";
-
 import {
   Select,
   Panel,
   create_text_maker_component,
   SpinnerWrapper,
 } from "../components";
+import { ensure_loaded } from "../core/lazy_loader.js";
+import { StandardRouteContainer } from "../core/NavComponents.js";
+
+import { result_docs } from "../models/results.js";
+import { Subject } from "../models/subject";
+import result_text from "../panels/panel_declarations/results/result_components.yaml";
+import {
+  Result,
+  indicator_text_functions,
+} from "../panels/panel_declarations/results/results_common.js";
+
+import diff_text from "./TextDiff.yaml";
+import "./TextDiff.scss";
 
 const { indicator_target_text } = indicator_text_functions;
 const { Dept, CRSO, Program } = Subject;

--- a/client/src/TreeMap/TreeMap.js
+++ b/client/src/TreeMap/TreeMap.js
@@ -1,28 +1,34 @@
 //https://gist.github.com/guglielmo/16d880a6615da7f502116220cb551498
 
-import { StandardRouteContainer } from "../core/NavComponents.js";
 import {
   SpinnerWrapper,
   create_text_maker_component,
 } from "../components/index.js";
-import { get_data, load_data } from "./data.js";
-import { formats } from "../core/format.js";
-import treemap_text from "./TreeMap.yaml";
-import "./TreeMap.scss";
-import { TreeMap } from "./TreeMapViz.js";
-import { TreeMapSidebar } from "./TreeMapSidebar.js";
-import { TreeMapTopbar } from "./TreeMapTopBar.js";
-import { TreeMapInstructions } from "./TreeMapInstructions.js";
-import { TreeMapLegend } from "./TreeMapLegend.js";
-import { infograph_href_template } from "../infographic/infographic_link.js";
-import { run_template } from "../models/text.js";
-import { actual_to_planned_gap_year } from "../models/years.js";
 import {
   sequentialBlues,
   sequentialReds,
   sequentialGreens,
   sequentialPurples,
 } from "../core/color_schemes.js";
+import { formats } from "../core/format.js";
+import { StandardRouteContainer } from "../core/NavComponents.js";
+import { infograph_href_template } from "../infographic/infographic_link.js";
+
+import { run_template } from "../models/text.js";
+
+import { actual_to_planned_gap_year } from "../models/years.js";
+
+import { get_data, load_data } from "./data.js";
+
+import { TreeMapInstructions } from "./TreeMapInstructions.js";
+import { TreeMapLegend } from "./TreeMapLegend.js";
+import { TreeMapSidebar } from "./TreeMapSidebar.js";
+import { TreeMapTopbar } from "./TreeMapTopBar.js";
+import { TreeMap } from "./TreeMapViz.js";
+
+import treemap_text from "./TreeMap.yaml";
+
+import "./TreeMap.scss";
 
 const { TM, text_maker } = create_text_maker_component([treemap_text]);
 

--- a/client/src/TreeMap/TreeMap.js
+++ b/client/src/TreeMap/TreeMap.js
@@ -1,7 +1,10 @@
 //https://gist.github.com/guglielmo/16d880a6615da7f502116220cb551498
 
 import { StandardRouteContainer } from "../core/NavComponents.js";
-import { SpinnerWrapper } from "../components/index.js";
+import {
+  SpinnerWrapper,
+  create_text_maker_component,
+} from "../components/index.js";
 import { get_data, load_data } from "./data.js";
 import { formats } from "../core/format.js";
 import treemap_text from "./TreeMap.yaml";
@@ -14,7 +17,6 @@ import { TreeMapLegend } from "./TreeMapLegend.js";
 import { infograph_href_template } from "../infographic/infographic_link.js";
 import { run_template } from "../models/text.js";
 import { actual_to_planned_gap_year } from "../models/years.js";
-import { create_text_maker_component } from "../components/index.js";
 import {
   sequentialBlues,
   sequentialReds,

--- a/client/src/TreeMap/TreeMapControls.js
+++ b/client/src/TreeMap/TreeMapControls.js
@@ -1,7 +1,6 @@
 import "./TreeMap.scss";
-import { run_template } from "../models/text.js";
+import { run_template, create_text_maker } from "../models/text.js";
 import treemap_text from "./TreeMap.yaml";
-import { create_text_maker } from "../models/text.js";
 import { Fragment } from "react";
 import classNames from "classnames";
 

--- a/client/src/TreeMap/TreeMapControls.js
+++ b/client/src/TreeMap/TreeMapControls.js
@@ -1,8 +1,10 @@
-import "./TreeMap.scss";
-import { run_template, create_text_maker } from "../models/text.js";
-import treemap_text from "./TreeMap.yaml";
-import { Fragment } from "react";
 import classNames from "classnames";
+import { Fragment } from "react";
+
+import { run_template, create_text_maker } from "../models/text.js";
+
+import treemap_text from "./TreeMap.yaml";
+import "./TreeMap.scss";
 
 const text_maker = create_text_maker([treemap_text]);
 

--- a/client/src/TreeMap/TreeMapInstructions.js
+++ b/client/src/TreeMap/TreeMapInstructions.js
@@ -1,7 +1,9 @@
-import "./TreeMap.scss";
-import treemap_text from "./TreeMap.yaml";
-import { create_text_maker } from "../models/text.js";
 import { Fragment } from "react";
+
+import { create_text_maker } from "../models/text.js";
+
+import treemap_text from "./TreeMap.yaml";
+import "./TreeMap.scss";
 
 const text_maker = create_text_maker([treemap_text]);
 

--- a/client/src/TreeMap/TreeMapLegend.js
+++ b/client/src/TreeMap/TreeMapLegend.js
@@ -1,8 +1,10 @@
-import "./TreeMap.scss";
-import treemap_text from "./TreeMap.yaml";
-import { create_text_maker } from "../models/text.js";
 import { Fragment } from "react";
+
 import { formats } from "../core/format.js";
+import { create_text_maker } from "../models/text.js";
+
+import treemap_text from "./TreeMap.yaml";
+import "./TreeMap.scss";
 
 const text_maker = create_text_maker([treemap_text]);
 

--- a/client/src/TreeMap/TreeMapSidebar.js
+++ b/client/src/TreeMap/TreeMapSidebar.js
@@ -1,5 +1,5 @@
-import "./TreeMap.scss";
 import { TreeMapControls } from "./TreeMapControls.js";
+import "./TreeMap.scss";
 
 export class TreeMapSidebar extends React.Component {
   constructor() {

--- a/client/src/TreeMap/TreeMapTopBar.js
+++ b/client/src/TreeMap/TreeMapTopBar.js
@@ -1,8 +1,10 @@
-import "./TreeMap.scss";
-import treemap_text from "./TreeMap.yaml";
-import { create_text_maker } from "../models/text.js";
 import { Fragment } from "react";
+
 import { IconArrow } from "../icons/icons.js";
+import { create_text_maker } from "../models/text.js";
+
+import treemap_text from "./TreeMap.yaml";
+import "./TreeMap.scss";
 
 const text_maker = create_text_maker([treemap_text]);
 

--- a/client/src/TreeMap/TreeMapViz.js
+++ b/client/src/TreeMap/TreeMapViz.js
@@ -1,7 +1,10 @@
-import text from "./TreeMap.yaml";
-import { create_text_maker } from "../models/text.js";
 import classNames from "classnames";
+
+import { create_text_maker } from "../models/text.js";
+
 import { smaller_items_text } from "./data.js";
+
+import text from "./TreeMap.yaml";
 
 const text_maker = create_text_maker(text);
 

--- a/client/src/TreeMap/data.js
+++ b/client/src/TreeMap/data.js
@@ -1,14 +1,15 @@
-import { Table } from "../core/TableClass.js";
 import { ensure_loaded } from "../core/lazy_loader.js";
-import treemap_text from "./TreeMap.yaml";
+import { Table } from "../core/TableClass.js";
+
+import { Subject } from "../models/subject.js";
 import { create_text_maker } from "../models/text.js";
+
+import treemap_text from "./TreeMap.yaml";
+
+const { Dept } = Subject;
 
 const tm = create_text_maker([treemap_text]);
 export const smaller_items_text = tm("smaller_items_text");
-
-import { Subject } from "../models/subject.js";
-
-const { Dept } = Subject;
 
 function has_non_zero_or_non_zero_children(node, perspective = "drf") {
   if (_.isEmpty(node.children)) {

--- a/client/src/about/about.js
+++ b/client/src/about/about.js
@@ -1,12 +1,13 @@
+import { IconGrid } from "../components/IconGrid.js";
+import { TM } from "../components/index.js";
+import { LabeledTable } from "../components/LabeledTable.js";
+import { StandardRouteContainer } from "../core/NavComponents.js";
+import { create_text_maker } from "../models/text.js";
+import { get_static_url } from "../request_utils.js";
+
 import about_text_bundle from "./about.yaml";
 import "./about.scss";
 import "../explorer_common/explorer-styles.scss";
-import { StandardRouteContainer } from "../core/NavComponents.js";
-import { TM } from "../components/index.js";
-import { create_text_maker } from "../models/text.js";
-import { LabeledTable } from "../components/LabeledTable.js";
-import { IconGrid } from "../components/IconGrid.js";
-import { get_static_url } from "../request_utils.js";
 
 const text_maker = create_text_maker(about_text_bundle);
 

--- a/client/src/app_bootstrap/bootstrap.js
+++ b/client/src/app_bootstrap/bootstrap.js
@@ -1,3 +1,4 @@
+/* eslint-disable import/order */
 import "dom4";
 import "whatwg-fetch";
 
@@ -8,37 +9,39 @@ import "../handlebars/helpers.side-effects.js";
 
 import "../common_css/common_css_index.side-effects.js";
 
-import ReactDOM from "react-dom";
-import { createStore, combineReducers, applyMiddleware } from "redux";
-import { Provider } from "react-redux";
 import {
   ConnectedRouter,
   routerMiddleware,
   connectRouter,
 } from "connected-react-router";
 import { default as createHistory } from "history/createHashHistory";
-import { populate_stores } from "../models/populate_stores.js";
-import { Table } from "../core/TableClass.js";
+import ReactDOM from "react-dom";
+import { Provider } from "react-redux";
+import { createStore, combineReducers, applyMiddleware } from "redux";
+
 import WebFont from "webfontloader";
 
-import orgVoteStatQfr from "../tables/orgVoteStatQfr.js";
-import orgSobjsQfr from "../tables/orgSobjsQfr.js";
-import orgVoteStatPa from "../tables/orgVoteStatPa.js";
+import { Table } from "../core/TableClass.js";
+import { populate_stores } from "../models/populate_stores.js";
+
+import orgEmployeeAgeGroup from "../tables/orgEmployeeAgeGroup.js";
+import orgEmployeeAvgAge from "../tables/orgEmployeeAvgAge.js";
+import orgEmployeeExLvl from "../tables/orgEmployeeExLvl.js";
+import orgEmployeeFol from "../tables/orgEmployeeFol.js";
+import orgEmployeeGender from "../tables/orgEmployeeGender.js";
+import orgEmployeeRegion from "../tables/orgEmployeeRegion.js";
+import orgEmployeeType from "../tables/orgEmployeeType.js";
 import orgSobjs from "../tables/orgSobjs.js";
-import programSpending from "../tables/programSpending.js";
+import orgSobjsQfr from "../tables/orgSobjsQfr.js";
 import orgTransferPayments from "../tables/orgTransferPayments.js";
 import orgTransferPaymentsRegion from "../tables/orgTransferPaymentsRegion.js";
 import orgVoteStatEstimates from "../tables/orgVoteStatEstimates.js";
-import orgEmployeeType from "../tables/orgEmployeeType.js";
-import orgEmployeeRegion from "../tables/orgEmployeeRegion.js";
-import orgEmployeeAgeGroup from "../tables/orgEmployeeAgeGroup.js";
+import orgVoteStatPa from "../tables/orgVoteStatPa.js";
+import orgVoteStatQfr from "../tables/orgVoteStatQfr.js";
 import programFtes from "../tables/programFtes.js";
-import orgEmployeeExLvl from "../tables/orgEmployeeExLvl.js";
-import programVoteStat from "../tables/programVoteStat.js";
-import orgEmployeeGender from "../tables/orgEmployeeGender.js";
-import orgEmployeeFol from "../tables/orgEmployeeFol.js";
-import orgEmployeeAvgAge from "../tables/orgEmployeeAvgAge.js";
 import programSobjs from "../tables/programSobjs.js";
+import programSpending from "../tables/programSpending.js";
+import programVoteStat from "../tables/programVoteStat.js";
 
 const table_defs = [
   orgVoteStatQfr,

--- a/client/src/app_bootstrap/d3-bundle.js
+++ b/client/src/app_bootstrap/d3-bundle.js
@@ -12,6 +12,7 @@ import * as i from "d3-interpolate";
 import * as j from "d3-path";
 import * as k from "d3-scale";
 import * as l from "d3-selection";
+// eslint-disable-next-line import/namespace
 import * as m from "d3-selection-multi";
 import * as n from "d3-shape";
 import * as o from "d3-transition";

--- a/client/src/app_bootstrap/d3-bundle.js
+++ b/client/src/app_bootstrap/d3-bundle.js
@@ -1,4 +1,3 @@
-import { completeAssign } from "../general_utils.js";
 
 import * as a from "d3-array";
 import * as b from "d3-axis";
@@ -11,12 +10,14 @@ import * as h from "d3-hierarchy";
 import * as i from "d3-interpolate";
 import * as j from "d3-path";
 import * as k from "d3-scale";
+import * as p from "d3-scale-chromatic";
 import * as l from "d3-selection";
 // eslint-disable-next-line import/namespace
 import * as m from "d3-selection-multi";
 import * as n from "d3-shape";
 import * as o from "d3-transition";
-import * as p from "d3-scale-chromatic";
+
+import { completeAssign } from "../general_utils.js";
 
 const d3 = completeAssign({}, a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p);
 

--- a/client/src/app_bootstrap/inject_app_globals.side-effects.js
+++ b/client/src/app_bootstrap/inject_app_globals.side-effects.js
@@ -1,3 +1,4 @@
+/* eslint-disable import/order */
 /* eslint-disable no-undef */
 if (typeof APPLICATION_LANGUAGE !== "undefined") {
   window.lang = APPLICATION_LANGUAGE;

--- a/client/src/charts/canada/CanadaD3Component.js
+++ b/client/src/charts/canada/CanadaD3Component.js
@@ -10,8 +10,9 @@
 //  with the array ordered by fiscal year
 //
 
-import graphRegistry from "../graphRegistry.js";
 import { businessConstants } from "../../models/businessConstants.js";
+import graphRegistry from "../graphRegistry.js";
+
 import { canada_svg } from "./canada_svg.yaml";
 
 const { provinces, provinces_short } = businessConstants;

--- a/client/src/charts/canada/canada.js
+++ b/client/src/charts/canada/canada.js
@@ -1,14 +1,16 @@
 import { Fragment } from "react";
 
-import text from "./canada.yaml";
-import { CanadaD3Component } from "./CanadaD3Component.js";
 
+import { secondaryColor, tertiaryColor } from "../../core/color_defs.js";
+import { hex_to_rgb } from "../../general_utils.js";
+import { businessConstants } from "../../models/businessConstants.js";
+import { run_template, create_text_maker } from "../../models/text.js";
 import { StandardLegend } from "../legends";
 import { WrappedNivoHBar } from "../wrapped_nivo/index.js";
-import { hex_to_rgb } from "../../general_utils.js";
-import { secondaryColor, tertiaryColor } from "../../core/color_defs.js";
-import { run_template, create_text_maker } from "../../models/text.js";
-import { businessConstants } from "../../models/businessConstants.js";
+
+import { CanadaD3Component } from "./CanadaD3Component.js";
+
+import text from "./canada.yaml";
 
 const text_maker = create_text_maker(text);
 

--- a/client/src/charts/canada/canada.js
+++ b/client/src/charts/canada/canada.js
@@ -7,9 +7,8 @@ import { StandardLegend } from "../legends";
 import { WrappedNivoHBar } from "../wrapped_nivo/index.js";
 import { hex_to_rgb } from "../../general_utils.js";
 import { secondaryColor, tertiaryColor } from "../../core/color_defs.js";
-import { run_template } from "../../models/text.js";
+import { run_template, create_text_maker } from "../../models/text.js";
 import { businessConstants } from "../../models/businessConstants.js";
-import { create_text_maker } from "../../models/text.js";
 
 const text_maker = create_text_maker(text);
 

--- a/client/src/charts/legends/LegendList.js
+++ b/client/src/charts/legends/LegendList.js
@@ -1,7 +1,8 @@
-import "./LegendList.scss";
-
 import classNames from "classnames";
+
 import { CheckBox } from "../../components/CheckBox.js";
+
+import "./LegendList.scss";
 
 export const LegendList = ({
   isHorizontal = false,

--- a/client/src/charts/legends/StandardLegend.js
+++ b/client/src/charts/legends/StandardLegend.js
@@ -1,6 +1,6 @@
-import "./StandardLegend.scss";
-
 import { LegendList } from "./LegendList.js";
+
+import "./StandardLegend.scss";
 
 export const StandardLegend = ({
   title,

--- a/client/src/charts/legends/TabularLegend.js
+++ b/client/src/charts/legends/TabularLegend.js
@@ -1,6 +1,5 @@
-import "./TabularLegend.scss";
-
 import { CheckBox } from "../../components/index.js";
+import "./TabularLegend.scss";
 
 export const TabularLegend = ({
   items, // [ { active, id, label, color }]

--- a/client/src/charts/shared.js
+++ b/client/src/charts/shared.js
@@ -1,6 +1,6 @@
-import { businessConstants } from "../models/businessConstants.js";
 import { NA_color } from "../core/color_schemes.js";
 import { formats } from "../core/format.js";
+import { businessConstants } from "../models/businessConstants.js";
 
 export const infobase_colors_smart = (col_scale) => (label) => {
   if (_.includes(businessConstants.NA_values, label)) {

--- a/client/src/charts/wrapped_nivo/CircleProportionChart.js
+++ b/client/src/charts/wrapped_nivo/CircleProportionChart.js
@@ -1,9 +1,11 @@
-import "./CircleProportionChart.scss";
-import text from "./CircleProportionChart.yaml";
-
 import { ResponsiveBubble } from "@nivo/circle-packing";
 import { Fragment } from "react";
 import MediaQuery from "react-responsive";
+
+import { SmartDisplayTable } from "../../components/index.js";
+import { breakpoints } from "../../core/breakpoint_defs.js";
+import { newIBCategoryColors } from "../../core/color_schemes.js";
+import { formats } from "../../core/format.js";
 
 import {
   InteractiveGraph,
@@ -13,10 +15,8 @@ import {
   TooltipFactory,
 } from "./wrapped_nivo_common.js";
 
-import { formats } from "../../core/format.js";
-import { breakpoints } from "../../core/breakpoint_defs.js";
-import { newIBCategoryColors } from "../../core/color_schemes.js";
-import { SmartDisplayTable } from "../../components/index.js";
+import text from "./CircleProportionChart.yaml";
+import "./CircleProportionChart.scss";
 
 const { text_maker, TM } = create_text_maker_component_with_nivo_common(text);
 

--- a/client/src/charts/wrapped_nivo/NivoLineBarToggle.js
+++ b/client/src/charts/wrapped_nivo/NivoLineBarToggle.js
@@ -1,15 +1,17 @@
-import text from "./NivoLineBarToggle.yaml";
 
 import classNames from "classnames";
 
-import { infobase_colors_smart } from "./wrapped_nivo_common.js";
-import { WrappedNivoBar } from "././wrapped_nivo_bar.js";
-import { WrappedNivoLine } from "./WrappedNivoLine.js";
 
-import { StandardLegend } from "../legends";
 import { newIBCategoryColors } from "../../core/color_schemes.js";
 import { formats } from "../../core/format.js";
 import { create_text_maker } from "../../models/text.js";
+import { StandardLegend } from "../legends";
+
+import { WrappedNivoBar } from "././wrapped_nivo_bar.js";
+import { infobase_colors_smart } from "./wrapped_nivo_common.js";
+import { WrappedNivoLine } from "./WrappedNivoLine.js";
+
+import text from "./NivoLineBarToggle.yaml";
 
 const text_maker = create_text_maker(text);
 

--- a/client/src/charts/wrapped_nivo/WrappedNivoLine.js
+++ b/client/src/charts/wrapped_nivo/WrappedNivoLine.js
@@ -1,7 +1,8 @@
-import text from "./WrappedNivoLine.yaml";
-
 import { ResponsiveLine } from "@nivo/line";
 import classNames from "classnames";
+
+import { SmartDisplayTable } from "../../components/index.js";
+import { IconZoomIn, IconZoomOut } from "../../icons/icons.js";
 
 import {
   create_text_maker_component_with_nivo_common,
@@ -12,8 +13,7 @@ import {
   fix_legend_symbols,
 } from "./wrapped_nivo_common.js";
 
-import { SmartDisplayTable } from "../../components/index.js";
-import { IconZoomIn, IconZoomOut } from "../../icons/icons.js";
+import text from "./WrappedNivoLine.yaml";
 
 const { text_maker } = create_text_maker_component_with_nivo_common(text);
 

--- a/client/src/charts/wrapped_nivo/WrappedNivoPie.js
+++ b/client/src/charts/wrapped_nivo/WrappedNivoPie.js
@@ -1,7 +1,10 @@
-import "./WrappedNivoPie.scss";
-
 import { ResponsivePie } from "@nivo/pie";
 import classNames from "classnames";
+
+import { Format, SmartDisplayTable } from "../../components/index.js";
+import { newIBCategoryColors } from "../../core/color_schemes.js";
+import { formats } from "../../core/format.js";
+import { TabularLegend } from "../legends";
 
 import {
   nivo_common_text_maker,
@@ -11,10 +14,7 @@ import {
   get_formatter,
 } from "./wrapped_nivo_common.js";
 
-import { TabularLegend } from "../legends";
-import { formats } from "../../core/format.js";
-import { newIBCategoryColors } from "../../core/color_schemes.js";
-import { SmartDisplayTable, Format } from "../../components/index.js";
+import "./WrappedNivoPie.scss";
 
 export class WrappedNivoPie extends React.Component {
   render() {

--- a/client/src/charts/wrapped_nivo/index.js
+++ b/client/src/charts/wrapped_nivo/index.js
@@ -1,7 +1,7 @@
+import { CircleProportionChart } from "./CircleProportionChart.js";
 import { WrappedNivoBar, WrappedNivoHBar } from "./wrapped_nivo_bar.js";
 import { WrappedNivoLine } from "./WrappedNivoLine.js";
 import { WrappedNivoPie } from "./WrappedNivoPie.js";
-import { CircleProportionChart } from "./CircleProportionChart.js";
 
 export { NivoLineBarToggle } from "./NivoLineBarToggle.js";
 

--- a/client/src/charts/wrapped_nivo/wrapped_nivo_bar.js
+++ b/client/src/charts/wrapped_nivo/wrapped_nivo_bar.js
@@ -1,5 +1,7 @@
 import { ResponsiveBar } from "@nivo/bar";
 
+import { SmartDisplayTable } from "../../components/index.js";
+
 import {
   nivo_common_text_maker,
   InteractiveGraph,
@@ -7,8 +9,6 @@ import {
   get_formatter,
   fix_legend_symbols,
 } from "./wrapped_nivo_common.js";
-
-import { SmartDisplayTable } from "../../components/index.js";
 
 const bar_table = (
   data,

--- a/client/src/charts/wrapped_nivo/wrapped_nivo_common.js
+++ b/client/src/charts/wrapped_nivo/wrapped_nivo_common.js
@@ -1,18 +1,18 @@
-import "./wrapped_nivo_common.scss";
-import graph_text from "./wrapped_nivo_common.yaml";
-
+import classNames from "classnames";
 import { Fragment } from "react";
 import MediaQuery from "react-responsive";
-import classNames from "classnames";
 
-import { breakpoints } from "../../core/breakpoint_defs.js";
-import { formats } from "../../core/format.js";
-import { get_formatter, infobase_colors_smart } from "../shared.js";
-import { IconTable } from "../../icons/icons.js";
 import {
   create_text_maker_component,
   StatelessModal,
 } from "../../components/index.js";
+import { breakpoints } from "../../core/breakpoint_defs.js";
+import { formats } from "../../core/format.js";
+import { IconTable } from "../../icons/icons.js";
+import { get_formatter, infobase_colors_smart } from "../shared.js";
+
+import graph_text from "./wrapped_nivo_common.yaml";
+import "./wrapped_nivo_common.scss";
 
 const { text_maker: nivo_common_text_maker } = create_text_maker_component(
   graph_text

--- a/client/src/components/Accordions.js
+++ b/client/src/components/Accordions.js
@@ -1,8 +1,10 @@
-import "./Accordions.scss";
 import { TransitionGroup, Transition } from "react-transition-group";
+
 import { IconChevron } from "../icons/icons.js";
 
 import { trivial_text_maker } from "../models/text.js";
+
+import "./Accordions.scss";
 
 const get_accordion_label = (isExpanded) =>
   ({

--- a/client/src/components/AlertBanner.js
+++ b/client/src/components/AlertBanner.js
@@ -1,6 +1,5 @@
-import "./AlertBanner.scss";
-
 import classNames from "classnames";
+import "./AlertBanner.scss";
 
 const banner_classes = ["info", "success", "warning", "danger"];
 export const AlertBanner = ({

--- a/client/src/components/BackToTop.js
+++ b/client/src/components/BackToTop.js
@@ -1,6 +1,7 @@
-import "./BackToTop.scss";
-import { trivial_text_maker } from "../models/text.js";
 import classNames from "classnames";
+
+import { trivial_text_maker } from "../models/text.js";
+import "./BackToTop.scss";
 
 export class BackToTop extends React.Component {
   constructor(props) {

--- a/client/src/components/CardBackgroundImage.js
+++ b/client/src/components/CardBackgroundImage.js
@@ -1,6 +1,5 @@
-import "./CardBackgroundImage.scss";
-
 import { TM } from "./TextMaker.js";
+import "./CardBackgroundImage.scss";
 
 const CardBackgroundImage = ({
   img_src,

--- a/client/src/components/CardCenteredImage.js
+++ b/client/src/components/CardCenteredImage.js
@@ -1,7 +1,7 @@
 import classNames from "classnames";
-import "./CardCenteredImage.scss";
 
 import { TM } from "./TextMaker.js";
+import "./CardCenteredImage.scss";
 
 const CardCenteredImage = ({
   img_src,

--- a/client/src/components/CardLeftImage.js
+++ b/client/src/components/CardLeftImage.js
@@ -1,6 +1,5 @@
-import "./CardLeftImage.scss";
-
 import { TM } from "./TextMaker.js";
+import "./CardLeftImage.scss";
 
 const CardLeftImage = ({
   img_src,

--- a/client/src/components/CardTopImage.js
+++ b/client/src/components/CardTopImage.js
@@ -1,6 +1,5 @@
-import "./CardTopImage.scss";
-
 import { TM } from "./TextMaker.js";
+import "./CardTopImage.scss";
 
 const CardTopImage = ({
   img_src,

--- a/client/src/components/CheckBox.js
+++ b/client/src/components/CheckBox.js
@@ -1,7 +1,7 @@
-import "./CheckBox.scss";
 import classNames from "classnames";
 
 import { IconCheckmark } from "../icons/icons.js";
+import "./CheckBox.scss";
 
 export class CheckBox extends React.Component {
   render() {

--- a/client/src/components/CountdownCircle.js
+++ b/client/src/components/CountdownCircle.js
@@ -1,8 +1,9 @@
-import "./CountdownCircle.scss";
-
 import { Fragment } from "react";
+
 import { is_IE } from "../core/feature_detection.js";
+
 import { Countdown } from "./Countdown.js";
+import "./CountdownCircle.scss";
 
 const split_value_and_units = (size) => {
   const unit = /[a-z]+$/.exec(size);

--- a/client/src/components/DebouncedTextInput.js
+++ b/client/src/components/DebouncedTextInput.js
@@ -1,5 +1,5 @@
-import { Fragment } from "react";
 import classNames from "classnames";
+import { Fragment } from "react";
 
 class DebouncedTextInput extends React.Component {
   render() {

--- a/client/src/components/DisplayTable/DisplayTable.js
+++ b/client/src/components/DisplayTable/DisplayTable.js
@@ -1,20 +1,21 @@
-import "./DisplayTable.scss";
-
 import classNames from "classnames";
 
+import { LegendList } from "../../charts/legends/LegendList.js";
+import { DebouncedTextInput } from "../DebouncedTextInput.js";
 import {
   create_text_maker_component,
   Format,
 } from "../misc_util_components.js";
-import { LegendList } from "../../charts/legends/LegendList.js";
+
+import { SortDirections } from "../SortDirection.js";
 
 import {
   DisplayTableCopyCsv,
   DisplayTableDownloadCsv,
   DisplayTableColumnToggle,
 } from "./DisplayTableUtils.js";
-import { SortDirections } from "../SortDirection.js";
-import { DebouncedTextInput } from "../DebouncedTextInput.js";
+
+import "./DisplayTable.scss";
 
 const { text_maker, TM } = create_text_maker_component();
 

--- a/client/src/components/DisplayTable/DisplayTableUtils.js
+++ b/client/src/components/DisplayTable/DisplayTableUtils.js
@@ -1,12 +1,12 @@
-import "./DisplayTableUtils.scss";
-import text from "./DisplayTable.yaml";
-
 import { Fragment } from "react";
 
+import { IconCopy, IconDownload } from "../../icons/icons.js";
+import { DropdownMenu } from "../DropdownMenu.js";
 import { create_text_maker_component } from "../misc_util_components.js";
 import { WriteToClipboard } from "../WriteToClipboard.js";
-import { DropdownMenu } from "../DropdownMenu.js";
-import { IconCopy, IconDownload } from "../../icons/icons.js";
+
+import text from "./DisplayTable.yaml";
+import "./DisplayTableUtils.scss";
 
 const { text_maker } = create_text_maker_component(text);
 

--- a/client/src/components/DropdownMenu.js
+++ b/client/src/components/DropdownMenu.js
@@ -1,5 +1,5 @@
-import "./DropdownMenu.scss";
 import classNames from "classnames";
+import "./DropdownMenu.scss";
 
 export class DropdownMenu extends React.Component {
   constructor(props) {

--- a/client/src/components/EmailFrontend.js
+++ b/client/src/components/EmailFrontend.js
@@ -1,19 +1,21 @@
-import { Fragment } from "react";
 import classNames from "classnames";
-
-import { create_text_maker_component } from "./misc_util_components.js";
-import { SpinnerWrapper } from "./SpinnerWrapper";
-import { CheckBox } from "./CheckBox.js";
+import { Fragment } from "react";
 
 import { get_client_id, log_standard_event } from "../core/analytics.js";
+
+import { has_local_storage } from "../core/feature_detection.js";
 import {
   get_email_template,
   send_completed_email_template,
 } from "../email_backend_utils.js";
 
+import { CheckBox } from "./CheckBox.js";
+import { create_text_maker_component } from "./misc_util_components.js";
+import { SpinnerWrapper } from "./SpinnerWrapper";
+
 import text from "./EmailFrontend.yaml";
+
 import "./EmailFrontend.scss";
-import { has_local_storage } from "../core/feature_detection.js";
 
 const { TM, text_maker } = create_text_maker_component(text);
 

--- a/client/src/components/FancyUL.js
+++ b/client/src/components/FancyUL.js
@@ -1,7 +1,6 @@
-import "./FancyUL.scss";
-
 import classNames from "classnames";
 import PropTypes from "prop-types";
+import "./FancyUL.scss";
 
 export const FancyUL = ({ className, title, TitleComponent, children }) => (
   <ul className={classNames("fancy-ul", className)} aria-label={title}>

--- a/client/src/components/FilterTable.js
+++ b/client/src/components/FilterTable.js
@@ -1,6 +1,7 @@
 import classNames from "classnames";
-import "./FilterTable.scss";
+
 import { IconEyeOpen, IconEyeClosed } from "../icons/icons.js";
+import "./FilterTable.scss";
 
 export class FilterTable extends React.Component {
   render() {

--- a/client/src/components/FootnoteList.js
+++ b/client/src/components/FootnoteList.js
@@ -1,11 +1,12 @@
-import "./FootnoteList.scss";
-import footnote_list_text from "./FootnoteList.yaml";
+import { sanitized_dangerous_inner_html } from "../general_utils.js";
 import footnote_topic_text from "../models/footnotes/footnote_topics.yaml";
 
 import { create_text_maker } from "../models/text.js";
-import { sanitized_dangerous_inner_html } from "../general_utils.js";
 
 import { FancyUL } from "./FancyUL.js";
+
+import footnote_list_text from "./FootnoteList.yaml";
+import "./FootnoteList.scss";
 
 const text_maker = create_text_maker([footnote_list_text, footnote_topic_text]);
 

--- a/client/src/components/HeaderNotification.js
+++ b/client/src/components/HeaderNotification.js
@@ -1,5 +1,5 @@
-import "./HeaderNotification.scss";
 import { trivial_text_maker } from "../models/text.js";
+import "./HeaderNotification.scss";
 
 export class HeaderNotification extends React.Component {
   state = {

--- a/client/src/components/KeyConceptList.js
+++ b/client/src/components/KeyConceptList.js
@@ -1,6 +1,7 @@
-import "../common_css/grid-system.scss";
 import { Fragment } from "react";
+
 import { Details } from "./Details.js";
+import "../common_css/grid-system.scss";
 
 const KeyConceptList = ({ question_answer_pairs, compact = true }) => (
   <div>

--- a/client/src/components/LabeledTable.js
+++ b/client/src/components/LabeledTable.js
@@ -1,6 +1,5 @@
-import "./LabeledTable.scss";
-
 import PropTypes from "prop-types";
+import "./LabeledTable.scss";
 
 export const LabeledTable = ({ title, TitleComponent, contents }) => (
   <section className="labeled-table" aria-label={title}>

--- a/client/src/components/LeafSpinner.js
+++ b/client/src/components/LeafSpinner.js
@@ -1,5 +1,5 @@
-import "./LeafSpinner.scss";
 import leaf_loading_spinner from "../svg/leaf-loading-spinner.svg";
+import "./LeafSpinner.scss";
 
 export const LeafSpinner = ({ config_name }) => {
   const default_spinner_config_form = (scale) => ({

--- a/client/src/components/PDFGenerator.js
+++ b/client/src/components/PDFGenerator.js
@@ -1,11 +1,13 @@
-import text from "./PDFGenerator.yaml";
+import { Fragment } from "react";
+
+import { IconDownload } from "../icons/icons.js";
 import { get_static_url } from "../request_utils.js";
 
 import { create_text_maker_component } from "./misc_util_components.js";
 import { SpinnerWrapper } from "./SpinnerWrapper.js";
 
-import { Fragment } from "react";
-import { IconDownload } from "../icons/icons.js";
+
+import text from "./PDFGenerator.yaml";
 
 const { text_maker } = create_text_maker_component(text);
 

--- a/client/src/components/PDFGenerator_lazy_loaded_dependencies.side-effects.js
+++ b/client/src/components/PDFGenerator_lazy_loaded_dependencies.side-effects.js
@@ -1,3 +1,5 @@
+/* eslint-disable import/order */
+
 import * as jsPDF from "jspdf";
 import "jspdf-autotable";
 

--- a/client/src/components/PageDetails.js
+++ b/client/src/components/PageDetails.js
@@ -1,15 +1,16 @@
-import "./PageDetails.scss";
-import text from "./PageDetails.yaml";
-
 import { withRouter } from "react-router";
 
+import { IconGitHub } from "../icons/icons.js";
+import { create_text_maker } from "../models/text.js";
+
 import { Details } from "./Details.js";
+import { EmailFrontend } from "./EmailFrontend.js";
 import { ExternalLink } from "./misc_util_components.js";
 
-import { create_text_maker } from "../models/text.js";
-import { IconGitHub } from "../icons/icons.js";
-import { EmailFrontend } from "./EmailFrontend.js";
 import { StatelessModal } from "./modals_and_popovers";
+
+import text from "./PageDetails.yaml";
+import "./PageDetails.scss";
 
 const text_maker = create_text_maker(text);
 

--- a/client/src/components/Panel.js
+++ b/client/src/components/Panel.js
@@ -1,12 +1,12 @@
-import "./Panel.scss";
-import text from "./Panel.yaml";
-import { GlossaryItem } from "./glossary_components.js";
-
 import classNames from "classnames";
 
 import { Details } from "./Details.js";
 import { FootnoteList } from "./FootnoteList.js";
+import { GlossaryItem } from "./glossary_components.js";
 import { create_text_maker_component } from "./misc_util_components.js";
+
+import text from "./Panel.yaml";
+import "./Panel.scss";
 
 const { TM } = create_text_maker_component(text);
 

--- a/client/src/components/RadioButtons.js
+++ b/client/src/components/RadioButtons.js
@@ -1,5 +1,5 @@
-import "./RadioButtons.scss";
 import classNames from "classnames";
+import "./RadioButtons.scss";
 
 export const RadioButtons = ({ options, onChange }) => (
   <div className="radio-buttons">

--- a/client/src/components/ShareButton.js
+++ b/client/src/components/ShareButton.js
@@ -1,6 +1,3 @@
-import "./ShareButton.scss";
-import text from "./ShareButton.yaml";
-
 import { Fragment } from "react";
 import {
   TwitterShareButton,
@@ -15,9 +12,13 @@ import {
   RedditIcon,
 } from "react-share";
 
-import { StatelessModal } from "./modals_and_popovers";
-import { create_text_maker } from "../models/text.js";
 import { IconShare } from "../icons/icons.js";
+import { create_text_maker } from "../models/text.js";
+
+import { StatelessModal } from "./modals_and_popovers";
+
+import text from "./ShareButton.yaml";
+import "./ShareButton.scss";
 
 const text_maker = create_text_maker(text);
 

--- a/client/src/components/SortDirection.js
+++ b/client/src/components/SortDirection.js
@@ -1,5 +1,5 @@
-import "./SortDirection.scss";
 import { trivial_text_maker } from "../models/text.js";
+import "./SortDirection.scss";
 
 export const SortDirection = ({ sortDirection, active }) => (
   <button

--- a/client/src/components/SpinnerWrapper.js
+++ b/client/src/components/SpinnerWrapper.js
@@ -1,4 +1,5 @@
 import { Spinner, spinner_configs } from "../core/Spinner.js";
+
 import { LeafSpinner } from "./LeafSpinner.js";
 
 export class SpinnerWrapper extends React.Component {

--- a/client/src/components/TabbedContent.js
+++ b/client/src/components/TabbedContent.js
@@ -1,5 +1,5 @@
-import "./TabbedContent.scss";
 import classNames from "classnames";
+import "./TabbedContent.scss";
 
 export class TabbedControls extends React.Component {
   render() {

--- a/client/src/components/Tombstones.js
+++ b/client/src/components/Tombstones.js
@@ -1,6 +1,5 @@
-import "./Tombstones.scss";
-
 import { Fragment } from "react";
+import "./Tombstones.scss";
 
 const UnlabeledTombstone = ({ items }) => (
   <table className="tombstone-table">

--- a/client/src/components/WriteToClipboard.js
+++ b/client/src/components/WriteToClipboard.js
@@ -1,12 +1,14 @@
-import text from "./WriteToClipboard.yaml";
 
 import * as clipboard from "clipboard-polyfill";
 import { Fragment } from "react";
 
-import { FixedPopover } from "./modals_and_popovers";
 import { IconCopy } from "../icons/icons.js";
 
 import { create_text_maker } from "../models/text.js";
+
+import { FixedPopover } from "./modals_and_popovers";
+
+import text from "./WriteToClipboard.yaml";
 
 const text_maker = create_text_maker(text);
 

--- a/client/src/components/glossary_components.js
+++ b/client/src/components/glossary_components.js
@@ -1,6 +1,6 @@
 import { IconQuestion } from "../icons/icons.js";
-import { GlossaryEntry } from "../models/glossary.js";
 import { glossary_href } from "../link_utils.js";
+import { GlossaryEntry } from "../models/glossary.js";
 import { trivial_text_maker } from "../models/text.js";
 
 const GlossaryTooltipWrapper = ({

--- a/client/src/components/misc_util_components.js
+++ b/client/src/components/misc_util_components.js
@@ -1,13 +1,13 @@
 import { Fragment } from "react";
 
+import { formats } from "../core/format.js";
+
+import { text_abbrev } from "../general_utils.js";
 import {
   run_template,
   trivial_text_maker,
   create_text_maker,
 } from "../models/text.js";
-import { formats } from "../core/format.js";
-
-import { text_abbrev } from "../general_utils.js";
 
 import { TextMaker, TM } from "./TextMaker.js";
 

--- a/client/src/components/modals_and_popovers/FixedPopover.js
+++ b/client/src/components/modals_and_popovers/FixedPopover.js
@@ -1,11 +1,11 @@
+import classNames from "classnames";
+import { Modal } from "react-bootstrap";
+
+import { trivial_text_maker } from "../../models/text.js";
+import { CountdownCircle } from "../CountdownCircle.js";
+
 import "./bootstrap_modal_exstension.scss";
 import "./FixedPopover.scss";
-
-import { Modal } from "react-bootstrap";
-import classNames from "classnames";
-
-import { CountdownCircle } from "../CountdownCircle.js";
-import { trivial_text_maker } from "../../models/text.js";
 
 // Lots of StatlessModal DNA in here, but conciously not DRYed against it! Don't want to couple
 // them, I actually want to encourage them to diverge further in the future to the point that

--- a/client/src/components/modals_and_popovers/StatelessModal.js
+++ b/client/src/components/modals_and_popovers/StatelessModal.js
@@ -1,9 +1,8 @@
-import "./bootstrap_modal_exstension.scss";
-
-import { Modal } from "react-bootstrap";
 import classNames from "classnames";
+import { Modal } from "react-bootstrap";
 
 import { trivial_text_maker } from "../../models/text.js";
+import "./bootstrap_modal_exstension.scss";
 
 export class StatelessModal extends React.Component {
   constructor(props) {

--- a/client/src/contact/contact.js
+++ b/client/src/contact/contact.js
@@ -1,7 +1,8 @@
-import contact_us_bundle from "./contact.yaml";
-import { StandardRouteContainer } from "../core/NavComponents.js";
 import { TM } from "../components/index.js";
+import { StandardRouteContainer } from "../core/NavComponents.js";
 import { create_text_maker } from "../models/text.js";
+
+import contact_us_bundle from "./contact.yaml";
 
 const text_maker = create_text_maker(contact_us_bundle);
 

--- a/client/src/core/EasyAccess.js
+++ b/client/src/core/EasyAccess.js
@@ -1,12 +1,13 @@
-import { TrivialTM } from "../components/index.js";
-import { trivial_text_maker } from "../models/text.js";
 import { Fragment } from "react";
+
+import { TrivialTM } from "../components/index.js";
 import {
   IconAbout,
   IconGlossary,
   IconDataset,
   IconQuestion,
 } from "../icons/icons.js";
+import { trivial_text_maker } from "../models/text.js";
 import "./NavComponents.scss";
 
 export class EasyAccess extends React.Component {

--- a/client/src/core/ErrorBoundary.js
+++ b/client/src/core/ErrorBoundary.js
@@ -1,4 +1,5 @@
 import { get_static_url, make_request } from "../request_utils.js";
+
 import { log_standard_event } from "./analytics.js";
 
 const NoIndex = () =>

--- a/client/src/core/InsertRuntimeFooterLinks.js
+++ b/client/src/core/InsertRuntimeFooterLinks.js
@@ -1,5 +1,5 @@
-import { trivial_text_maker, run_template } from "../models/text.js";
 import { index_lang_lookups } from "../InfoBase/index_data.js";
+import { trivial_text_maker, run_template } from "../models/text.js";
 
 const footer_link_items = _.compact([
   {

--- a/client/src/core/NavComponents.js
+++ b/client/src/core/NavComponents.js
@@ -1,11 +1,14 @@
 import { Fragment } from "react";
 import { withRouter } from "react-router";
-import { reactAdapter } from "./reactAdapter.js";
-import { log_page_view } from "./analytics.js";
-import { index_lang_lookups } from "../InfoBase/index_data.js";
-import { trivial_text_maker } from "../models/text.js";
-import { IconHome } from "../icons/icons.js";
+
 import { AlertBanner } from "../components/index.js";
+import { IconHome } from "../icons/icons.js";
+import { index_lang_lookups } from "../InfoBase/index_data.js";
+
+import { trivial_text_maker } from "../models/text.js";
+
+import { log_page_view } from "./analytics.js";
+import { reactAdapter } from "./reactAdapter.js";
 
 import "./NavComponents.scss";
 

--- a/client/src/core/Spinner.js
+++ b/client/src/core/Spinner.js
@@ -1,5 +1,5 @@
-import "spin.js/spin.css";
 import { Spinner } from "spin.js";
+import "spin.js/spin.css";
 
 const spinner_configs = {
   initial: { scale: 4 },

--- a/client/src/core/Statistics.js
+++ b/client/src/core/Statistics.js
@@ -1,6 +1,8 @@
 import { mix, staticStoreMixin } from "../models/storeMixins.js";
-import { Table } from "./TableClass.js";
+
 import { Subject } from "../models/subject.js";
+
+import { Table } from "./TableClass.js";
 
 const { Gov } = Subject;
 

--- a/client/src/core/SurveyPopup.js
+++ b/client/src/core/SurveyPopup.js
@@ -1,14 +1,16 @@
-import text from "./SurveyPopup.yaml";
 
 import { Fragment } from "react";
 import { withRouter } from "react-router";
 
-import { log_standard_event } from "./analytics.js";
-import { IconFeedback } from "../icons/icons.js";
 import {
   FixedPopover,
   create_text_maker_component,
 } from "../components/index.js";
+import { IconFeedback } from "../icons/icons.js";
+
+import { log_standard_event } from "./analytics.js";
+
+import text from "./SurveyPopup.yaml";
 
 const { TM, text_maker } = create_text_maker_component(text);
 

--- a/client/src/core/TableClass.js
+++ b/client/src/core/TableClass.js
@@ -1,10 +1,5 @@
-import { get_static_url, make_request } from "../request_utils.js";
-import { query_adapter } from "./tables/queries.js";
-import {
-  attach_dimensions,
-  fill_dimension_columns,
-  trivial_dimension,
-} from "./tables/dimensions.js";
+import { make_unique_func, make_unique } from "../general_utils.js";
+import { sources as all_sources } from "../metadata/data_sources.js";
 import { mix, staticStoreMixin } from "../models/storeMixins.js";
 import { Subject } from "../models/subject.js";
 import {
@@ -12,8 +7,14 @@ import {
   run_template,
   create_text_maker,
 } from "../models/text.js";
-import { sources as all_sources } from "../metadata/data_sources.js";
-import { make_unique_func, make_unique } from "../general_utils.js";
+import { get_static_url, make_request } from "../request_utils.js";
+
+import {
+  attach_dimensions,
+  fill_dimension_columns,
+  trivial_dimension,
+} from "./tables/dimensions.js";
+import { query_adapter } from "./tables/queries.js";
 
 const table_id_to_csv_path = (table_id) => `csv/${_.snakeCase(table_id)}.csv`;
 const { Dept } = Subject;

--- a/client/src/core/lazy_loader.js
+++ b/client/src/core/lazy_loader.js
@@ -1,21 +1,22 @@
-import { Table } from "./TableClass.js";
-import { PanelRegistry, tables_for_panel } from "../panels/PanelRegistry.js";
-import { Statistics, tables_for_statistics } from "./Statistics.js";
-import {
-  api_load_results_bundle,
-  api_load_results_counts,
-  subject_has_results,
-} from "../models/populate_results.js";
 import { load_footnotes_bundle } from "../models/footnotes/populate_footnotes.js";
 import {
   api_load_subject_has_measures,
   api_load_budget_measures,
 } from "../models/populate_budget_measures.js";
+import { load_horizontal_initiative_lookups } from "../models/populate_horizontal_initiative_lookups.js";
+import {
+  api_load_results_bundle,
+  api_load_results_counts,
+  subject_has_results,
+} from "../models/populate_results.js";
 import {
   api_load_subject_has_services,
   api_load_services,
 } from "../models/populate_services.js";
-import { load_horizontal_initiative_lookups } from "../models/populate_horizontal_initiative_lookups.js";
+import { PanelRegistry, tables_for_panel } from "../panels/PanelRegistry.js";
+
+import { Statistics, tables_for_statistics } from "./Statistics.js";
+import { Table } from "./TableClass.js";
 
 // given an array of tables, returns a promise when they are all loaded.
 function load(table_objs) {

--- a/client/src/core/tables/queries.js
+++ b/client/src/core/tables/queries.js
@@ -1,5 +1,5 @@
-import * as FORMAT from "../format";
 import { Subject } from "../../models/subject";
+import * as FORMAT from "../format";
 
 // #Queries
 // This module exists to  provides a common interface for querying

--- a/client/src/core/tables/table_builder.js
+++ b/client/src/core/tables/table_builder.js
@@ -1,4 +1,4 @@
-import general_utils from "../../general_utils.js";
+import { make_unique } from "../../general_utils.js";
 
 //  Generates all the tables displayed on the page
 //  * no code repetition
@@ -55,7 +55,7 @@ function prepare_data(options) {
     _.each(headers, function (header_row, i) {
       _.each(header_row, function (header, j) {
         var wcag_headers;
-        var id = general_utils.make_unique();
+        var id = make_unique();
         header_links[j] += " " + id;
         if (i > 0) {
           wcag_headers = _.chain(headers)

--- a/client/src/explorer_common/abstract_explorer_scheme.js
+++ b/client/src/explorer_common/abstract_explorer_scheme.js
@@ -1,7 +1,7 @@
-import { createSelector } from "reselect";
+import { connect, Provider } from "react-redux";
 import { createStore, combineReducers, applyMiddleware } from "redux";
 import redux_promise_middleware from "redux-promise-middleware";
-import { connect, Provider } from "react-redux";
+import { createSelector } from "reselect";
 
 import { cached_property, bound } from "src/general_utils.js";
 

--- a/client/src/explorer_common/explorer_components.js
+++ b/client/src/explorer_common/explorer_components.js
@@ -1,8 +1,6 @@
-import "./explorer-components.scss";
-
 import classNames from "classnames";
-import { TransitionGroup } from "react-transition-group";
 import FlipMove from "react-flip-move";
+import { TransitionGroup } from "react-transition-group";
 import { createSelector } from "reselect";
 
 import {
@@ -12,6 +10,8 @@ import {
 } from "../components/index.js";
 
 import { trivial_text_maker } from "../models/text.js";
+
+import "./explorer-components.scss";
 
 const INDENT_SIZE = 24;
 

--- a/client/src/explorer_common/resource_explorer_common.js
+++ b/client/src/explorer_common/resource_explorer_common.js
@@ -1,9 +1,9 @@
 import { createSelector } from "reselect";
 
 import { TrivialTM as TM, Format } from "../components/index.js";
+import { Table } from "../core/TableClass.js";
 import { run_template } from "../models/text.js";
 import { year_templates } from "../models/years.js";
-import { Table } from "../core/TableClass.js";
 
 const is_planning_year = (year) =>
   _.includes(year_templates.planning_years, year);

--- a/client/src/explorer_common/search_tools.js
+++ b/client/src/explorer_common/search_tools.js
@@ -1,5 +1,5 @@
-import { GlossaryEntry } from "../models/glossary.js";
 import { escapeRegExp } from "../general_utils.js";
+import { GlossaryEntry } from "../models/glossary.js";
 
 function node_to_match_tokens(node) {
   const {

--- a/client/src/explorer_common/state_and_memoizing.js
+++ b/client/src/explorer_common/state_and_memoizing.js
@@ -1,4 +1,5 @@
 import { createSelector } from "reselect";
+
 import {
   filter_hierarchy,
   toggleExpandedFlat,

--- a/client/src/general_utils.js
+++ b/client/src/general_utils.js
@@ -1,6 +1,6 @@
-import marked from "marked";
 import DOMPurify from "dompurify";
 import JSURL from "jsurl";
+import marked from "marked";
 
 export const sanitized_marked = (markdown) =>
   DOMPurify.sanitize(marked(markdown, { sanitize: false, gfm: true }));

--- a/client/src/glossary/TooltipActivator.js
+++ b/client/src/glossary/TooltipActivator.js
@@ -1,6 +1,7 @@
+import Tooltip from "tooltip.js";
+
 import { get_glossary_item_tooltip_html } from "../models/glossary.js";
 
-import Tooltip from "tooltip.js";
 
 // Patch over Tooltip's _scheduleShow and _scheduleHide to not use setTimeout with a 0 second delay
 // The 0 second delay could still result in the _show call being stuck pending for extended periods (was consistently > 1 second on mobile Chrome)

--- a/client/src/glossary/glossary.js
+++ b/client/src/glossary/glossary.js
@@ -1,18 +1,20 @@
-import "./glossary.scss";
-import glossary_text from "./glossary.yaml";
 import { Fragment } from "react";
-import {
-  StandardRouteContainer,
-  ScrollToTargetContainer,
-} from "../core/NavComponents.js";
-import { Table } from "../core/TableClass.js";
-import { rpb_link } from "../rpb/rpb_link.js";
-import { GlossaryEntry } from "../models/glossary.js";
+
 import {
   create_text_maker_component,
   GlossarySearch,
   BackToTop,
 } from "../components/index.js";
+import {
+  StandardRouteContainer,
+  ScrollToTargetContainer,
+} from "../core/NavComponents.js";
+import { Table } from "../core/TableClass.js";
+import { GlossaryEntry } from "../models/glossary.js";
+import { rpb_link } from "../rpb/rpb_link.js";
+
+import glossary_text from "./glossary.yaml";
+import "./glossary.scss";
 
 const { text_maker, TM } = create_text_maker_component(glossary_text);
 

--- a/client/src/graphql_utils/GraphiQL.js
+++ b/client/src/graphql_utils/GraphiQL.js
@@ -1,10 +1,14 @@
-import GraphiQL from "graphiql";
 import "graphiql/graphiql.css";
+
 import fetch from "isomorphic-fetch";
 
-import { StandardRouteContainer } from "../core/NavComponents.js";
-import { log_standard_event } from "../core/analytics.js";
+// strange error: "casing of graphiql does not match the underlying filesystem"
+/* eslint-disable-next-line import/no-unresolved */
+import GraphiQL from "graphiql";
+
 import { SpinnerWrapper, ContainerEscapeHatch } from "../components/index.js";
+import { log_standard_event } from "../core/analytics.js";
+import { StandardRouteContainer } from "../core/NavComponents.js";
 
 import { get_api_url } from "./graphql_utils.js";
 

--- a/client/src/graphql_utils/graphql_utils.js
+++ b/client/src/graphql_utils/graphql_utils.js
@@ -1,9 +1,9 @@
+import { InMemoryCache } from "apollo-cache-inmemory";
 import { ApolloClient } from "apollo-client";
 import { createHttpLink } from "apollo-link-http";
-import { InMemoryCache } from "apollo-cache-inmemory";
+import { compressToBase64 } from "lz-string";
 import { graphql as apollo_connect } from "react-apollo";
 import string_hash from "string-hash";
-import { compressToBase64 } from "lz-string";
 
 const prod_api_url = `https://us-central1-ib-serverless-api-prod.cloudfunctions.net/prod-api-${window.sha}/graphql`;
 

--- a/client/src/handlebars/helpers.side-effects.js
+++ b/client/src/handlebars/helpers.side-effects.js
@@ -1,8 +1,8 @@
 /* eslint-disable no-console, no-debugger */
+import { infograph_href_template, glossary_href } from "../link_utils.js";
+import { GlossaryEntry } from "../models/glossary.js";
 import { Subject } from "../models/subject";
 
-import { GlossaryEntry } from "../models/glossary.js";
-import { infograph_href_template, glossary_href } from "../link_utils.js";
 import { trivial_text_maker, run_template } from "../models/text.js";
 
 const change_map = {

--- a/client/src/home/a11y_home.js
+++ b/client/src/home/a11y_home.js
@@ -1,13 +1,15 @@
-import home_text1 from "./home.yaml";
-import home_text2 from "./a11y-home.yaml";
-
-import { featured_content_items } from "./home-data.js";
-
-import { StandardRouteContainer } from "../core/NavComponents.js";
 import {
   create_text_maker_component,
   AlertBanner,
 } from "../components/index.js";
+import { StandardRouteContainer } from "../core/NavComponents.js";
+
+import { featured_content_items } from "./home-data.js";
+
+import home_text2 from "./a11y-home.yaml";
+import home_text1 from "./home.yaml";
+
+
 
 const { text_maker, TM } = create_text_maker_component([
   home_text1,

--- a/client/src/home/home.js
+++ b/client/src/home/home.js
@@ -1,7 +1,3 @@
-import "./home.scss";
-import home_text_bundle from "./home.yaml";
-import { featured_content_items } from "./home-data.js";
-import { log_standard_event } from "../core/analytics.js";
 import MediaQuery from "react-responsive";
 
 import {
@@ -12,10 +8,16 @@ import {
   ContainerEscapeHatch,
   TrinityItem,
 } from "../components/index.js";
+import { log_standard_event } from "../core/analytics.js";
 
-import { smart_href_template } from "../link_utils.js";
 import { StandardRouteContainer } from "../core/NavComponents.js";
+import { smart_href_template } from "../link_utils.js";
 import { get_static_url } from "../request_utils.js";
+
+import { featured_content_items } from "./home-data.js";
+
+import home_text_bundle from "./home.yaml";
+import "./home.scss";
 
 const { text_maker: home_tm, TM } = create_text_maker_component(
   home_text_bundle

--- a/client/src/icons/icons.js
+++ b/client/src/icons/icons.js
@@ -1,7 +1,6 @@
-import "./icons.scss";
-
-import { Fragment } from "react";
 import classNames from "classnames";
+import { Fragment } from "react";
+import "./icons.scss";
 
 const svg_default_styles = {
   width: "1.5em",

--- a/client/src/infographic/BubbleMenu.js
+++ b/client/src/infographic/BubbleMenu.js
@@ -1,5 +1,5 @@
-import "./BubbleMenu.scss";
 import classNames from "classnames";
+import "./BubbleMenu.scss";
 
 class BubbleMenu extends React.Component {
   render() {

--- a/client/src/infographic/Infographic.js
+++ b/client/src/infographic/Infographic.js
@@ -1,25 +1,31 @@
 import { Redirect } from "react-router";
 
 import "./Infographic.scss";
-import text from "./Infographic.yaml";
 
-import { StandardRouteContainer } from "../core/NavComponents";
-import { log_standard_event } from "../core/analytics.js";
-import { BubbleMenu } from "./BubbleMenu.js";
-import AccessibleBubbleMenu from "./a11y_bubble_menu.js";
-import { shallowEqualObjectsOverKeys, SafeJSURL } from "../general_utils.js";
-import { Subject } from "../models/subject.js";
-import { ensure_loaded } from "../core/lazy_loader.js";
-import { bubble_defs } from "./bubble_definitions.js";
-import { get_panels_for_subject } from "../panels/get_panels_for_subject/index.js";
-import { PanelRenderer } from "../panels/PanelRenderer.js";
 import {
   create_text_maker_component,
   SpinnerWrapper,
   AdvancedSearch,
 } from "../components/index.js";
+import { log_standard_event } from "../core/analytics.js";
+
+
+import { ensure_loaded } from "../core/lazy_loader.js";
+import { StandardRouteContainer } from "../core/NavComponents";
+import { shallowEqualObjectsOverKeys, SafeJSURL } from "../general_utils.js";
+import { Subject } from "../models/subject.js";
+
+
+import { get_panels_for_subject } from "../panels/get_panels_for_subject/index.js";
+import { PanelRenderer } from "../panels/PanelRenderer.js";
+
+import AccessibleBubbleMenu from "./a11y_bubble_menu.js";
+import { bubble_defs } from "./bubble_definitions.js";
+import { BubbleMenu } from "./BubbleMenu.js";
 
 import { infograph_href_template } from "./infographic_link.js";
+
+import text from "./Infographic.yaml";
 
 const sub_app_name = "infographic_org";
 

--- a/client/src/infographic/bubble_definitions.js
+++ b/client/src/infographic/bubble_definitions.js
@@ -1,6 +1,7 @@
+import { trivial_text_maker as text_maker } from "../models/text.js";
+
 import text from "./bubble_definitions.yaml";
 import svgs from "./bubble_svgs.yaml";
-import { trivial_text_maker as text_maker } from "../models/text.js";
 
 export const bubble_defs = {
   intro: {

--- a/client/src/link_utils.js
+++ b/client/src/link_utils.js
@@ -1,8 +1,8 @@
-import { infograph_href_template } from "./infographic/infographic_link.js";
-import { rpb_link } from "./rpb/rpb_link.js";
 import { Table } from "./core/TableClass.js";
-import { Subject } from "./models/subject.js";
+import { infograph_href_template } from "./infographic/infographic_link.js";
 import { GlossaryEntry } from "./models/glossary.js";
+import { Subject } from "./models/subject.js";
+import { rpb_link } from "./rpb/rpb_link.js";
 
 const { Gov, Dept, CRSO, Program, Tag } = Subject;
 const subject_classes_with_infographics = [Gov, Dept, CRSO, Program, Tag];

--- a/client/src/metadata/data_sources.js
+++ b/client/src/metadata/data_sources.js
@@ -1,11 +1,12 @@
-import data_source_text from "./data_sources.yaml";
-import freq_text from "./frequencies.yaml";
 
 //circular dependency hack..
 import { Table } from "../core/TableClass.js";
-import { rpb_link } from "../rpb/rpb_link.js";
 import { GlossaryEntry } from "../models/glossary.js";
 import { create_text_maker } from "../models/text.js";
+import { rpb_link } from "../rpb/rpb_link.js";
+
+import data_source_text from "./data_sources.yaml";
+import freq_text from "./frequencies.yaml";
 
 const tm = create_text_maker([data_source_text, freq_text]);
 

--- a/client/src/metadata/metadata.js
+++ b/client/src/metadata/metadata.js
@@ -1,11 +1,12 @@
-import metadata_text from "./metadata.yaml";
+import { create_text_maker_component, FancyUL, Panel } from "../components";
 import {
   StandardRouteContainer,
   ScrollToTargetContainer,
 } from "../core/NavComponents.js";
-import { create_text_maker_component, FancyUL, Panel } from "../components";
 
 import { sources } from "./data_sources.js";
+
+import metadata_text from "./metadata.yaml";
 
 const { text_maker, TM } = create_text_maker_component(metadata_text);
 

--- a/client/src/models/budget_measures.js
+++ b/client/src/models/budget_measures.js
@@ -1,10 +1,11 @@
+import { trivial_text_maker } from "../models/text.js";
+
 import {
   mix,
   staticStoreMixin,
   PluralSingular,
   SubjectMixin,
 } from "./storeMixins.js";
-import { trivial_text_maker } from "../models/text.js";
 
 const static_subject_store = () =>
   mix().with(staticStoreMixin, PluralSingular, SubjectMixin);

--- a/client/src/models/footnotes/FootnoteInventory.js
+++ b/client/src/models/footnotes/FootnoteInventory.js
@@ -1,9 +1,10 @@
-import { load_footnotes_bundle } from "./populate_footnotes.js";
-import FootNote from "./footnotes.js";
-
+import { FootnoteList, SpinnerWrapper } from "../../components/index.js";
 import { StandardRouteContainer } from "../../core/NavComponents.js";
 
-import { FootnoteList, SpinnerWrapper } from "../../components/index.js";
+import FootNote from "./footnotes.js";
+import { load_footnotes_bundle } from "./populate_footnotes.js";
+
+
 
 export default class FootnoteInventory extends React.Component {
   constructor() {

--- a/client/src/models/footnotes/dynamic_footnotes.js
+++ b/client/src/models/footnotes/dynamic_footnotes.js
@@ -1,9 +1,10 @@
-import text from "./dynamic_footnotes.yaml";
 
 import { Gov, Dept, CRSO, Program } from "../organizational_entities.js";
-import { actual_to_planned_gap_year, fiscal_year_to_year } from "../years.js";
 import { result_docs_in_tabling_order } from "../results.js";
 import { create_text_maker } from "../text.js";
+import { actual_to_planned_gap_year, fiscal_year_to_year } from "../years.js";
+
+import text from "./dynamic_footnotes.yaml";
 
 const all_subject_classes = [Gov, Dept, CRSO, Program];
 const text_maker = create_text_maker(text);

--- a/client/src/models/footnotes/populate_footnotes.js
+++ b/client/src/models/footnotes/populate_footnotes.js
@@ -1,12 +1,14 @@
-import FootNote from "./footnotes.js";
-import { get_dynamic_footnotes } from "./dynamic_footnotes.js";
-import footnote_topic_text from "./footnote_topics.yaml";
 
 import { sanitized_marked } from "../../general_utils.js";
 import { get_static_url, make_request } from "../../request_utils.js";
 import { Subject } from "../subject.js";
 import { run_template } from "../text.js";
 import { fiscal_year_to_year } from "../years.js";
+
+import { get_dynamic_footnotes } from "./dynamic_footnotes.js";
+import FootNote from "./footnotes.js";
+
+import footnote_topic_text from "./footnote_topics.yaml";
 
 const footnote_topic_keys = _.keys(footnote_topic_text);
 

--- a/client/src/models/glossary.js
+++ b/client/src/models/glossary.js
@@ -1,4 +1,5 @@
 import { sanitized_marked } from "../general_utils.js";
+
 import { mix, staticStoreMixin } from "./storeMixins.js";
 import { trivial_text_maker } from "./text.js";
 

--- a/client/src/models/organizational_entities.js
+++ b/client/src/models/organizational_entities.js
@@ -1,3 +1,5 @@
+import { trivial_text_maker } from "../models/text.js";
+
 import {
   mix,
   staticStoreMixin,
@@ -5,7 +7,6 @@ import {
   SubjectMixin,
   CanHaveAPIData,
 } from "./storeMixins.js";
-import { trivial_text_maker } from "../models/text.js";
 
 const static_subject_store = () =>
   mix().with(staticStoreMixin, PluralSingular, SubjectMixin);

--- a/client/src/models/populate_budget_measures.js
+++ b/client/src/models/populate_budget_measures.js
@@ -1,6 +1,8 @@
-import { get_client } from "../graphql_utils/graphql_utils.js";
 import gql from "graphql-tag";
+
 import { log_standard_event } from "../core/analytics.js";
+import { get_client } from "../graphql_utils/graphql_utils.js";
+
 import { Subject } from "./subject.js";
 
 const { BudgetMeasure } = Subject;

--- a/client/src/models/populate_horizontal_initiative_lookups.js
+++ b/client/src/models/populate_horizontal_initiative_lookups.js
@@ -1,4 +1,5 @@
 import { get_static_url, make_request } from "../request_utils.js";
+
 import { Subject } from "./subject.js";
 
 const { Tag } = Subject;

--- a/client/src/models/populate_results.js
+++ b/client/src/models/populate_results.js
@@ -1,6 +1,8 @@
-import { get_client } from "../graphql_utils/graphql_utils.js";
 import gql from "graphql-tag";
+
 import { log_standard_event } from "../core/analytics.js";
+import { get_client } from "../graphql_utils/graphql_utils.js";
+
 import {
   Indicator,
   Result,

--- a/client/src/models/populate_services.js
+++ b/client/src/models/populate_services.js
@@ -1,6 +1,8 @@
-import { get_client } from "../graphql_utils/graphql_utils.js";
 import gql from "graphql-tag";
+
 import { log_standard_event } from "../core/analytics.js";
+import { get_client } from "../graphql_utils/graphql_utils.js";
+
 import { Service, ServiceStandard } from "./services.js";
 
 const get_subject_has_services_query = (level, id_arg_name) => gql`

--- a/client/src/models/populate_stores.js
+++ b/client/src/models/populate_stores.js
@@ -1,7 +1,8 @@
 import { sanitized_marked } from "../general_utils.js";
 import { get_static_url, make_request } from "../request_utils.js";
-import { GlossaryEntry } from "./glossary.js";
+
 import { populate_global_footnotes } from "./footnotes/populate_footnotes.js";
+import { GlossaryEntry } from "./glossary.js";
 import { Subject } from "./subject.js";
 import { trivial_text_maker } from "./text";
 

--- a/client/src/models/results.js
+++ b/client/src/models/results.js
@@ -1,8 +1,7 @@
-import { trivial_text_maker } from "./text.js";
+import { trivial_text_maker, run_template } from "./text.js";
 import { Program, CRSO } from "./organizational_entities.js";
 import { businessConstants } from "./businessConstants.js";
 import { formats } from "../core/format.js";
-import { run_template } from "../models/text.js";
 
 const { months } = businessConstants;
 const { year_to_fiscal_year } = formats;

--- a/client/src/models/results.js
+++ b/client/src/models/results.js
@@ -1,7 +1,9 @@
-import { trivial_text_maker, run_template } from "./text.js";
-import { Program, CRSO } from "./organizational_entities.js";
-import { businessConstants } from "./businessConstants.js";
 import { formats } from "../core/format.js";
+
+import { businessConstants } from "./businessConstants.js";
+import { Program, CRSO } from "./organizational_entities.js";
+import { trivial_text_maker, run_template } from "./text.js";
+
 
 const { months } = businessConstants;
 const { year_to_fiscal_year } = formats;

--- a/client/src/models/services.js
+++ b/client/src/models/services.js
@@ -1,12 +1,12 @@
+import { trivial_text_maker } from "../models/text.js";
+
+import { Program } from "./organizational_entities.js";
 import {
   mix,
   staticStoreMixin,
   PluralSingular,
   SubjectMixin,
 } from "./storeMixins.js";
-import { trivial_text_maker } from "../models/text.js";
-
-import { Program } from "./organizational_entities.js";
 
 // dependencies are tangled up too much here, disable it for the whole file
 /* eslint-disable no-use-before-define */

--- a/client/src/models/subject.js
+++ b/client/src/models/subject.js
@@ -1,3 +1,4 @@
+import { BudgetMeasure } from "./budget_measures.js";
 import {
   Gov,
   Dept,
@@ -7,9 +8,8 @@ import {
   Ministry,
   Minister,
 } from "./organizational_entities.js";
-import { Tag } from "./tags.js";
 import { Result, Indicator } from "./results.js";
-import { BudgetMeasure } from "./budget_measures.js";
+import { Tag } from "./tags.js";
 
 const Subject = {
   Gov,

--- a/client/src/models/tags.js
+++ b/client/src/models/tags.js
@@ -1,11 +1,12 @@
+import { trivial_text_maker } from "../models/text.js";
+
+import { Dept } from "./organizational_entities.js";
 import {
   mix,
   exstensibleStoreMixin,
   PluralSingular,
   SubjectMixin,
 } from "./storeMixins.js";
-import { trivial_text_maker } from "../models/text.js";
-import { Dept } from "./organizational_entities.js";
 
 const extensible_subject_store = () =>
   mix().with(exstensibleStoreMixin, PluralSingular, SubjectMixin);

--- a/client/src/models/text.js
+++ b/client/src/models/text.js
@@ -1,12 +1,13 @@
 import marked from "marked";
-import template_globals_file from "../common_text/template_globals.csv";
+
+import a11y_lang from "../common_text/a11y_lang.yaml";
 import common_lang from "../common_text/common_lang.yaml";
+import estimates_lang from "../common_text/estimates_lang.yaml";
 import igoc_lang from "../common_text/igoc-lang.yaml";
 import nav_lang from "../common_text/nav_lang.yaml";
-import result_lang from "../common_text/result_lang.yaml";
 import people_lang from "../common_text/people_lang.yaml";
-import estimates_lang from "../common_text/estimates_lang.yaml";
-import a11y_lang from "../common_text/a11y_lang.yaml";
+import result_lang from "../common_text/result_lang.yaml";
+import template_globals_file from "../common_text/template_globals.csv";
 
 /* 
   TODO: some parts of this still feel hacky 

--- a/client/src/panels/PanelRegistry.js
+++ b/client/src/panels/PanelRegistry.js
@@ -1,7 +1,7 @@
-import { Table } from "../core/TableClass.js";
 import { get_info, tables_for_statistics } from "../core/Statistics.js";
-import { Subject } from "../models/subject.js";
+import { Table } from "../core/TableClass.js";
 import FootNote from "../models/footnotes/footnotes.js";
+import { Subject } from "../models/subject.js";
 import { rpb_link, get_appropriate_rpb_subject } from "../rpb/rpb_link.js";
 
 const subjects = _.keys(Subject);

--- a/client/src/panels/PanelRenderer.js
+++ b/client/src/panels/PanelRenderer.js
@@ -1,8 +1,9 @@
 import { withRouter } from "react-router";
 
+import { shallowEqualObjectsOverKeys } from "../general_utils.js";
+
 import { PanelRegistry } from "./PanelRegistry.js";
 
-import { shallowEqualObjectsOverKeys } from "../general_utils.js";
 
 export const panel_context = React.createContext(null);
 

--- a/client/src/panels/panel_declarations/InfographicPanel.js
+++ b/client/src/panels/panel_declarations/InfographicPanel.js
@@ -1,7 +1,6 @@
-import text from "./InfographicPanel.yaml";
 
-import PropTypes from "prop-types";
 import classNames from "classnames";
+import PropTypes from "prop-types";
 import { Fragment } from "react";
 
 import {
@@ -17,6 +16,8 @@ import { IconCopyLink } from "../../icons/icons.js";
 import { panel_href_template } from "../../infographic/infographic_link.js";
 
 import { panel_context } from "../PanelRenderer.js";
+
+import text from "./InfographicPanel.yaml";
 
 const { text_maker } = create_text_maker_component(text);
 

--- a/client/src/panels/panel_declarations/finances/auth_exp_planned_spending/auth_exp_planned_spending.js
+++ b/client/src/panels/panel_declarations/finances/auth_exp_planned_spending/auth_exp_planned_spending.js
@@ -1,6 +1,3 @@
-import "./auth_exp_planned_spending.scss";
-import text from "./auth_exp_planned_spending.yaml";
-
 import { Fragment } from "react";
 
 import {
@@ -17,6 +14,9 @@ import {
   util_components,
   declare_panel,
 } from "../../shared.js";
+
+import text from "./auth_exp_planned_spending.yaml";
+import "./auth_exp_planned_spending.scss";
 
 const { Details } = util_components;
 

--- a/client/src/panels/panel_declarations/finances/budget_measures/budget_measures_panel.js
+++ b/client/src/panels/panel_declarations/finances/budget_measures/budget_measures_panel.js
@@ -1,9 +1,7 @@
-import "./budget_measures_panel.scss";
-import text1 from "./budget_measures_panel.yaml";
-import text2 from "../../../../partition/budget_measures_subapp/BudgetMeasuresRoute.yaml";
-
 import { Fragment } from "react";
 import MediaQuery from "react-responsive";
+
+import text2 from "../../../../partition/budget_measures_subapp/BudgetMeasuresRoute.yaml";
 
 import {
   formats,
@@ -20,6 +18,9 @@ import {
   declare_panel,
   TspanLineWrapper,
 } from "../../shared.js";
+
+import text1 from "./budget_measures_panel.yaml";
+import "./budget_measures_panel.scss";
 
 const { budget_values } = businessConstants;
 

--- a/client/src/panels/panel_declarations/finances/detailed_program_spending_split/detailed_program_spending_split.js
+++ b/client/src/panels/panel_declarations/finances/detailed_program_spending_split/detailed_program_spending_split.js
@@ -1,5 +1,4 @@
-import text from "./detailed_program_spending_split.yaml";
-
+import { SmartDisplayTable } from "../../../../components";
 import {
   WrappedNivoBar,
   WrappedNivoHBar,
@@ -21,7 +20,8 @@ import {
   TspanLineWrapper,
   HeightClippedGraph,
 } from "../../shared.js";
-import { SmartDisplayTable } from "../../../../components";
+
+import text from "./detailed_program_spending_split.yaml";
 
 const { std_years } = year_templates;
 

--- a/client/src/panels/panel_declarations/finances/drr_dp_resources/crso_by_prog.js
+++ b/client/src/panels/panel_declarations/finances/drr_dp_resources/crso_by_prog.js
@@ -1,4 +1,3 @@
-import text from "./crso_by_prog.yaml";
 import {
   WrappedNivoBar,
   year_templates,
@@ -12,6 +11,8 @@ import {
   get_planned_spending_source_link,
   declare_panel,
 } from "../../shared.js";
+
+import text from "./crso_by_prog.yaml";
 
 const { Format } = util_components;
 

--- a/client/src/panels/panel_declarations/finances/drr_dp_resources/dp_rev_split.js
+++ b/client/src/panels/panel_declarations/finances/drr_dp_resources/dp_rev_split.js
@@ -1,4 +1,4 @@
-import text from "./dp_rev_split.yaml";
+import { Format, SmartDisplayTable } from "../../../../components";
 import {
   year_templates,
   run_template,
@@ -7,7 +7,8 @@ import {
   get_source_links,
   declare_panel,
 } from "../../shared.js";
-import { SmartDisplayTable, Format } from "../../../../components";
+
+import text from "./dp_rev_split.yaml";
 
 const { text_maker } = create_text_maker_component(text);
 

--- a/client/src/panels/panel_declarations/finances/drr_dp_resources/spending_in_perspective.js
+++ b/client/src/panels/panel_declarations/finances/drr_dp_resources/spending_in_perspective.js
@@ -1,4 +1,3 @@
-import text from "./perspective_text.yaml";
 import {
   declare_panel,
   util_components,
@@ -6,6 +5,8 @@ import {
   create_text_maker_component,
   WrappedNivoPie,
 } from "../../shared.js";
+
+import text from "./perspective_text.yaml";
 
 const { Select } = util_components;
 

--- a/client/src/panels/panel_declarations/finances/goco/goco.js
+++ b/client/src/panels/panel_declarations/finances/goco/goco.js
@@ -1,5 +1,5 @@
-import text from "./goco.yaml";
 import { Fragment } from "react";
+
 import {
   create_text_maker_component,
   Subject,
@@ -16,8 +16,9 @@ import {
   util_components,
 } from "../../shared.js";
 
-const { SmartDisplayTable } = util_components;
+import text from "./goco.yaml";
 
+const { SmartDisplayTable } = util_components;
 const { Tag } = Subject;
 
 const { text_maker, TM } = create_text_maker_component(text);

--- a/client/src/panels/panel_declarations/finances/internal_services/internal_services.js
+++ b/client/src/panels/panel_declarations/finances/internal_services/internal_services.js
@@ -1,5 +1,3 @@
-import text from "./internal_services.yaml";
-
 import {
   InfographicPanel,
   Subject,
@@ -11,6 +9,9 @@ import {
   WrappedNivoBar,
   declare_panel,
 } from "../../shared.js";
+
+import text from "./internal_services.yaml";
+
 
 const { Gov, Tag } = Subject;
 const { std_years } = year_templates;

--- a/client/src/panels/panel_declarations/finances/planned_actual_comparison/planned_actual_comparison.js
+++ b/client/src/panels/panel_declarations/finances/planned_actual_comparison/planned_actual_comparison.js
@@ -1,7 +1,3 @@
-import text from "./planned_actual_comparison.yaml";
-
-import { PlannedActualTable } from "./PlannedActualTable.js";
-
 import {
   declare_panel,
   FootNote,
@@ -9,6 +5,12 @@ import {
   TextPanel,
   get_source_links,
 } from "../../shared.js";
+
+import { PlannedActualTable } from "./PlannedActualTable.js";
+
+import text from "./planned_actual_comparison.yaml";
+
+
 
 const { text_maker, TM } = create_text_maker_component(text);
 

--- a/client/src/panels/panel_declarations/finances/sobj/personel_spend.js
+++ b/client/src/panels/panel_declarations/finances/sobj/personel_spend.js
@@ -1,4 +1,3 @@
-import { text_maker, TM } from "./sobj_text_provider.js";
 import {
   declare_panel,
   year_templates,
@@ -10,6 +9,8 @@ import {
   WrappedNivoLine,
   run_template,
 } from "../../shared.js";
+
+import { text_maker, TM } from "./sobj_text_provider.js";
 const { sos } = businessConstants;
 const { std_years } = year_templates;
 const { Format } = util_components;

--- a/client/src/panels/panel_declarations/finances/sobj/sobj_text_provider.js
+++ b/client/src/panels/panel_declarations/finances/sobj/sobj_text_provider.js
@@ -1,4 +1,5 @@
 import { create_text_maker_component } from "../../shared.js";
+
 import text from "./sobj-panel-text.yaml";
 
 export const { text_maker, TM } = create_text_maker_component(text);

--- a/client/src/panels/panel_declarations/finances/sobj/spend_by_so_hist.js
+++ b/client/src/panels/panel_declarations/finances/sobj/spend_by_so_hist.js
@@ -12,6 +12,7 @@ import {
   newIBDarkCategoryColors,
   declare_panel,
 } from "../../shared.js";
+
 import { text_maker, TM } from "./sobj_text_provider.js";
 
 const { sos } = businessConstants;

--- a/client/src/panels/panel_declarations/finances/sobj/spend_rev_split.js
+++ b/client/src/panels/panel_declarations/finances/sobj/spend_rev_split.js
@@ -1,4 +1,3 @@
-import text from "./spend_rev_split.yaml";
 import {
   formats,
   create_text_maker_component,
@@ -8,6 +7,8 @@ import {
   table_common,
   declare_panel,
 } from "../../shared.js";
+
+import text from "./spend_rev_split.yaml";
 
 const { rows_to_rev_split } = table_common;
 

--- a/client/src/panels/panel_declarations/finances/sobj/top_spending_areas.js
+++ b/client/src/panels/panel_declarations/finances/sobj/top_spending_areas.js
@@ -1,5 +1,3 @@
-import text from "./top_spending_areas.yaml";
-
 import {
   util_components,
   run_template,
@@ -12,6 +10,9 @@ import {
   declare_panel,
   WrappedNivoPie,
 } from "../../shared.js";
+
+import text from "./top_spending_areas.yaml";
+
 
 const { is_non_revenue, collapse_by_so } = table_common;
 

--- a/client/src/panels/panel_declarations/finances/transfer_payments/gnc_text_provider.js
+++ b/client/src/panels/panel_declarations/finances/transfer_payments/gnc_text_provider.js
@@ -1,4 +1,5 @@
-import text1 from "./gnc-text.yaml";
 import { create_text_maker_component } from "../../shared.js";
+
+import text1 from "./gnc-text.yaml";
 
 export const { text_maker, TM } = create_text_maker_component([text1]);

--- a/client/src/panels/panel_declarations/finances/transfer_payments/historical_g_and_c.js
+++ b/client/src/panels/panel_declarations/finances/transfer_payments/historical_g_and_c.js
@@ -1,6 +1,5 @@
 import { Fragment } from "react";
 
-import { text_maker, TM } from "./gnc_text_provider.js";
 import {
   run_template,
   declare_panel,
@@ -13,6 +12,8 @@ import {
   util_components,
   WrappedNivoLine,
 } from "../../shared.js";
+
+import { text_maker, TM } from "./gnc_text_provider.js";
 
 const { transfer_payments } = businessConstants;
 const { std_years } = year_templates;

--- a/client/src/panels/panel_declarations/finances/transfer_payments/last_year_g_and_c_perspective.js
+++ b/client/src/panels/panel_declarations/finances/transfer_payments/last_year_g_and_c_perspective.js
@@ -1,12 +1,13 @@
 import { Fragment } from "react";
 
-import { text_maker, TM } from "./gnc_text_provider.js";
 import {
   StdPanel,
   Col,
   CircleProportionChart,
   declare_panel,
 } from "../../shared.js";
+
+import { text_maker, TM } from "./gnc_text_provider.js";
 
 export const declare_last_year_g_and_c_perspective_panel = () =>
   declare_panel({

--- a/client/src/panels/panel_declarations/finances/transfer_payments/tp_by_region.js
+++ b/client/src/panels/panel_declarations/finances/transfer_payments/tp_by_region.js
@@ -1,7 +1,10 @@
-import text from "./tp_by_region.yaml";
 
 import { Fragment } from "react";
 
+
+import { Canada } from "../../../../charts/canada/index.js";
+import { SpinnerWrapper, TabbedContent } from "../../../../components/index.js";
+import { get_static_url, make_request } from "../../../../request_utils.js";
 import {
   formats,
   run_template,
@@ -14,9 +17,7 @@ import {
   A11yTable,
 } from "../../shared.js";
 
-import { Canada } from "../../../../charts/canada/index.js";
-import { SpinnerWrapper, TabbedContent } from "../../../../components/index.js";
-import { get_static_url, make_request } from "../../../../request_utils.js";
+import text from "./tp_by_region.yaml";
 
 const { std_years } = year_templates;
 

--- a/client/src/panels/panel_declarations/finances/vote_stat/estimates_in_perspective.js
+++ b/client/src/panels/panel_declarations/finances/vote_stat/estimates_in_perspective.js
@@ -1,10 +1,11 @@
-import { TM, text_maker } from "./vote_stat_text_provider.js";
 import {
   StdPanel,
   Col,
   CircleProportionChart,
   declare_panel,
 } from "../../shared.js";
+
+import { TM, text_maker } from "./vote_stat_text_provider.js";
 
 export const declare_estimates_in_perspective_panel = () =>
   declare_panel({

--- a/client/src/panels/panel_declarations/finances/vote_stat/in_year_estimates_split.js
+++ b/client/src/panels/panel_declarations/finances/vote_stat/in_year_estimates_split.js
@@ -1,4 +1,4 @@
-import { text_maker, TM } from "./vote_stat_text_provider.js";
+import { formats } from "../../../../core/format.js";
 import {
   util_components,
   run_template,
@@ -8,7 +8,8 @@ import {
   WrappedNivoBar,
   declare_panel,
 } from "../../shared.js";
-import { formats } from "../../../../core/format.js";
+
+import { text_maker, TM } from "./vote_stat_text_provider.js";
 
 const { Format } = util_components;
 

--- a/client/src/panels/panel_declarations/finances/vote_stat/in_year_vote_stat_breakdown.js
+++ b/client/src/panels/panel_declarations/finances/vote_stat/in_year_vote_stat_breakdown.js
@@ -1,4 +1,3 @@
-import { text_maker, TM } from "./vote_stat_text_provider.js";
 import {
   Subject,
   formats,
@@ -10,6 +9,9 @@ import {
   FlatTreeMapViz,
   declare_panel,
 } from "../../shared.js";
+
+import { text_maker, TM } from "./vote_stat_text_provider.js";
+
 const { SmartDisplayTable, default_dept_name_sort_func } = util_components;
 
 const main_col = "{{est_in_year}}_estimates";

--- a/client/src/panels/panel_declarations/finances/vote_stat/in_year_vote_stat_split.js
+++ b/client/src/panels/panel_declarations/finances/vote_stat/in_year_vote_stat_split.js
@@ -1,10 +1,11 @@
-import { text_maker, TM } from "./vote_stat_text_provider.js";
 import {
   StdPanel,
   Col,
   WrappedNivoPie,
   declare_panel,
 } from "../../shared.js";
+
+import { text_maker, TM } from "./vote_stat_text_provider.js";
 
 const render_w_options = ({ graph_col, text_col, text_key }) => ({
   calculations,

--- a/client/src/panels/panel_declarations/finances/vote_stat/last_year_vote_stat_split.js
+++ b/client/src/panels/panel_declarations/finances/vote_stat/last_year_vote_stat_split.js
@@ -1,10 +1,11 @@
-import { text_maker, TM } from "./vote_stat_text_provider.js";
 import {
   StdPanel,
   Col,
   WrappedNivoPie,
   declare_panel,
 } from "../../shared.js";
+
+import { text_maker, TM } from "./vote_stat_text_provider.js";
 
 const render_w_options = ({ text_key, graph_col, text_col }) => ({
   calculations,

--- a/client/src/panels/panel_declarations/finances/vote_stat/vote_stat_text_provider.js
+++ b/client/src/panels/panel_declarations/finances/vote_stat/vote_stat_text_provider.js
@@ -1,4 +1,5 @@
 import { create_text_maker_component } from "../../shared.js";
+
 import text from "./vote_stat_text.yaml";
 
 export const { text_maker, TM } = create_text_maker_component([text]);

--- a/client/src/panels/panel_declarations/finances/welcome_mat/welcome_mat.js
+++ b/client/src/panels/panel_declarations/finances/welcome_mat/welcome_mat.js
@@ -1,8 +1,5 @@
-import "./welcome-mat.scss";
-import text from "./welcome_mat.yaml";
-
-import { Fragment } from "react";
 import classNames from "classnames";
+import { Fragment } from "react";
 
 import {
   run_template,
@@ -20,6 +17,9 @@ import {
 
 import { format_and_get_exp_program_spending } from "./welcome_mat_exp_program_spending.js";
 import { format_and_get_fte } from "./welcome_mat_fte.js";
+
+import text from "./welcome_mat.yaml";
+import "./welcome-mat.scss";
 
 const { Format } = util_components;
 

--- a/client/src/panels/panel_declarations/finances/welcome_mat/welcome_mat_exp_program_spending.js
+++ b/client/src/panels/panel_declarations/finances/welcome_mat/welcome_mat_exp_program_spending.js
@@ -1,5 +1,6 @@
 import { Fragment } from "react";
 import MediaQuery from "react-responsive";
+
 import {
   run_template,
   year_templates,

--- a/client/src/panels/panel_declarations/intro/profile_panels.js
+++ b/client/src/panels/panel_declarations/intro/profile_panels.js
@@ -1,5 +1,3 @@
-import text from "./profile_panels.yaml";
-
 import {
   TextPanel,
   general_utils,
@@ -10,6 +8,9 @@ import {
   formats,
   declare_panel,
 } from "../shared.js";
+
+import text from "./profile_panels.yaml";
+
 
 const { text_maker } = create_text_maker_component(text);
 const { sanitized_dangerous_inner_html, generate_href } = general_utils;

--- a/client/src/panels/panel_declarations/intro/simplographic/simplographic.js
+++ b/client/src/panels/panel_declarations/intro/simplographic/simplographic.js
@@ -1,15 +1,15 @@
-import "./simplographic.scss";
-import simplographic_text from "./simplographic.yaml";
-
+import { infograph_href_template, rpb_link } from "../../../../link_utils.js";
+import { ResultCounts, current_drr_key } from "../../../../models/results.js";
+import { get_static_url } from "../../../../request_utils.js";
 import {
   Subject,
   declare_panel,
   util_components,
   InfographicPanel,
 } from "../../shared.js";
-import { infograph_href_template, rpb_link } from "../../../../link_utils.js";
-import { ResultCounts, current_drr_key } from "../../../../models/results.js";
-import { get_static_url } from "../../../../request_utils.js";
+
+import simplographic_text from "./simplographic.yaml";
+import "./simplographic.scss";
 
 const { Gov, Dept } = Subject;
 const { create_text_maker_component } = util_components;

--- a/client/src/panels/panel_declarations/misc/gov_related.js
+++ b/client/src/panels/panel_declarations/misc/gov_related.js
@@ -1,10 +1,11 @@
-import text from "./gov_related.yaml";
 import {
   declare_panel,
   create_text_maker,
   TM,
   InfographicPanel,
 } from "../shared.js";
+
+import text from "./gov_related.yaml";
 
 const text_maker = create_text_maker(text);
 

--- a/client/src/panels/panel_declarations/misc/hierarchy_component.js
+++ b/client/src/panels/panel_declarations/misc/hierarchy_component.js
@@ -1,10 +1,11 @@
-import text from "./hierarchy_panels.yaml";
 
 import classNames from "classnames";
 import { Fragment } from "react";
 
-import { Subject, create_text_maker_component } from "../shared.js";
 import { IconAttentionTriangle } from "../../../icons/icons.js";
+import { Subject, create_text_maker_component } from "../shared.js";
+
+import text from "./hierarchy_panels.yaml";
 
 const { text_maker, TM } = create_text_maker_component(text);
 const { Gov } = Subject;

--- a/client/src/panels/panel_declarations/misc/hierarchy_panels.js
+++ b/client/src/panels/panel_declarations/misc/hierarchy_panels.js
@@ -1,4 +1,3 @@
-import text from "./hierarchy_panels.yaml";
 
 import {
   util_components,
@@ -7,6 +6,7 @@ import {
   create_text_maker,
   declare_panel,
 } from "../shared.js";
+
 import {
   HierarchyPeek,
   org_external_hierarchy,
@@ -16,6 +16,8 @@ import {
   crso_hierarchy,
   crso_pi_hierarchy,
 } from "./hierarchy_component.js";
+
+import text from "./hierarchy_panels.yaml";
 
 const text_maker = create_text_maker(text);
 const { HeightClipper } = util_components;

--- a/client/src/panels/panel_declarations/misc/key_concept_panels/key_concept_panels.js
+++ b/client/src/panels/panel_declarations/misc/key_concept_panels/key_concept_panels.js
@@ -1,12 +1,13 @@
-import MediaQuery from "react-responsive";
 import classNames from "classnames";
+import MediaQuery from "react-responsive";
+
+import { util_components, breakpoints, declare_panel } from "../../shared.js";
 
 import common_lang from "./common_questions.yaml";
 import fin_lang from "./financial_questions.yaml";
 import ppl_lang from "./people_questions.yaml";
 import results_lang from "./results_questions.yaml";
 import tag_lang from "./tagging_questions.yaml";
-import { util_components, breakpoints, declare_panel } from "../../shared.js";
 
 const {
   create_text_maker_component,

--- a/client/src/panels/panel_declarations/misc/resource_structure/explorer_component.js
+++ b/client/src/panels/panel_declarations/misc/resource_structure/explorer_component.js
@@ -1,15 +1,16 @@
 import "src/explorer_common/explorer-styles.scss";
 
 import { Fragment } from "react";
+
+import { Explorer } from "src/explorer_common/explorer_components.js";
+import { get_root } from "src/explorer_common/hierarchy_tools.js";
+import { get_col_defs } from "src/explorer_common/resource_explorer_common.js";
 import { infograph_href_template } from "src/link_utils.js";
 import {
   TabbedControls,
   run_template,
 } from "src/panels//panel_declarations/shared.js";
 
-import { get_root } from "src/explorer_common/hierarchy_tools.js";
-import { get_col_defs } from "src/explorer_common/resource_explorer_common.js";
-import { Explorer } from "src/explorer_common/explorer_components.js";
 
 import { actual_year, planning_year, TM } from "./utils";
 

--- a/client/src/panels/panel_declarations/misc/resource_structure/rooted_resource_scheme.js
+++ b/client/src/panels/panel_declarations/misc/resource_structure/rooted_resource_scheme.js
@@ -1,20 +1,20 @@
 import { createSelector } from "reselect";
 
+import { AbstractExplorerScheme } from "src/explorer_common/abstract_explorer_scheme";
+import {
+  filter_hierarchy,
+  convert_d3_hierarchy_to_explorer_hierarchy,
+} from "src/explorer_common/hierarchy_tools.js";
+import {
+  get_resources_for_subject,
+  create_sort_func_selector,
+} from "src/explorer_common/resource_explorer_common.js";
 import {
   cached_property,
   bound,
   shallowEqualObjectsOverKeys,
   sanitized_dangerous_inner_html,
 } from "src/general_utils";
-import {
-  get_resources_for_subject,
-  create_sort_func_selector,
-} from "src/explorer_common/resource_explorer_common.js";
-import {
-  filter_hierarchy,
-  convert_d3_hierarchy_to_explorer_hierarchy,
-} from "src/explorer_common/hierarchy_tools.js";
-import { AbstractExplorerScheme } from "src/explorer_common/abstract_explorer_scheme";
 
 import { trivial_text_maker } from "src/models/text";
 

--- a/client/src/panels/panel_declarations/misc/rpb_links.js
+++ b/client/src/panels/panel_declarations/misc/rpb_links.js
@@ -1,5 +1,3 @@
-import text from "./rpb_links.yaml";
-
 import {
   TextPanel,
   util_components,
@@ -8,6 +6,9 @@ import {
   create_text_maker_component,
   declare_panel,
 } from "../shared.js";
+
+import text from "./rpb_links.yaml";
+
 
 const { WellList } = util_components;
 

--- a/client/src/panels/panel_declarations/misc/tags_related_to_subject_panels.js
+++ b/client/src/panels/panel_declarations/misc/tags_related_to_subject_panels.js
@@ -1,5 +1,3 @@
-import text from "./tags_related_to_subject_panels.yaml";
-import hierarchy_text from "./hierarchy_panels.yaml";
 
 import classNames from "classnames";
 import { Fragment } from "react";
@@ -12,7 +10,11 @@ import {
   create_text_maker_component,
   declare_panel,
 } from "../shared.js";
+
 import { HierarchyDeadElementIcon } from "./hierarchy_component.js";
+
+import hierarchy_text from "./hierarchy_panels.yaml";
+import text from "./tags_related_to_subject_panels.yaml";
 
 const { text_maker, TM } = create_text_maker_component([text, hierarchy_text]);
 const { Dept, Tag, Program } = Subject;

--- a/client/src/panels/panel_declarations/misc/warning_panels.js
+++ b/client/src/panels/panel_declarations/misc/warning_panels.js
@@ -1,4 +1,3 @@
-import text from "./warning_panels.yaml";
 
 import { Fragment } from "react";
 
@@ -11,6 +10,8 @@ import {
   create_text_maker_component,
   declare_panel,
 } from "../shared.js";
+
+import text from "./warning_panels.yaml";
 
 const { TM, text_maker } = create_text_maker_component([
   text,

--- a/client/src/panels/panel_declarations/people/employee_age.js
+++ b/client/src/panels/panel_declarations/people/employee_age.js
@@ -1,4 +1,3 @@
-import text from "./employee_age.yaml";
 import {
   formats,
   run_template,
@@ -13,6 +12,8 @@ import {
   declare_panel,
   NivoLineBarToggle,
 } from "../shared.js";
+
+import text from "./employee_age.yaml";
 
 const { text_maker, TM } = create_text_maker_component(text);
 

--- a/client/src/panels/panel_declarations/people/employee_executive_level.js
+++ b/client/src/panels/panel_declarations/people/employee_executive_level.js
@@ -1,4 +1,3 @@
-import text from "./employee_executive_level.yaml";
 import {
   formats,
   run_template,
@@ -11,6 +10,8 @@ import {
   declare_panel,
   NivoLineBarToggle,
 } from "../shared.js";
+
+import text from "./employee_executive_level.yaml";
 
 const { text_maker, TM } = create_text_maker_component(text);
 

--- a/client/src/panels/panel_declarations/people/employee_fol.js
+++ b/client/src/panels/panel_declarations/people/employee_fol.js
@@ -1,4 +1,3 @@
-import text from "./employee_fol.yaml";
 import {
   formats,
   run_template,
@@ -11,6 +10,8 @@ import {
   declare_panel,
   NivoLineBarToggle,
 } from "../shared.js";
+
+import text from "./employee_fol.yaml";
 
 const { text_maker, TM } = create_text_maker_component(text);
 

--- a/client/src/panels/panel_declarations/people/employee_gender.js
+++ b/client/src/panels/panel_declarations/people/employee_gender.js
@@ -1,4 +1,3 @@
-import text from "./employee_gender.yaml";
 import {
   formats,
   run_template,
@@ -11,6 +10,8 @@ import {
   declare_panel,
   NivoLineBarToggle,
 } from "../shared.js";
+
+import text from "./employee_gender.yaml";
 
 const { text_maker, TM } = create_text_maker_component(text);
 

--- a/client/src/panels/panel_declarations/people/employee_last_year_totals.js
+++ b/client/src/panels/panel_declarations/people/employee_last_year_totals.js
@@ -1,4 +1,3 @@
-import text1 from "./employee_last_year_totals.yaml";
 import text2 from "../../../common_text/common_lang.yaml";
 import {
   create_text_maker_component,
@@ -7,6 +6,8 @@ import {
   CircleProportionChart,
   declare_panel,
 } from "../shared.js";
+
+import text1 from "./employee_last_year_totals.yaml";
 
 const { text_maker, TM } = create_text_maker_component([text1, text2]);
 

--- a/client/src/panels/panel_declarations/people/employee_prov.js
+++ b/client/src/panels/panel_declarations/people/employee_prov.js
@@ -1,4 +1,4 @@
-import text from "./employee_prov.yaml";
+import { Canada } from "../../../charts/canada/index.js";
 import {
   formats,
   run_template,
@@ -10,7 +10,8 @@ import {
   A11yTable,
   declare_panel,
 } from "../shared.js";
-import { Canada } from "../../../charts/canada/index.js";
+
+import text from "./employee_prov.yaml";
 
 const { text_maker, TM } = create_text_maker_component(text);
 

--- a/client/src/panels/panel_declarations/people/employee_totals.js
+++ b/client/src/panels/panel_declarations/people/employee_totals.js
@@ -1,4 +1,3 @@
-import text from "./employee_totals.yaml";
 import {
   formats,
   run_template,
@@ -11,6 +10,8 @@ import {
   businessConstants,
   declare_panel,
 } from "../shared.js";
+
+import text from "./employee_totals.yaml";
 
 const { months } = businessConstants;
 

--- a/client/src/panels/panel_declarations/people/employee_type.js
+++ b/client/src/panels/panel_declarations/people/employee_type.js
@@ -1,4 +1,3 @@
-import text from "./employee_type.yaml";
 import {
   formats,
   run_template,
@@ -11,6 +10,8 @@ import {
   declare_panel,
   NivoLineBarToggle,
 } from "../shared.js";
+
+import text from "./employee_type.yaml";
 
 const { text_maker, TM } = create_text_maker_component(text);
 

--- a/client/src/panels/panel_declarations/results/drr_summary.js
+++ b/client/src/panels/panel_declarations/results/drr_summary.js
@@ -1,9 +1,7 @@
-import "./drr_summary.scss";
-import { TM, text_maker } from "./drr_summary_text.js";
-
 import classNames from "classnames";
 import { Fragment } from "react";
 
+import { IconArray } from "../../../charts/IconArray.js";
 import {
   StandardLegend,
   A11yTable,
@@ -14,6 +12,9 @@ import {
   declare_panel,
   WrappedNivoPie,
 } from "../shared.js";
+
+import { TM, text_maker } from "./drr_summary_text.js";
+import { large_status_icons } from "./result_components.js";
 import {
   row_to_drr_status_counts,
   ResultCounts,
@@ -24,9 +25,7 @@ import {
   result_color_scale,
 } from "./results_common.js";
 
-import { large_status_icons } from "./result_components.js";
-
-import { IconArray } from "../../../charts/IconArray.js";
+import "./drr_summary.scss";
 
 const { result_simple_statuses } = businessConstants;
 const { current_drr_key, result_docs } = Results;

--- a/client/src/panels/panel_declarations/results/drr_summary_text.js
+++ b/client/src/panels/panel_declarations/results/drr_summary_text.js
@@ -1,4 +1,5 @@
-import text from "./drr_summary_text.yaml";
 import { create_text_maker_component } from "../shared.js";
+
+import text from "./drr_summary_text.yaml";
 
 export const { text_maker, TM } = create_text_maker_component(text);

--- a/client/src/panels/panel_declarations/results/gov_dp.js
+++ b/client/src/panels/panel_declarations/results/gov_dp.js
@@ -1,7 +1,9 @@
-import text from "./gov_dp.yaml";
-
 import { Fragment } from "react";
 
+import {
+  default_dept_name_sort_func,
+  SmartDisplayTable,
+} from "../../../components";
 import {
   Subject,
   create_text_maker_component,
@@ -10,6 +12,8 @@ import {
   declare_panel,
   HeightClippedGraph,
 } from "../shared.js";
+
+import { LateDepartmentsBanner } from "./result_components.js";
 import {
   ResultCounts,
   filter_and_genericize_doc_counts,
@@ -17,11 +21,8 @@ import {
   result_docs,
   link_to_results_infograph,
 } from "./results_common.js";
-import { LateDepartmentsBanner } from "./result_components.js";
-import {
-  SmartDisplayTable,
-  default_dept_name_sort_func,
-} from "../../../components";
+
+import text from "./gov_dp.yaml";
 
 const { Dept } = Subject;
 const { text_maker, TM } = create_text_maker_component(text);

--- a/client/src/panels/panel_declarations/results/gov_drr.js
+++ b/client/src/panels/panel_declarations/results/gov_drr.js
@@ -1,4 +1,7 @@
-import { TM, text_maker } from "./drr_summary_text.js";
+import {
+  SmartDisplayTable,
+  default_dept_name_sort_func,
+} from "../../../components/index.js";
 import {
   Subject,
   InfographicPanel,
@@ -6,6 +9,10 @@ import {
   declare_panel,
   HeightClippedGraph,
 } from "../shared.js";
+
+import { DrrSummary } from "./drr_summary.js";
+import { TM, text_maker } from "./drr_summary_text.js";
+import { LateDepartmentsBanner } from "./result_components.js";
 import {
   row_to_drr_status_counts,
   ResultCounts,
@@ -14,12 +21,6 @@ import {
   current_drr_key,
   link_to_results_infograph,
 } from "./results_common.js";
-import { DrrSummary } from "./drr_summary.js";
-import { LateDepartmentsBanner } from "./result_components.js";
-import {
-  SmartDisplayTable,
-  default_dept_name_sort_func,
-} from "../../../components/index.js";
 
 const { Gov, Dept } = Subject;
 

--- a/client/src/panels/panel_declarations/results/result_components.js
+++ b/client/src/panels/panel_declarations/results/result_components.js
@@ -1,9 +1,15 @@
-import "./result_components.scss";
-import { TM, text_maker } from "./result_text_provider.js";
-
 import { Fragment } from "react";
 
+import {
+  IconCheck,
+  IconAttention,
+  IconNotApplicable,
+  IconClock,
+} from "../../../icons/icons.js";
 import { util_components, general_utils } from "../shared.js";
+
+import { TM, text_maker } from "./result_text_provider.js";
+
 import {
   status_key_to_glossary_key,
   ordered_status_keys,
@@ -14,12 +20,8 @@ import {
   result_docs,
   result_color_scale,
 } from "./results_common.js";
-import {
-  IconCheck,
-  IconAttention,
-  IconNotApplicable,
-  IconClock,
-} from "../../../icons/icons.js";
+
+import "./result_components.scss";
 
 const {
   indicator_target_text,

--- a/client/src/panels/panel_declarations/results/result_drilldown/result_displays.js
+++ b/client/src/panels/panel_declarations/results/result_drilldown/result_displays.js
@@ -1,10 +1,10 @@
 import { createSelector } from "reselect";
 
-import { TM, text_maker } from "../result_text_provider.js";
-import { IndicatorList } from "../result_components.js";
 
 import { infograph_href_template } from "../../../../link_utils.js";
 import { Indicator, result_docs } from "../../../../models/results.js";
+import { IndicatorList } from "../result_components.js";
+import { TM, text_maker } from "../result_text_provider.js";
 
 const type_text_keys = {
   dept: "orgs",

--- a/client/src/panels/panel_declarations/results/result_drilldown/result_drilldown.js
+++ b/client/src/panels/panel_declarations/results/result_drilldown/result_drilldown.js
@@ -8,13 +8,13 @@ import {
 
 const { SpinnerWrapper } = util_components;
 
+import { text_maker } from "../result_text_provider.js";
 import {
   ResultCounts,
   GranularResultCounts,
   result_docs,
   result_docs_in_tabling_order,
 } from "../results_common.js";
-import { text_maker } from "../result_text_provider.js";
 
 import ResultsExplorer from "./results_scheme.js";
 

--- a/client/src/panels/panel_declarations/results/result_drilldown/result_drilldown_display.js
+++ b/client/src/panels/panel_declarations/results/result_drilldown/result_drilldown_display.js
@@ -9,16 +9,13 @@ import {
   TextAbbrev,
 } from "src/components";
 
-import { infograph_href_template } from "src/infographic/infographic_link.js";
-
 import { Explorer } from "src/explorer_common/explorer_components.js";
 import { get_root } from "src/explorer_common/hierarchy_tools.js";
+import { infograph_href_template } from "src/infographic/infographic_link.js";
 
-import "./result_drilldown.scss";
-
-import { Indicator, result_docs } from "../results_common.js";
 import { StatusIconTable, InlineStatusIconList } from "../result_components.js";
 import { TM, text_maker } from "../result_text_provider.js";
+import { Indicator, result_docs } from "../results_common.js";
 
 import {
   get_type_name,
@@ -27,6 +24,7 @@ import {
   fte_header,
   ResultCounts as ResultCountsComponent,
 } from "./result_displays.js";
+import "./result_drilldown.scss";
 
 const get_non_col_content_func = createSelector(_.property("doc"), (doc) => {
   return ({ node }) => {

--- a/client/src/panels/panel_declarations/results/result_drilldown/result_hierarchies.js
+++ b/client/src/panels/panel_declarations/results/result_drilldown/result_hierarchies.js
@@ -2,9 +2,9 @@ import {
   filter_hierarchy,
   convert_d3_hierarchy_to_explorer_hierarchy,
 } from "../../../../explorer_common/hierarchy_tools.js";
+import { Subject, Results } from "../../shared.js";
 import { results_resource_fragment } from "../results_common.js";
 
-import { Subject, Results } from "../../shared.js";
 
 const { Dept } = Subject;
 const { Result } = Results;

--- a/client/src/panels/panel_declarations/results/result_drilldown/results_scheme.js
+++ b/client/src/panels/panel_declarations/results/result_drilldown/results_scheme.js
@@ -2,15 +2,15 @@ import { createSelector } from "reselect";
 
 import { ensure_loaded } from "src/core/lazy_loader.js";
 
-import { Subject } from "src/models/subject";
-import { Indicator } from "src/models/results";
 
-import { filter_hierarchy } from "src/explorer_common/hierarchy_tools.js";
 import { AbstractExplorerScheme } from "src/explorer_common/abstract_explorer_scheme";
+import { filter_hierarchy } from "src/explorer_common/hierarchy_tools.js";
 import { cached_property, bound } from "src/general_utils.js";
+import { Indicator } from "src/models/results";
+import { Subject } from "src/models/subject";
 
-import { create_full_results_hierarchy } from "./result_hierarchies.js";
 import ResultsExplorerDisplay from "./result_drilldown_display";
+import { create_full_results_hierarchy } from "./result_hierarchies.js";
 
 export default class ResultsExplorer extends AbstractExplorerScheme {
   Component = ResultsExplorerDisplay;

--- a/client/src/panels/panel_declarations/results/result_flat_table.js
+++ b/client/src/panels/panel_declarations/results/result_flat_table.js
@@ -1,7 +1,5 @@
-import "./result_flat_table.scss";
-
 import { Fragment } from "react";
-import { TM, text_maker } from "./result_text_provider.js";
+
 import { businessConstants } from "../../../models/businessConstants.js";
 import {
   util_components,
@@ -13,6 +11,21 @@ import {
   declare_panel,
   HeightClippedGraph,
 } from "../shared.js";
+
+import { StatusIconTable, large_status_icons } from "./result_components.js";
+
+import { create_full_results_hierarchy } from "./result_drilldown/result_hierarchies.js";
+import { TM, text_maker } from "./result_text_provider.js";
+import {
+  ResultCounts,
+  GranularResultCounts,
+  result_docs,
+  result_statuses,
+  indicator_text_functions,
+} from "./results_common.js";
+
+import "./result_flat_table.scss";
+
 const {
   SpinnerWrapper,
   SmartDisplayTable,
@@ -22,20 +35,10 @@ const {
 const { current_drr_key } = Results;
 const { months } = businessConstants;
 
-import { StatusIconTable, large_status_icons } from "./result_components.js";
-import {
-  ResultCounts,
-  GranularResultCounts,
-  result_docs,
-  result_statuses,
-  indicator_text_functions,
-} from "./results_common.js";
 const {
   indicator_target_text,
   indicator_actual_text,
 } = indicator_text_functions;
-
-import { create_full_results_hierarchy } from "./result_drilldown/result_hierarchies.js";
 
 const current_drr_year = result_docs[current_drr_key].year;
 

--- a/client/src/panels/panel_declarations/results/result_text_provider.js
+++ b/client/src/panels/panel_declarations/results/result_text_provider.js
@@ -1,7 +1,9 @@
+import { create_text_maker_component } from "../shared.js";
+
 import drilldown_text from "./result_drilldown/result_drilldown.yaml";
+
 import component_text from "./result_components.yaml";
 import result_table_text from "./result_table_text.yaml";
-import { create_text_maker_component } from "../shared.js";
 
 export const { text_maker, TM } = create_text_maker_component([
   drilldown_text,

--- a/client/src/panels/panel_declarations/results/results_common.js
+++ b/client/src/panels/panel_declarations/results/results_common.js
@@ -1,4 +1,4 @@
-import { text_maker } from "./result_text_provider.js";
+import { get_resources_for_subject } from "../../../explorer_common/resource_explorer_common.js";
 import {
   Results,
   infograph_href_template,
@@ -7,7 +7,8 @@ import {
   newIBCategoryColors,
 } from "../shared.js";
 
-import { get_resources_for_subject } from "../../../explorer_common/resource_explorer_common.js";
+import { text_maker } from "./result_text_provider.js";
+
 
 const {
   Result,

--- a/client/src/panels/panel_declarations/results/results_intro.js
+++ b/client/src/panels/panel_declarations/results/results_intro.js
@@ -1,3 +1,4 @@
+import { get_static_url } from "../../../request_utils.js";
 import {
   Subject,
   declare_panel,
@@ -5,11 +6,7 @@ import {
   get_source_links,
   create_text_maker_component,
 } from "../shared.js";
-const { Dept } = Subject;
 
-import { get_static_url } from "../../../request_utils.js";
-
-import text from "./results_intro_text.yaml";
 import {
   ResultCounts,
   GranularResultCounts,
@@ -17,6 +14,10 @@ import {
   current_drr_key,
   current_dp_key,
 } from "./results_common.js";
+
+import text from "./results_intro_text.yaml";
+
+const { Dept } = Subject;
 
 const { text_maker, TM } = create_text_maker_component(text);
 

--- a/client/src/panels/panel_declarations/shared.js
+++ b/client/src/panels/panel_declarations/shared.js
@@ -1,41 +1,12 @@
 import "./shared.scss";
 
-import {
-  InfographicPanel,
-  StdPanel,
-  TextPanel,
-  Col,
-} from "./InfographicPanel.js";
-
-import { formats, formatter } from "../../core/format.js";
-import { PanelRegistry, layout_types } from "../PanelRegistry.js";
-import {
-  newIBCategoryColors,
-  newIBLightCategoryColors,
-  newIBDarkCategoryColors,
-} from "../../core/color_schemes.js";
-import { breakpoints } from "../../core/breakpoint_defs.js";
-import { Table } from "../../core/TableClass.js";
-import { Statistics } from "../../core/Statistics.js";
-import { ensure_loaded } from "../../core/lazy_loader.js";
-
-import * as Results from "../../models/results.js";
-import {
-  create_text_maker,
-  trivial_text_maker,
-  run_template,
-} from "../../models/text.js";
-import { Subject } from "../../models/subject";
-import {
-  year_templates,
-  actual_to_planned_gap_year,
-} from "../../models/years.js";
-import { businessConstants } from "../../models/businessConstants.js";
-import FootNote from "../../models/footnotes/footnotes.js";
-import { GlossaryEntry } from "../../models/glossary.js";
+import { Fragment } from "react";
 
 import { A11yTable } from "../../charts/A11yTable.js";
+import { Canada } from "../../charts/canada/index.js";
+import { FlatTreeMapViz } from "../../charts/flat_treemap/FlatTreeMapViz.js";
 import { StandardLegend, SelectAllControl } from "../../charts/legends";
+import { get_formatter, infobase_colors_smart } from "../../charts/shared.js";
 import {
   WrappedNivoBar,
   WrappedNivoHBar,
@@ -44,19 +15,51 @@ import {
   CircleProportionChart,
   NivoLineBarToggle,
 } from "../../charts/wrapped_nivo/index.js";
-import { get_formatter, infobase_colors_smart } from "../../charts/shared.js";
-import { Canada } from "../../charts/canada/index.js";
-import { FlatTreeMapViz } from "../../charts/flat_treemap/FlatTreeMapViz.js";
+import * as util_components from "../../components/index.js";
+import { breakpoints } from "../../core/breakpoint_defs.js";
+import {
+  newIBCategoryColors,
+  newIBLightCategoryColors,
+  newIBDarkCategoryColors,
+} from "../../core/color_schemes.js";
+import { formats, formatter } from "../../core/format.js";
+
+
+import { ensure_loaded } from "../../core/lazy_loader.js";
+import { Statistics } from "../../core/Statistics.js";
+import { Table } from "../../core/TableClass.js";
+
+import * as general_utils from "../../general_utils.js";
+import { infograph_href_template } from "../../infographic/infographic_link.js";
+import { glossary_href } from "../../link_utils.js";
+import { get_source_links } from "../../metadata/data_sources.js";
+import { businessConstants } from "../../models/businessConstants.js";
+import FootNote from "../../models/footnotes/footnotes.js";
+import { GlossaryEntry } from "../../models/glossary.js";
+import * as Results from "../../models/results.js";
+import { Subject } from "../../models/subject";
+import {
+  create_text_maker,
+  trivial_text_maker,
+  run_template,
+} from "../../models/text.js";
+import {
+  year_templates,
+  actual_to_planned_gap_year,
+} from "../../models/years.js";
+
 
 import { rpb_link, get_appropriate_rpb_subject } from "../../rpb/rpb_link.js";
-import { infograph_href_template } from "../../infographic/infographic_link.js";
-import { get_source_links } from "../../metadata/data_sources.js";
-import { glossary_href } from "../../link_utils.js";
-import * as general_utils from "../../general_utils.js";
-import * as util_components from "../../components/index.js";
 import * as table_common from "../../tables/table_common.js";
+import { PanelRegistry, layout_types } from "../PanelRegistry.js";
 
-import { Fragment } from "react";
+import {
+  InfographicPanel,
+  StdPanel,
+  TextPanel,
+  Col,
+} from "./InfographicPanel.js";
+
 
 const {
   Format,

--- a/client/src/panels/panel_routes/IndicatorPanel.js
+++ b/client/src/panels/panel_routes/IndicatorPanel.js
@@ -1,14 +1,14 @@
 import gql from "graphql-tag";
 
-import { get_client } from "../../graphql_utils/graphql_utils.js";
+import { Panel, SpinnerWrapper } from "../../components/index.js";
 import { log_standard_event } from "../../core/analytics.js";
 import { StandardRouteContainer } from "../../core/NavComponents.js";
+import { get_client } from "../../graphql_utils/graphql_utils.js";
 
-import { Panel, SpinnerWrapper } from "../../components/index.js";
 
+import { infograph_href_template } from "../../link_utils.js";
 import { Indicator } from "../../models/results.js";
 import { Subject } from "../../models/subject";
-import { infograph_href_template } from "../../link_utils.js";
 
 import { IndicatorDisplay } from "../panel_declarations/results/result_components.js";
 import {

--- a/client/src/panels/panel_routes/IsolatedPanel.js
+++ b/client/src/panels/panel_routes/IsolatedPanel.js
@@ -1,13 +1,14 @@
-import text from "./IsolatedPanel.yaml";
 
-import { PanelRenderer } from "../PanelRenderer.js";
-import { get_panels_for_subject } from "../get_panels_for_subject/index.js";
 
 import { SpinnerWrapper } from "../../components/index.js";
+import { ensure_loaded } from "../../core/lazy_loader";
+import { StandardRouteContainer } from "../../core/NavComponents.js";
 import { Subject } from "../../models/subject";
 import { create_text_maker } from "../../models/text.js";
-import { StandardRouteContainer } from "../../core/NavComponents.js";
-import { ensure_loaded } from "../../core/lazy_loader";
+import { get_panels_for_subject } from "../get_panels_for_subject/index.js";
+import { PanelRenderer } from "../PanelRenderer.js";
+
+import text from "./IsolatedPanel.yaml";
 
 const text_maker = create_text_maker(text);
 

--- a/client/src/panels/panel_routes/PanelInventory.js
+++ b/client/src/panels/panel_routes/PanelInventory.js
@@ -1,18 +1,19 @@
-import { createSelector } from "reselect";
 import { Link } from "react-router-dom";
+import { createSelector } from "reselect";
 
-import panel_text from "./PanelInventory.yaml";
 
-import { get_panels_for_subject } from "../get_panels_for_subject/index.js";
-import { PanelRenderer } from "../PanelRenderer.js";
-import { PanelRegistry } from "../PanelRegistry.js";
-
-import { StandardRouteContainer } from "../../core/NavComponents.js";
-import { create_text_maker } from "../../models/text.js";
-
-import { Subject } from "../../models/subject.js";
 import { EverythingSearch, SpinnerWrapper } from "../../components/index.js";
 import { ensure_loaded } from "../../core/lazy_loader.js";
+import { StandardRouteContainer } from "../../core/NavComponents.js";
+import { Subject } from "../../models/subject.js";
+import { create_text_maker } from "../../models/text.js";
+import { get_panels_for_subject } from "../get_panels_for_subject/index.js";
+import { PanelRegistry } from "../PanelRegistry.js";
+import { PanelRenderer } from "../PanelRenderer.js";
+
+
+
+import panel_text from "./PanelInventory.yaml";
 
 const tm = create_text_maker(panel_text);
 

--- a/client/src/partition/budget_measures_subapp/BudgetMeasuresA11yContent.js
+++ b/client/src/partition/budget_measures_subapp/BudgetMeasuresA11yContent.js
@@ -1,10 +1,14 @@
 import { Fragment } from "react";
+
 import { formats } from "../../core/format.js";
+
+import { sanitized_dangerous_inner_html } from "../../general_utils.js";
+import { businessConstants } from "../../models/businessConstants.js";
+
+import { Subject } from "../../models/subject";
+
 import { text_maker, TextMaker } from "./budget_measure_text_provider.js";
 import { budget_measures_hierarchy_factory } from "./budget_measures_hierarchy_factory.js";
-import { businessConstants } from "../../models/businessConstants.js";
-import { Subject } from "../../models/subject";
-import { sanitized_dangerous_inner_html } from "../../general_utils.js";
 
 const { budget_values } = businessConstants;
 const { BudgetMeasure } = Subject;

--- a/client/src/partition/budget_measures_subapp/BudgetMeasuresControls.js
+++ b/client/src/partition/budget_measures_subapp/BudgetMeasuresControls.js
@@ -1,6 +1,3 @@
-import "./BudgetMeasuresControls.scss";
-
-import { text_maker, TextMaker } from "./budget_measure_text_provider.js";
 import {
   LabeledBox,
   RadioButtons,
@@ -8,6 +5,9 @@ import {
 } from "../../components/index.js";
 
 import { businessConstants } from "../../models/businessConstants.js";
+
+import { text_maker, TextMaker } from "./budget_measure_text_provider.js";
+import "./BudgetMeasuresControls.scss";
 
 const { budget_values } = businessConstants;
 

--- a/client/src/partition/budget_measures_subapp/BudgetMeasuresFooter.js
+++ b/client/src/partition/budget_measures_subapp/BudgetMeasuresFooter.js
@@ -1,10 +1,9 @@
-import "./BudgetMeasuresFooter.scss";
-
-import { TextMaker } from "./budget_measure_text_provider.js";
-
 import { LabeledBox, FancyUL } from "../../components/index.js";
 
 import { sources } from "../../metadata/data_sources.js";
+
+import { TextMaker } from "./budget_measure_text_provider.js";
+import "./BudgetMeasuresFooter.scss";
 
 const { BUDGET: budget_source } = sources;
 

--- a/client/src/partition/budget_measures_subapp/BudgetMeasuresPartition.js
+++ b/client/src/partition/budget_measures_subapp/BudgetMeasuresPartition.js
@@ -1,14 +1,15 @@
-import "./BudgetMeasuresPartition.scss";
-import { PartitionDiagram } from "../partition_diagram/PartitionDiagram.js";
-import { text_maker } from "./budget_measure_text_provider.js";
-import { budget_measures_hierarchy_factory } from "./budget_measures_hierarchy_factory.js";
 import { ContainerEscapeHatch } from "../../components/index.js";
-import { Subject } from "../../models/subject";
-import { businessConstants } from "../../models/businessConstants.js";
+import * as color_defs from "../../core/color_defs.js";
+import { newIBLightCategoryColors } from "../../core/color_schemes.js";
 import { formats } from "../../core/format.js";
 import { sanitized_marked } from "../../general_utils.js";
-import { newIBLightCategoryColors } from "../../core/color_schemes.js";
-import * as color_defs from "../../core/color_defs.js";
+import { businessConstants } from "../../models/businessConstants.js";
+import { Subject } from "../../models/subject";
+import { PartitionDiagram } from "../partition_diagram/PartitionDiagram.js";
+
+import { text_maker } from "./budget_measure_text_provider.js";
+import { budget_measures_hierarchy_factory } from "./budget_measures_hierarchy_factory.js";
+import "./BudgetMeasuresPartition.scss";
 
 const { budget_chapters } = businessConstants;
 const { BudgetMeasure, CRSO } = Subject;

--- a/client/src/partition/budget_measures_subapp/BudgetMeasuresRoute.js
+++ b/client/src/partition/budget_measures_subapp/BudgetMeasuresRoute.js
@@ -1,24 +1,25 @@
 import "./BudgetMeasuresRoute.yaml";
-import "./BudgetMeasuresRoute.scss";
 import { Fragment } from "react";
-import { Subject } from "../../models/subject";
-import { businessConstants } from "../../models/businessConstants.js";
-import { ensure_loaded } from "../../core/lazy_loader.js";
-import { StandardRouteContainer } from "../../core/NavComponents.js";
+
 import {
   SpinnerWrapper,
   Details,
   TabbedControls,
 } from "../../components/index.js";
+import { ensure_loaded } from "../../core/lazy_loader.js";
+import { StandardRouteContainer } from "../../core/NavComponents.js";
+import { businessConstants } from "../../models/businessConstants.js";
+import { Subject } from "../../models/subject";
 
 import { text_maker, TextMaker } from "./budget_measure_text_provider.js";
 
+import { BudgetMeasuresA11yContent } from "./BudgetMeasuresA11yContent.js";
+import { BudgetMeasuresControls } from "./BudgetMeasuresControls.js";
+import { BudgetMeasuresFooter } from "./BudgetMeasuresFooter.js";
+import { BudgetMeasuresPartition } from "./BudgetMeasuresPartition.js";
 import { calculate_budget_stats } from "./calculate_budget_stats.js";
 
-import { BudgetMeasuresControls } from "./BudgetMeasuresControls.js";
-import { BudgetMeasuresPartition } from "./BudgetMeasuresPartition.js";
-import { BudgetMeasuresFooter } from "./BudgetMeasuresFooter.js";
-import { BudgetMeasuresA11yContent } from "./BudgetMeasuresA11yContent.js";
+import "./BudgetMeasuresRoute.scss";
 
 const { BudgetMeasure } = Subject;
 const {

--- a/client/src/partition/budget_measures_subapp/budget_measure_text_provider.js
+++ b/client/src/partition/budget_measures_subapp/budget_measure_text_provider.js
@@ -1,10 +1,12 @@
-import budget_measure_text from "./BudgetMeasuresPartition.yaml";
-import route_text from "./BudgetMeasuresRoute.yaml";
-import controls_text from "./BudgetMeasuresControls.yaml";
-import a11y_text from "./BudgetMeasuresA11yContent.yaml";
-import partition_text from "../partition_diagram/PartitionDiagram.yaml";
 import { TextMaker as StandardTextMaker } from "../../components/index.js";
 import { create_text_maker } from "../../models/text.js";
+import partition_text from "../partition_diagram/PartitionDiagram.yaml";
+
+import a11y_text from "./BudgetMeasuresA11yContent.yaml";
+import controls_text from "./BudgetMeasuresControls.yaml";
+import budget_measure_text from "./BudgetMeasuresPartition.yaml";
+import route_text from "./BudgetMeasuresRoute.yaml";
+
 
 export const text_maker = create_text_maker([
   budget_measure_text,

--- a/client/src/partition/budget_measures_subapp/budget_measures_hierarchy_factory.js
+++ b/client/src/partition/budget_measures_subapp/budget_measures_hierarchy_factory.js
@@ -1,7 +1,8 @@
-import { text_maker } from "./budget_measure_text_provider.js";
-import { Subject } from "../../models/subject.js";
-import { GlossaryEntry } from "../../models/glossary.js";
 import { businessConstants } from "../../models/businessConstants.js";
+import { GlossaryEntry } from "../../models/glossary.js";
+import { Subject } from "../../models/subject.js";
+
+import { text_maker } from "./budget_measure_text_provider.js";
 
 const { budget_values } = businessConstants;
 

--- a/client/src/partition/budget_measures_subapp/calculate_budget_stats.js
+++ b/client/src/partition/budget_measures_subapp/calculate_budget_stats.js
@@ -1,5 +1,5 @@
-import { Subject } from "../../models/subject";
 import { businessConstants } from "../../models/businessConstants.js";
+import { Subject } from "../../models/subject";
 
 const { BudgetMeasure } = Subject;
 

--- a/client/src/partition/partition_diagram/PartitionDiagram.js
+++ b/client/src/partition/partition_diagram/PartitionDiagram.js
@@ -1,8 +1,10 @@
-import diagram_text from "./PartitionDiagram.yaml";
-import "./PartitionDiagram.scss";
-import { PartitionDataWrapper } from "./PartitionDataWrapper.js";
 import * as general_utils from "../../general_utils";
 import { create_text_maker } from "../../models/text.js";
+
+import { PartitionDataWrapper } from "./PartitionDataWrapper.js";
+
+import diagram_text from "./PartitionDiagram.yaml";
+import "./PartitionDiagram.scss";
 
 const text_maker = create_text_maker(diagram_text);
 

--- a/client/src/partition/partition_subapp/PartitionNotes.js
+++ b/client/src/partition/partition_subapp/PartitionNotes.js
@@ -1,4 +1,5 @@
 import { AutoAccordion } from "../../components/index.js";
+
 import { text_maker } from "./partition_text_provider.js";
 
 export class PartitionNotes extends React.Component {

--- a/client/src/partition/partition_subapp/PartitionRoute.js
+++ b/client/src/partition/partition_subapp/PartitionRoute.js
@@ -1,16 +1,19 @@
+import {
+  SpinnerWrapper,
+  ContainerEscapeHatch,
+} from "../../components/index.js";
+import { ensure_loaded } from "../../core/lazy_loader.js";
+
+import { StandardRouteContainer } from "../../core/NavComponents.js";
+
+import { text_maker } from "./partition_text_provider.js";
 import { PartitionSubApp } from "./PartitionSubApp.js";
 import {
   get_all_perspectives,
   all_data_types,
   remapped_data_types,
 } from "./perspectives/index.js";
-import { ensure_loaded } from "../../core/lazy_loader.js";
-import { StandardRouteContainer } from "../../core/NavComponents.js";
-import {
-  SpinnerWrapper,
-  ContainerEscapeHatch,
-} from "../../components/index.js";
-import { text_maker } from "./partition_text_provider.js";
+
 
 export default class PartitionRoute extends React.Component {
   constructor() {

--- a/client/src/partition/partition_subapp/PartitionSubApp.js
+++ b/client/src/partition/partition_subapp/PartitionSubApp.js
@@ -1,11 +1,12 @@
-import "./PartitionSubApp.scss";
-import { text_maker } from "./partition_text_provider.js";
-import { PartitionNotes } from "./PartitionNotes.js";
-import { PartitionDiagram } from "../partition_diagram/PartitionDiagram.js";
-import { reactAdapter } from "../../core/reactAdapter";
-import { get_static_url } from "../../request_utils.js";
 import { primaryColor } from "../../core/color_defs.js";
 import { newIBDarkCategoryColors } from "../../core/color_schemes.js";
+import { reactAdapter } from "../../core/reactAdapter";
+import { get_static_url } from "../../request_utils.js";
+import { PartitionDiagram } from "../partition_diagram/PartitionDiagram.js";
+
+import { text_maker } from "./partition_text_provider.js";
+import { PartitionNotes } from "./PartitionNotes.js";
+import "./PartitionSubApp.scss";
 
 export class PartitionSubApp {
   constructor(

--- a/client/src/partition/partition_subapp/partition_text_provider.js
+++ b/client/src/partition/partition_subapp/partition_text_provider.js
@@ -1,7 +1,9 @@
-import partition_text from "./PartitionSubApp.yaml";
-import perspective_text from "./perspectives/perspective_content.yaml";
-import diagram_text from "../partition_diagram/PartitionDiagram.yaml";
 import { create_text_maker } from "../../models/text.js";
+import diagram_text from "../partition_diagram/PartitionDiagram.yaml";
+
+import perspective_text from "./perspectives/perspective_content.yaml";
+
+import partition_text from "./PartitionSubApp.yaml";
 
 export const text_maker = create_text_maker([
   partition_text,

--- a/client/src/partition/partition_subapp/perspectives/data_hierarchy_utils.js
+++ b/client/src/partition/partition_subapp/perspectives/data_hierarchy_utils.js
@@ -1,5 +1,5 @@
-import { GlossaryEntry } from "../../../models/glossary";
 import { Table } from "../../../core/TableClass.js";
+import { GlossaryEntry } from "../../../models/glossary";
 
 const absolute_value_sort = (a, b) => -(Math.abs(a.value) - Math.abs(b.value));
 const alphabetic_name_sort = (a, b) =>

--- a/client/src/partition/partition_subapp/perspectives/dept_perspectives.js
+++ b/client/src/partition/partition_subapp/perspectives/dept_perspectives.js
@@ -1,12 +1,13 @@
 import { Subject } from "../../../models/subject.js";
 import { text_maker } from "../partition_text_provider.js";
-import { PartitionPerspective } from "./PartitionPerspective.js";
 
 import {
   absolute_value_sort,
   post_traversal_value_set,
   post_traversal_search_string_set,
 } from "./data_hierarchy_utils.js";
+import { PartitionPerspective } from "./PartitionPerspective.js";
+
 
 import {
   get_common_popup_options,

--- a/client/src/partition/partition_subapp/perspectives/estimates_perspectives.js
+++ b/client/src/partition/partition_subapp/perspectives/estimates_perspectives.js
@@ -1,16 +1,18 @@
-import { Subject } from "../../../models/subject";
-import { Table } from "../../../core/TableClass.js";
-import { text_maker } from "../partition_text_provider.js";
 import { TextMaker as StandardTextMaker } from "../../../components/index.js";
+import { Table } from "../../../core/TableClass.js";
 import { rpb_link } from "../../../link_utils.js";
-import { PartitionPerspective } from "./PartitionPerspective.js";
+import { Subject } from "../../../models/subject";
+
+
 import { run_template } from "../../../models/text.js";
+import { text_maker } from "../partition_text_provider.js";
 
 import {
   absolute_value_sort,
   get_glossary_entry,
   post_traversal_search_string_set,
 } from "./data_hierarchy_utils.js";
+import { PartitionPerspective } from "./PartitionPerspective.js";
 
 import {
   get_common_popup_options,

--- a/client/src/partition/partition_subapp/perspectives/index.js
+++ b/client/src/partition/partition_subapp/perspectives/index.js
@@ -3,18 +3,6 @@ import {
   make_dept_fte_perspective,
 } from "./dept_perspectives.js";
 import {
-  make_goco_exp_perspective,
-  make_goco_fte_perspective,
-  //make_hwh_exp_perspective,
-  //make_hwh_fte_perspective,
-} from "./tag_perspectives.js";
-import { make_spend_type_perspective } from "./spend_type_perspective.js";
-import {
-  make_org_info_ministry_perspective,
-  make_org_info_federal_perspective,
-  make_org_info_interests_perspective,
-} from "./org_info_perspectives.js";
-import {
   make_estimates_est_type_perspective,
   make_estimates_est_doc_sea_perspective,
   make_estimates_est_doc_seb_perspective,
@@ -24,8 +12,20 @@ import {
   make_estimates_org_estimates_perspective,
   //make_estimates_est_doc_im_perspective,
 } from "./estimates_perspectives.js";
+import {
+  make_org_info_ministry_perspective,
+  make_org_info_federal_perspective,
+  make_org_info_interests_perspective,
+} from "./org_info_perspectives.js";
 
 import { data_types, remapped_data_types } from "./perspective_utils.js";
+import { make_spend_type_perspective } from "./spend_type_perspective.js";
+import {
+  make_goco_exp_perspective,
+  make_goco_fte_perspective,
+  //make_hwh_exp_perspective,
+  //make_hwh_fte_perspective,
+} from "./tag_perspectives.js";
 
 const all_data_types = data_types;
 

--- a/client/src/partition/partition_subapp/perspectives/org_info_perspectives.js
+++ b/client/src/partition/partition_subapp/perspectives/org_info_perspectives.js
@@ -1,8 +1,5 @@
-import { text_maker } from "../partition_text_provider.js";
-import { PartitionPerspective } from "./PartitionPerspective.js";
 import { Subject } from "../../../models/subject.js";
-
-const { InstForm } = Subject;
+import { text_maker } from "../partition_text_provider.js";
 
 import {
   absolute_value_sort,
@@ -10,12 +7,15 @@ import {
   get_glossary_entry,
   post_traversal_search_string_set,
 } from "./data_hierarchy_utils";
+import { PartitionPerspective } from "./PartitionPerspective.js";
 
 import {
   get_common_popup_options,
   wrap_in_brackets,
   formats_by_data_type,
 } from "./perspective_utils.js";
+
+const { InstForm } = Subject;
 
 const glossary_entry_from_inst_form_type_id = (type_id) => {
   const type_id_to_glossary_suffix_map = {

--- a/client/src/partition/partition_subapp/perspectives/perspective_utils.js
+++ b/client/src/partition/partition_subapp/perspectives/perspective_utils.js
@@ -1,6 +1,6 @@
-import { text_maker } from "../partition_text_provider.js";
-import { run_template } from "../../../models/text.js";
 import { formats } from "../../../core/format.js";
+import { run_template } from "../../../models/text.js";
+import { text_maker } from "../partition_text_provider.js";
 
 const get_common_popup_options = (d) => {
   return {

--- a/client/src/partition/partition_subapp/perspectives/spend_type_perspective.js
+++ b/client/src/partition/partition_subapp/perspectives/spend_type_perspective.js
@@ -1,23 +1,24 @@
-import { Subject } from "../../../models/subject.js";
-import { text_maker } from "../partition_text_provider.js";
 import { TextMaker as StandardTextMaker } from "../../../components/index.js";
 import { Table } from "../../../core/TableClass.js";
-import { PartitionPerspective } from "./PartitionPerspective.js";
-import { businessConstants } from "../../../models/businessConstants";
 
-const { sos } = businessConstants;
+import { businessConstants } from "../../../models/businessConstants";
+import { Subject } from "../../../models/subject.js";
+import { text_maker } from "../partition_text_provider.js";
 
 import {
   absolute_value_sort,
   get_glossary_entry,
   post_traversal_search_string_set,
 } from "./data_hierarchy_utils.js";
+import { PartitionPerspective } from "./PartitionPerspective.js";
 
 import {
   get_common_popup_options,
   wrap_in_brackets,
   formats_by_data_type,
 } from "./perspective_utils.js";
+
+const { sos } = businessConstants;
 
 const TextMaker = (props) => (
   <StandardTextMaker text_maker_func={text_maker} {...props} />

--- a/client/src/partition/partition_subapp/perspectives/tag_perspectives.js
+++ b/client/src/partition/partition_subapp/perspectives/tag_perspectives.js
@@ -1,14 +1,15 @@
-import { Subject } from "../../../models/subject.js";
-import { text_maker } from "../partition_text_provider.js";
 import { TM, KeyConceptList } from "../../../components/index.js";
 import { Table } from "../../../core/TableClass.js";
-import { PartitionPerspective } from "./PartitionPerspective.js";
+import { Subject } from "../../../models/subject.js";
+import { text_maker } from "../partition_text_provider.js";
 
 import {
   absolute_value_sort,
   post_traversal_value_set,
   post_traversal_search_string_set,
 } from "./data_hierarchy_utils.js";
+import { PartitionPerspective } from "./PartitionPerspective.js";
+
 
 import {
   get_common_popup_options,

--- a/client/src/rpb/TablePicker.js
+++ b/client/src/rpb/TablePicker.js
@@ -1,18 +1,20 @@
-import "./TablePicker.scss";
 import "../components/LabeledBox.scss";
+import classNames from "classnames";
+import { Fragment } from "react";
+
+import { TransitionGroup, CSSTransition } from "react-transition-group";
+
+import { AlertBanner, GlossaryIcon } from "../components";
 import { Table } from "../core/TableClass.js";
 import { GlossaryEntry } from "../models/glossary.js";
-import { Fragment } from "react";
-import { TransitionGroup, CSSTransition } from "react-transition-group";
-import classNames from "classnames";
-import { AlertBanner, GlossaryIcon } from "../components";
 
+import { TextMaker } from "./rpb_text_provider.js";
 import {
   categories,
   concepts_by_category,
   concept_filter,
 } from "./table_picker_concept_filter.js";
-import { TextMaker } from "./rpb_text_provider.js";
+import "./TablePicker.scss";
 
 const BrokenLinkBanner = () => (
   <AlertBanner banner_class={"warning"}>

--- a/client/src/rpb/granular_view.js
+++ b/client/src/rpb/granular_view.js
@@ -1,5 +1,3 @@
-import { TextMaker, text_maker } from "./rpb_text_provider.js";
-import { ReportDetails, ReportDatasets } from "./shared.js";
 import {
   LabeledBox,
   AlertBanner,
@@ -7,7 +5,11 @@ import {
   Details,
   DropdownMenu,
 } from "../components/index.js";
+
 import { Subject } from "../models/subject.js";
+
+import { TextMaker, text_maker } from "./rpb_text_provider.js";
+import { ReportDetails, ReportDatasets } from "./shared.js";
 
 const { Dept } = Subject;
 

--- a/client/src/rpb/index.js
+++ b/client/src/rpb/index.js
@@ -1,31 +1,33 @@
+import { Fragment } from "react";
+
+//data and state stuff
+
+//re-usable view stuff
+import AriaModal from "react-aria-modal";
+import { withRouter } from "react-router";
+
+import { SpinnerWrapper, LabeledBox } from "../components/index.js";
+import { log_standard_event } from "../core/analytics.js";
+import { ensure_loaded } from "../core/lazy_loader.js";
 import {
   StandardRouteContainer,
   LangSynchronizer,
 } from "../core/NavComponents";
-import { withRouter } from "react-router";
-import { log_standard_event } from "../core/analytics.js";
-import { Fragment } from "react";
-import { TextMaker, text_maker } from "./rpb_text_provider.js";
-import "./rpb.scss";
-
-//data and state stuff
-import { ensure_loaded } from "../core/lazy_loader.js";
-
-//re-usable view stuff
-import { SpinnerWrapper, LabeledBox } from "../components/index.js";
-import AriaModal from "react-aria-modal";
 
 //specific view stuff
-import { AccessibleTablePicker, TablePicker } from "./TablePicker.js";
-import { GranularView } from "./granular_view.js";
-import { ShareReport } from "./shared.js";
 import { Table } from "../core/TableClass.js";
-import { Subject } from "../models/subject.js";
-import Footnote from "../models/footnotes/footnotes.js";
 
 //misc app stuff
-import { rpb_link } from "./rpb_link.js";
 import { SafeJSURL } from "../general_utils.js";
+import Footnote from "../models/footnotes/footnotes.js";
+import { Subject } from "../models/subject.js";
+
+import { GranularView } from "./granular_view.js";
+import { rpb_link } from "./rpb_link.js";
+import { TextMaker, text_maker } from "./rpb_text_provider.js";
+import { ShareReport } from "./shared.js";
+import { AccessibleTablePicker, TablePicker } from "./TablePicker.js";
+import "./rpb.scss";
 
 const sub_app_name = "_rpb";
 

--- a/client/src/rpb/rpb_link.js
+++ b/client/src/rpb/rpb_link.js
@@ -1,5 +1,5 @@
-import { Subject } from "../models/subject.js";
 import { SafeJSURL } from "../general_utils.js";
+import { Subject } from "../models/subject.js";
 
 const rpb_link = (naive_state, first_character = "#") =>
   _.chain(naive_state)

--- a/client/src/rpb/rpb_text_provider.js
+++ b/client/src/rpb/rpb_text_provider.js
@@ -1,9 +1,10 @@
-import rpb_text from "./rpb.yaml";
-import footnote_topic_text from "../models/footnotes/footnote_topics.yaml";
 import {
   create_text_maker_component,
   TextMaker as StandardTextMaker,
 } from "../components/index.js";
+import footnote_topic_text from "../models/footnotes/footnote_topics.yaml";
+
+import rpb_text from "./rpb.yaml";
 
 export const { text_maker, TM } = create_text_maker_component([
   rpb_text,

--- a/client/src/rpb/shared.js
+++ b/client/src/rpb/shared.js
@@ -1,5 +1,3 @@
-import { TextMaker } from "./rpb_text_provider.js";
-import { sources as all_sources } from "../metadata/data_sources.js";
 import {
   FancyUL,
   ShareButton,
@@ -7,6 +5,9 @@ import {
   FootnoteList,
 } from "../components/index.js";
 import { IconCopyLink } from "../icons/icons.js";
+import { sources as all_sources } from "../metadata/data_sources.js";
+
+import { TextMaker } from "./rpb_text_provider.js";
 
 const ReportDetails = ({
   table,

--- a/client/src/search/AdvancedSearch.js
+++ b/client/src/search/AdvancedSearch.js
@@ -1,12 +1,12 @@
-import "./AdvancedSearch.scss";
-import text from "./AdvancedSearch.yaml";
+import { CheckBox } from "../components/CheckBox";
+import { Details } from "../components/Details.js";
+
+import { create_text_maker } from "../models/text.js";
 
 import { EverythingSearch } from "./EverythingSearch.js";
 
-import { Details } from "../components/Details.js";
-import { CheckBox } from "../components/CheckBox";
-
-import { create_text_maker } from "../models/text.js";
+import text from "./AdvancedSearch.yaml";
+import "./AdvancedSearch.scss";
 const text_maker = create_text_maker(text);
 
 // Maintenance alert: this will need to be kept in sync with the search config options available on the EverythingSearch

--- a/client/src/search/BaseTypeahead.js
+++ b/client/src/search/BaseTypeahead.js
@@ -5,14 +5,15 @@ import "./BaseTypeahead.scss";
 
 import { Typeahead, Menu, MenuItem } from "react-bootstrap-typeahead";
 
+import { TM } from "../components/TextMaker.js";
 import { log_standard_event } from "../core/analytics.js";
+import { create_text_maker } from "../models/text.js";
 import { get_static_url } from "../request_utils.js";
 
-import text from "./BaseTypeahead.yaml";
-import { create_text_maker } from "../models/text.js";
-import { TM } from "../components/TextMaker.js";
-
 import { InfoBaseHighlighter } from "./search_utils.js";
+
+import text from "./BaseTypeahead.yaml";
+
 
 const text_maker = create_text_maker(text);
 const TextMaker = (props) => <TM tmf={text_maker} {...props} />;

--- a/client/src/search/EverythingSearch.js
+++ b/client/src/search/EverythingSearch.js
@@ -1,5 +1,7 @@
 import { withRouter } from "react-router";
 
+import { trivial_text_maker } from "../models/text.js";
+
 import { BaseTypeahead } from "./BaseTypeahead.js";
 import {
   make_orgs_search_config,
@@ -13,7 +15,6 @@ import {
   glossary_lite as glossary_lite_search_config,
 } from "./search_configs.js";
 
-import { trivial_text_maker } from "../models/text.js";
 
 const get_tag_search_configs = (
   include_tags_goco,

--- a/client/src/search/GlossarySearch.js
+++ b/client/src/search/GlossarySearch.js
@@ -1,9 +1,10 @@
 import { withRouter } from "react-router";
 
+import { glossary_href } from "../link_utils.js";
+
 import { BaseTypeahead } from "./BaseTypeahead.js";
 import { glossary as glossary_search_config } from "./search_configs.js";
 
-import { glossary_href } from "../link_utils.js";
 
 const glossary_placeholder = {
   en: "Search for a term used in the InfoBase",

--- a/client/src/tables/orgEmployeeAgeGroup.js
+++ b/client/src/tables/orgEmployeeAgeGroup.js
@@ -1,5 +1,3 @@
-import text from "./orgEmployeeAgeGroup.yaml";
-
 import {
   stats,
   trivial_text_maker,
@@ -9,6 +7,9 @@ import {
   businessConstants,
   year_templates,
 } from "./table_common";
+
+import text from "./orgEmployeeAgeGroup.yaml";
+
 
 const { formats } = format;
 const { age_groups, compact_age_groups, emp_age_map } = businessConstants;

--- a/client/src/tables/orgEmployeeAvgAge.js
+++ b/client/src/tables/orgEmployeeAvgAge.js
@@ -1,11 +1,12 @@
-import text from "./orgEmployeeAvgAge.yaml";
-
 import {
   trivial_text_maker,
   m,
   Statistics,
   year_templates,
 } from "./table_common";
+
+import text from "./orgEmployeeAvgAge.yaml";
+
 
 const { people_years, people_years_short_second } = year_templates;
 

--- a/client/src/tables/orgEmployeeExLvl.js
+++ b/client/src/tables/orgEmployeeExLvl.js
@@ -1,5 +1,3 @@
-import text from "./orgEmployeeExLvl.yaml";
-
 import {
   stats,
   trivial_text_maker,
@@ -8,6 +6,9 @@ import {
   businessConstants,
   year_templates,
 } from "./table_common";
+
+import text from "./orgEmployeeExLvl.yaml";
+
 
 const { compact_ex_level_map, ex_levels } = businessConstants;
 const { people_years, people_years_short_second } = year_templates;

--- a/client/src/tables/orgEmployeeFol.js
+++ b/client/src/tables/orgEmployeeFol.js
@@ -1,5 +1,3 @@
-import text from "./orgEmployeeFol.yaml";
-
 import {
   stats,
   trivial_text_maker,
@@ -8,6 +6,9 @@ import {
   businessConstants,
   year_templates,
 } from "./table_common";
+
+import text from "./orgEmployeeFol.yaml";
+
 
 const { fol } = businessConstants;
 const { people_years, people_years_short_second } = year_templates;

--- a/client/src/tables/orgEmployeeGender.js
+++ b/client/src/tables/orgEmployeeGender.js
@@ -1,5 +1,3 @@
-import text from "./orgEmployeeGender.yaml";
-
 import {
   stats,
   trivial_text_maker,
@@ -8,6 +6,9 @@ import {
   businessConstants,
   year_templates,
 } from "./table_common";
+
+import text from "./orgEmployeeGender.yaml";
+
 
 const { gender } = businessConstants;
 const { people_years, people_years_short_second } = year_templates;

--- a/client/src/tables/orgEmployeeRegion.js
+++ b/client/src/tables/orgEmployeeRegion.js
@@ -1,5 +1,3 @@
-import text from "./orgEmployeeRegion.yaml";
-
 import {
   stats,
   trivial_text_maker,
@@ -9,6 +7,9 @@ import {
   businessConstants,
   year_templates,
 } from "./table_common";
+
+import text from "./orgEmployeeRegion.yaml";
+
 
 const { formats } = format;
 const { provinces } = businessConstants;

--- a/client/src/tables/orgEmployeeType.js
+++ b/client/src/tables/orgEmployeeType.js
@@ -1,5 +1,3 @@
-import text from "./orgEmployeeType.yaml";
-
 import {
   stats,
   trivial_text_maker,
@@ -8,6 +6,9 @@ import {
   businessConstants,
   year_templates,
 } from "./table_common";
+
+import text from "./orgEmployeeType.yaml";
+
 
 const { tenure } = businessConstants;
 const { people_years, people_years_short_second } = year_templates;

--- a/client/src/tables/orgSobjs.js
+++ b/client/src/tables/orgSobjs.js
@@ -1,8 +1,3 @@
-import text from "./orgSobjs.yaml";
-
-// see [here](../table_definition.html) for description
-// of the table spec
-
 import {
   stats,
   trivial_text_maker,
@@ -11,6 +6,12 @@ import {
   businessConstants,
   year_templates,
 } from "./table_common";
+
+import text from "./orgSobjs.yaml";
+
+// see [here](../table_definition.html) for description
+// of the table spec
+
 
 const { sos } = businessConstants;
 const { std_years } = year_templates;

--- a/client/src/tables/orgSobjsQfr.js
+++ b/client/src/tables/orgSobjsQfr.js
@@ -1,9 +1,10 @@
-import text from "./orgSobjsQfr.yaml";
 import { businessConstants } from "../models/businessConstants";
 
-const { sos } = businessConstants;
-
 import { trivial_text_maker } from "../models/text";
+
+import text from "./orgSobjsQfr.yaml";
+
+const { sos } = businessConstants;
 
 export default {
   text,

--- a/client/src/tables/orgTransferPayments.js
+++ b/client/src/tables/orgTransferPayments.js
@@ -1,7 +1,5 @@
 // see [here](../table_definition.html) for description
 // of the table spec
-import text from "./orgTransferPayments.yaml";
-
 import {
   stats,
   trivial_text_maker,
@@ -9,6 +7,9 @@ import {
   year_templates,
   businessConstants,
 } from "./table_common";
+
+import text from "./orgTransferPayments.yaml";
+
 
 const { std_years } = year_templates;
 const { transfer_payments } = businessConstants;

--- a/client/src/tables/orgTransferPaymentsRegion.js
+++ b/client/src/tables/orgTransferPaymentsRegion.js
@@ -1,5 +1,6 @@
-import text from "./orgTransferPaymentsRegion.yaml";
 import { businessConstants, year_templates } from "./table_common.js";
+
+import text from "./orgTransferPaymentsRegion.yaml";
 
 const { provinces } = businessConstants;
 const { std_years } = year_templates;

--- a/client/src/tables/orgVoteStatEstimates.js
+++ b/client/src/tables/orgVoteStatEstimates.js
@@ -1,8 +1,8 @@
 // see [here](../table_definition.html) for description
 // of the table spec
 
-import text from "./orgVoteStatEstimates.yaml";
 import * as FORMAT from "../core/format";
+
 import {
   vote_stat_dimension,
   trivial_text_maker,
@@ -11,6 +11,8 @@ import {
   year_templates,
   businessConstants,
 } from "./table_common";
+
+import text from "./orgVoteStatEstimates.yaml";
 const { estimates_years } = year_templates;
 const est_cols = _.map(estimates_years, (yr) => yr + "_estimates");
 const in_year_col = est_cols[4];

--- a/client/src/tables/orgVoteStatPa.js
+++ b/client/src/tables/orgVoteStatPa.js
@@ -1,6 +1,6 @@
 // see [here](../table_definition.html) for description
 // of the table spec
-import text from "./orgVoteStatPa.yaml";
+import { trivial_text_maker } from "../models/text.js";
 
 import {
   stats,
@@ -10,7 +10,9 @@ import {
   Statistics,
   year_templates,
 } from "./table_common";
-import { trivial_text_maker } from "../models/text.js";
+
+import text from "./orgVoteStatPa.yaml";
+
 
 const { std_years } = year_templates;
 const voted_label = trivial_text_maker("voted");

--- a/client/src/tables/orgVoteStatQfr.js
+++ b/client/src/tables/orgVoteStatQfr.js
@@ -1,10 +1,12 @@
-import text from "./orgVoteStatQfr.yaml";
 
-import { vote_stat_dimension, major_vote_stat } from "./table_common";
 
 import * as FORMAT from "../core/format";
 
 import { trivial_text_maker } from "../models/text";
+
+import { vote_stat_dimension, major_vote_stat } from "./table_common";
+
+import text from "./orgVoteStatQfr.yaml";
 
 export default {
   text,

--- a/client/src/tables/programFtes.js
+++ b/client/src/tables/programFtes.js
@@ -1,9 +1,3 @@
-import text from "./programFtes.yaml";
-
-// see [here](../table_definition.html) for description
-// of the table spec
-//
-
 import {
   stats,
   Subject,
@@ -12,6 +6,13 @@ import {
   Statistics,
   year_templates,
 } from "./table_common";
+
+import text from "./programFtes.yaml";
+
+// see [here](../table_definition.html) for description
+// of the table spec
+//
+
 
 const { std_years, planning_years } = year_templates;
 const { Program, Gov } = Subject;

--- a/client/src/tables/programSobjs.js
+++ b/client/src/tables/programSobjs.js
@@ -1,9 +1,7 @@
 //require("../../panels/spend_by_so_hist"); //we arent showing this stuff.
 
-import text from "./programSobjs.yaml";
+import { Subject } from "../models/subject";
 
-// see [here](../table_definition.html) for description
-// of the table spec
 import {
   trivial_text_maker,
   run_template,
@@ -14,7 +12,11 @@ import {
   collapse_by_so,
   is_non_revenue,
 } from "./table_common";
-import { Subject } from "../models/subject";
+
+import text from "./programSobjs.yaml";
+
+// see [here](../table_definition.html) for description
+// of the table spec
 
 const { Program } = Subject;
 const { sos } = businessConstants;

--- a/client/src/tables/programSpending.js
+++ b/client/src/tables/programSpending.js
@@ -1,9 +1,3 @@
-import text from "./programSpending.yaml";
-
-// see [here](../table_definition.html) for description
-// of the table spec
-//const {spending_areas} = require('../../models/goco.js');
-
 import {
   stats,
   Subject,
@@ -11,6 +5,13 @@ import {
   Statistics,
   year_templates,
 } from "./table_common";
+
+import text from "./programSpending.yaml";
+
+// see [here](../table_definition.html) for description
+// of the table spec
+//const {spending_areas} = require('../../models/goco.js');
+
 
 const { Program, Gov, Dept } = Subject;
 const { std_years, planning_years } = year_templates;

--- a/client/src/tables/programVoteStat.js
+++ b/client/src/tables/programVoteStat.js
@@ -1,7 +1,3 @@
-import text from "./programVoteStat.yaml";
-
-// see [here](../table_definition.html) for description
-// of the table spec
 import {
   Subject,
   trivial_text_maker,
@@ -9,6 +5,11 @@ import {
   Statistics,
   year_templates,
 } from "./table_common";
+
+import text from "./programVoteStat.yaml";
+
+// see [here](../table_definition.html) for description
+// of the table spec
 
 const { Program } = Subject;
 

--- a/client/src/tables/table_common.js
+++ b/client/src/tables/table_common.js
@@ -1,10 +1,10 @@
-import { stats } from "../core/tables/stats.js";
-import { year_templates } from "../models/years.js";
-import { Subject } from "../models/subject";
-import { Statistics } from "../core/Statistics.js";
 import * as format from "../core/format";
+import { Statistics } from "../core/Statistics.js";
+import { stats } from "../core/tables/stats.js";
 import { businessConstants } from "../models/businessConstants.js";
+import { Subject } from "../models/subject";
 import { trivial_text_maker, run_template } from "../models/text.js";
+import { year_templates } from "../models/years.js";
 
 const m = run_template;
 const text_maker = trivial_text_maker;

--- a/package-lock.json
+++ b/package-lock.json
@@ -648,6 +648,15 @@
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
+    "eslint-import-resolver-node": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.4.tgz",
+      "integrity": "sha512-ogtf+5AB/O+nM6DIeBUNr2fuT7ot9Qg/1harBfBtaP13ekEWFQEEMP94BCB7zaNW3gyY+8SHYF00rnqYwXKWOA==",
+      "requires": {
+        "debug": "^2.6.9",
+        "resolve": "^1.13.1"
+      }
+    },
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
@@ -1582,6 +1591,11 @@
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
       "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
     },
+    "path-parse": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
+    },
     "path-to-regexp": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
@@ -1844,6 +1858,14 @@
         "tough-cookie": "~2.5.0",
         "tunnel-agent": "^0.6.0",
         "uuid": "^3.3.2"
+      }
+    },
+    "resolve": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
+      "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+      "requires": {
+        "path-parse": "^1.0.6"
       }
     },
     "restore-cursor": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "license": "MIT",
   "dependencies": {
     "@lhci/server": "^0.4.4",
+    "eslint-import-resolver-node": "^0.3.4",
     "pg": "^7.12.1",
     "pg-hstore": "^2.3.3"
   },


### PR DESCRIPTION
Added an eslint-plugin to get notified of undefined imports:

![Screen Shot 2020-09-02 at 8 28 18 AM](https://user-images.githubusercontent.com/7769215/91984639-3eee3880-ecfa-11ea-9bab-2bb2c31f9f12.png)

The rule also warns about duplicate imports (two different lines from the same module), so I fixed those.

I tried to get this working in the server, but didn't succeed. We can revisit, it's not nearly as useful for a much smaller project. 