### PR TITLE
Minor a11y and displaytable

### DIFF
--- a/client/src/components/CheckBox.js
+++ b/client/src/components/CheckBox.js
@@ -4,11 +4,12 @@ import { IconCheckmark } from "../icons/icons.js";
 import "./CheckBox.scss";
 
 export class CheckBox extends React.Component {
-  handleOnClick = (onClick, disabled, id) => {
+  handleOnClick() {
+    const { disabled, onClick, id } = this.props;
     if (!disabled && onClick) {
       onClick(id);
     }
-  };
+  }
   render() {
     const {
       id,
@@ -31,7 +32,7 @@ export class CheckBox extends React.Component {
             <input
               type="checkbox"
               checked={active}
-              onChange={this.handleOnClick.bind(this, onClick, disabled, id)}
+              onChange={this.handleOnClick}
               style={{ marginRight: 5 }}
             />
             {label}
@@ -56,7 +57,7 @@ export class CheckBox extends React.Component {
               ...checkbox_style,
             }}
             className={classNames("checkbox-span", onClick && "span-hover")}
-            onClick={this.handleOnClick.bind(this, onClick, disabled, id)}
+            onClick={this.handleOnClick}
           >
             {!isSolidBox && (
               <IconCheckmark
@@ -74,7 +75,7 @@ export class CheckBox extends React.Component {
               aria-checked={active}
               tabIndex={0}
               className="link-styled"
-              onClick={this.handleOnClick.bind(this, onClick, disabled, id)}
+              onClick={this.handleOnClick}
               onKeyDown={(e) =>
                 (e.keyCode === 13 || e.keyCode === 32) &&
                 !disabled &&

--- a/client/src/components/CheckBox.js
+++ b/client/src/components/CheckBox.js
@@ -4,12 +4,12 @@ import { IconCheckmark } from "../icons/icons.js";
 import "./CheckBox.scss";
 
 export class CheckBox extends React.Component {
-  handleOnClick() {
+  handleOnClick = () => {
     const { disabled, onClick, id } = this.props;
     if (!disabled && onClick) {
       onClick(id);
     }
-  }
+  };
   render() {
     const {
       id,

--- a/client/src/components/CheckBox.js
+++ b/client/src/components/CheckBox.js
@@ -26,7 +26,7 @@ export class CheckBox extends React.Component {
             <input
               type="checkbox"
               checked={active}
-              onChange={onClick}
+              onChange={() => !disabled && onClick && onClick(id)}
               style={{ marginRight: 5 }}
             />
             {label}

--- a/client/src/components/CheckBox.js
+++ b/client/src/components/CheckBox.js
@@ -4,6 +4,11 @@ import { IconCheckmark } from "../icons/icons.js";
 import "./CheckBox.scss";
 
 export class CheckBox extends React.Component {
+  handleOnClick = (onClick, disabled, id) => {
+    if (!disabled && onClick) {
+      onClick(id);
+    }
+  };
   render() {
     const {
       id,
@@ -26,7 +31,7 @@ export class CheckBox extends React.Component {
             <input
               type="checkbox"
               checked={active}
-              onChange={() => !disabled && onClick && onClick(id)}
+              onChange={this.handleOnClick.bind(this, onClick, disabled, id)}
               style={{ marginRight: 5 }}
             />
             {label}
@@ -51,7 +56,7 @@ export class CheckBox extends React.Component {
               ...checkbox_style,
             }}
             className={classNames("checkbox-span", onClick && "span-hover")}
-            onClick={() => !disabled && onClick && onClick(id)}
+            onClick={this.handleOnClick.bind(this, onClick, disabled, id)}
           >
             {!isSolidBox && (
               <IconCheckmark
@@ -69,7 +74,7 @@ export class CheckBox extends React.Component {
               aria-checked={active}
               tabIndex={0}
               className="link-styled"
-              onClick={() => onClick(id)}
+              onClick={this.handleOnClick.bind(this, onClick, disabled, id)}
               onKeyDown={(e) =>
                 (e.keyCode === 13 || e.keyCode === 32) &&
                 !disabled &&

--- a/client/src/components/DisplayTable/DisplayTable.js
+++ b/client/src/components/DisplayTable/DisplayTable.js
@@ -300,57 +300,59 @@ export class DisplayTable extends React.Component {
                 </th>
               ))}
             </tr>
-            <tr className="table-header">
-              {_.map(visible_ordered_col_keys, (column_key) => {
-                const sortable =
-                  col_configs_with_defaults[column_key].is_sortable;
-                const searchable =
-                  col_configs_with_defaults[column_key].is_searchable;
+            {_.some(col_configs_with_defaults, "is_sortable") && (
+              <tr className="table-header">
+                {_.map(visible_ordered_col_keys, (column_key) => {
+                  const sortable =
+                    col_configs_with_defaults[column_key].is_sortable;
+                  const searchable =
+                    col_configs_with_defaults[column_key].is_searchable;
 
-                const current_search_input =
-                  (searchable && searches[column_key]) || null;
+                  const current_search_input =
+                    (searchable && searches[column_key]) || null;
 
-                return (
-                  <th key={column_key} style={{ textAlign: "center" }}>
-                    {sortable && (
-                      <div
-                        onClick={() =>
-                          this.setState({
-                            sort_by: column_key,
-                            descending:
-                              this.state.sort_by === column_key
-                                ? !this.state.descending
-                                : true,
-                          })
-                        }
-                      >
-                        <SortDirections
-                          asc={!descending && sort_by === column_key}
-                          desc={descending && sort_by === column_key}
+                  return (
+                    <th key={column_key} style={{ textAlign: "center" }}>
+                      {sortable && (
+                        <div
+                          onClick={() =>
+                            this.setState({
+                              sort_by: column_key,
+                              descending:
+                                this.state.sort_by === column_key
+                                  ? !this.state.descending
+                                  : true,
+                            })
+                          }
+                        >
+                          <SortDirections
+                            asc={!descending && sort_by === column_key}
+                            desc={descending && sort_by === column_key}
+                          />
+                        </div>
+                      )}
+                      {searchable && (
+                        <DebouncedTextInput
+                          inputClassName={"search input-sm"}
+                          placeHolder={text_maker("filter_data")}
+                          defaultValue={current_search_input}
+                          updateCallback={(search_value) => {
+                            const updated_searches = _.mapValues(
+                              searches,
+                              (value, key) =>
+                                key === column_key ? search_value : value
+                            );
+
+                            this.setState({ searches: updated_searches });
+                          }}
+                          debounceTime={300}
                         />
-                      </div>
-                    )}
-                    {searchable && (
-                      <DebouncedTextInput
-                        inputClassName={"search input-sm"}
-                        placeHolder={text_maker("filter_data")}
-                        defaultValue={current_search_input}
-                        updateCallback={(search_value) => {
-                          const updated_searches = _.mapValues(
-                            searches,
-                            (value, key) =>
-                              key === column_key ? search_value : value
-                          );
-
-                          this.setState({ searches: updated_searches });
-                        }}
-                        debounceTime={300}
-                      />
-                    )}
-                  </th>
-                );
-              })}
-            </tr>
+                      )}
+                    </th>
+                  );
+                })}
+              </tr>
+            )}
           </thead>
           {_.isEmpty(sorted_filtered_data) ? (
             <NoDataMessage />

--- a/client/src/components/Panel.js
+++ b/client/src/components/Panel.js
@@ -8,7 +8,7 @@ import { create_text_maker_component } from "./misc_util_components.js";
 import text from "./Panel.yaml";
 import "./Panel.scss";
 
-const { TM } = create_text_maker_component(text);
+const { text_maker, TM } = create_text_maker_component(text);
 
 const PanelSource = ({ links }) => {
   if (_.isEmpty(links)) {
@@ -91,6 +91,11 @@ export class Panel extends React.Component {
                 className={classNames("panel-heading-utils")}
                 onClick={() => this.setState({ isOpen: !isOpen })}
                 aria-labelledby={label_id}
+                aria-label={
+                  isOpen
+                    ? text_maker("collapse_panel")
+                    : text_maker("expand_panel")
+                }
               >
                 <span aria-hidden>{isOpen ? "▼" : "►"}</span>
               </button>

--- a/client/src/components/Panel.yaml
+++ b/client/src/components/Panel.yaml
@@ -15,7 +15,7 @@ panel_glossary_text:
     Définitions supplémentaires :
 collapse_panel:
   en: Collapse this panel
-  fr: TODO
+  fr: Fermer ce graphique
 expand_panel:
   en: Expand this panel
-  fr: TODO
+  fr: Ouvrir ce graphique

--- a/client/src/components/Panel.yaml
+++ b/client/src/components/Panel.yaml
@@ -13,3 +13,9 @@ panel_glossary_text:
     Additional terms:
   fr: |
     Définitions supplémentaires :
+collapse_panel:
+  en: Collapse this panel
+  fr: TODO
+expand_panel:
+  en: Expand this panel
+  fr: TODO


### PR DESCRIPTION
closes #782 and comments from Alex on Slack
```
I can’t seem to toggle columns on display-tables, the checkbox widget just doesn’t check stuff. It’s not even a screen-reader thing, you can’t check it with a mouse click
https://dev.ea-ad.ca/a11y_table_to_displaytable/index-basic-eng.html#orgs/gov/gov/infograph/financial/.-.-(panel_key.-.-'auth_exp_planned_spending)

Hmm so the heading of a display-table are spread accross two rows
the titles
the sort buttons
It can be weird to have a blank row is when there are no sort buttons. Can we just exclude the sort row in that case?
```