### PR TITLE
React-responsive update for MediaQuery

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -9554,9 +9554,9 @@
       "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw=="
     },
     "hyphenate-style-name": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.2.tgz",
-      "integrity": "sha1-MRYKNpMK2vH8BMYHT360FGXU7Es="
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.4.tgz",
+      "integrity": "sha512-ygGZLjmXfPHj+ZWh6LwbC37l43MhfztxetbFCoYTM2VjkIUpeHgSNn7QIyVFj7YQ1Wl9Cbw5sholVJPzWvC2MQ=="
     },
     "iconv-lite": {
       "version": "0.4.19",
@@ -10894,9 +10894,9 @@
       }
     },
     "matchmediaquery": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/matchmediaquery/-/matchmediaquery-0.2.1.tgz",
-      "integrity": "sha1-IjxwBXk94D5HzpKxMoWnLEStos8=",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/matchmediaquery/-/matchmediaquery-0.3.1.tgz",
+      "integrity": "sha512-Hlk20WQHRIm9EE9luN1kjRjYXAQToHOIAHPJn9buxBwuhfTHoKUcX+lXBbxc85DVQfXYbEQ4HcwQdd128E3qHQ==",
       "requires": {
         "css-mediaquery": "^0.1.2"
       }
@@ -14325,13 +14325,13 @@
       }
     },
     "react-responsive": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/react-responsive/-/react-responsive-1.3.4.tgz",
-      "integrity": "sha512-I2MvP3DvrKKVWWvciaxGcKvDoTlsE9zI/kPSOBrSiCo+6UvCVzPNJY0siMc676Eld1E67aLXb1UpiVQLxd6J3Q==",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/react-responsive/-/react-responsive-6.1.2.tgz",
+      "integrity": "sha512-AXentVC/kN3KED9zhzJv2pu4vZ0i6cSHdTtbCScVV1MT6F5KXaG2qs5D7WLmhdaOvmiMX8UfmS4ZSO+WPwDt4g==",
       "requires": {
         "hyphenate-style-name": "^1.0.0",
-        "matchmediaquery": "^0.2.1",
-        "prop-types": "^15.5.7"
+        "matchmediaquery": "^0.3.0",
+        "prop-types": "^15.6.1"
       }
     },
     "react-router": {

--- a/client/package.json
+++ b/client/package.json
@@ -99,7 +99,7 @@
     "react-dom": "^16.7.0",
     "react-flip-move": "^2.10.2",
     "react-redux": "^6",
-    "react-responsive": "^1.3.4",
+    "react-responsive": "^6.1.2",
     "react-router": "^5",
     "react-router-dom": "^5",
     "react-share": "^3.0.0",

--- a/client/src/charts/wrapped_nivo/CircleProportionChart.js
+++ b/client/src/charts/wrapped_nivo/CircleProportionChart.js
@@ -149,18 +149,15 @@ export class CircleProportionChart extends React.Component {
         TooltipContentComponent={({ tooltip_item }) => (
           <Fragment>
             <MediaQuery minDeviceWidth={breakpoints.minSmallDevice}>
-              <Fragment>
-                {/* MediaQuery jank, it will insert a div wrapping its children when it has mutliple of them, need a manual Fragment to avoid that */}
-                <td className="nivo-tooltip__label">{tooltip_item.name}</td>
-                <td className="nivo-tooltip__value">
-                  {value_formatter(tooltip_item.value)}
-                </td>
-                <td className="nivo-tooltip__value">
-                  {`(${formats.smart_percentage1_raw(
-                    tooltip_item.value / parent_value
-                  )})`}
-                </td>
-              </Fragment>
+              <td className="nivo-tooltip__label">{tooltip_item.name}</td>
+              <td className="nivo-tooltip__value">
+                {value_formatter(tooltip_item.value)}
+              </td>
+              <td className="nivo-tooltip__value">
+                {`(${formats.smart_percentage1_raw(
+                  tooltip_item.value / parent_value
+                )})`}
+              </td>
             </MediaQuery>
             <MediaQuery maxDeviceWidth={breakpoints.maxSmallDevice}>
               <td>

--- a/client/src/charts/wrapped_nivo/wrapped_nivo_common.js
+++ b/client/src/charts/wrapped_nivo/wrapped_nivo_common.js
@@ -82,18 +82,15 @@ const DefaultTooltip = ({ tooltip_items, formatter }) => (
     TooltipContentComponent={({ tooltip_item }) => (
       <Fragment>
         <MediaQuery minDeviceWidth={breakpoints.minSmallDevice}>
-          <Fragment>
-            {/* MediaQuery jank, it will insert a div wrapping its children when it has mutliple of them, need a manual Fragment to avoid that */}
-            <td className="nivo-tooltip__label">
-              {tooltip_item.name || tooltip_item.id}
-            </td>
-            <td
-              className="nivo-tooltip__value"
-              dangerouslySetInnerHTML={{
-                __html: formatter(tooltip_item.value),
-              }}
-            />
-          </Fragment>
+          <td className="nivo-tooltip__label">
+            {tooltip_item.name || tooltip_item.id}
+          </td>
+          <td
+            className="nivo-tooltip__value"
+            dangerouslySetInnerHTML={{
+              __html: formatter(tooltip_item.value),
+            }}
+          />
         </MediaQuery>
         <MediaQuery maxDeviceWidth={breakpoints.maxSmallDevice}>
           <td>
@@ -119,30 +116,25 @@ const DefaultPercentTooltip = ({ tooltip_items, formatter, total }) => (
     TooltipContentComponent={({ tooltip_item }) => (
       <Fragment>
         <MediaQuery minDeviceWidth={breakpoints.minSmallDevice}>
-          <Fragment>
-            {/* MediaQuery jank, it will insert a div wrapping its children when it has mutliple of them, need a manual Fragment to avoid that */}
-            <td className="nivo-tooltip__label">
-              {
-                /* TODO: standardize our chart APIs on either label or name. 
+          <td className="nivo-tooltip__label">
+            {
+              /* TODO: standardize our chart APIs on either label or name. 
                   Resolve whatever dumb issue meant the full plain language name needed to be used as the id sometimes... */
-                tooltip_item.name || tooltip_item.label || tooltip_item.id
-              }
-            </td>
-            <td
-              className="nivo-tooltip__value"
-              dangerouslySetInnerHTML={{
-                __html: formatter(tooltip_item.value),
-              }}
-            />
-            <td
-              className="nivo-tooltip__value"
-              dangerouslySetInnerHTML={{
-                __html: formats.percentage1(
-                  Math.abs(tooltip_item.value) / total
-                ),
-              }}
-            />
-          </Fragment>
+              tooltip_item.name || tooltip_item.label || tooltip_item.id
+            }
+          </td>
+          <td
+            className="nivo-tooltip__value"
+            dangerouslySetInnerHTML={{
+              __html: formatter(tooltip_item.value),
+            }}
+          />
+          <td
+            className="nivo-tooltip__value"
+            dangerouslySetInnerHTML={{
+              __html: formats.percentage1(Math.abs(tooltip_item.value) / total),
+            }}
+          />
         </MediaQuery>
         <MediaQuery maxDeviceWidth={breakpoints.maxSmallDevice}>
           <td>


### PR DESCRIPTION
closes #589 

Updated to 6.1.2 (not the latest version) - probably need to update react to get latest to work

but now multiple descendants of MediaQuery no longer produces a div