### PR TITLE
A11y reviews

### DIFF
--- a/client/src/EstimatesComparison/EstimatesExplorerComponent.js
+++ b/client/src/EstimatesComparison/EstimatesExplorerComponent.js
@@ -1,6 +1,5 @@
 import classNames from "classnames";
 
-
 import {
   SpinnerWrapper,
   FootnoteList,
@@ -16,7 +15,6 @@ import { Explorer } from "src/explorer_common/explorer_components.js";
 import { get_root } from "src/explorer_common/hierarchy_tools.js";
 import { infograph_href_template, rpb_link } from "src/link_utils.js";
 import { sources } from "src/metadata/data_sources.js";
-
 
 import { businessConstants } from "../models/businessConstants.js";
 
@@ -44,13 +42,13 @@ const DetailedAmountsByDoc = ({ amounts_by_doc }) => {
         <table className="table table-condensed">
           <thead>
             <tr>
-              <th scope="column">
+              <th scope="col">
                 <TM k="estimates_doc" />
               </th>
-              <th scope="column">
+              <th scope="col">
                 <TM k="last_year_authorities" />
               </th>
-              <th scope="column">
+              <th scope="col">
                 <TM k="this_year_authorities" />
               </th>
             </tr>

--- a/client/src/TextDiff/TextDiff.js
+++ b/client/src/TextDiff/TextDiff.js
@@ -230,7 +230,6 @@ const difference_report = (diff, key) => {
           </span>
           {window.is_a11y_mode && part.added && (
             <span className="text-diff__text-part--added">
-              {" "}
               [{text_maker("a11y_end_added")}]
             </span>
           )}
@@ -557,7 +556,7 @@ export default class TextDiffApp extends React.Component {
         </div>
         <div style={{ padding: "0px 0px 20px 0px" }}>
           <div className="medium_panel_text">
-            <label htmlFor="select_program">
+            <label htmlFor="filter_by_status">
               <TM k="filter_by_status" />
             </label>
             <LegendList

--- a/client/src/charts/graphRegistry.js
+++ b/client/src/charts/graphRegistry.js
@@ -76,10 +76,7 @@ class GraphRegistry {
 
     instance.options = options;
 
-    container
-      .attr("aria-hidden", "true")
-      .append("div")
-      .classed("__svg__", true);
+    container.append("div").classed("__svg__", true);
 
     if (options.alternative_svg) {
       container.select(".__svg__").html(options.alternative_svg);

--- a/client/src/charts/legends/SelectAllControl.js
+++ b/client/src/charts/legends/SelectAllControl.js
@@ -1,15 +1,8 @@
 import { TrivialTM } from "../../components/index.js";
 
 export const SelectAllControl = ({ SelectAllOnClick, SelectNoneOnClick }) => (
-  <div
-    role="group"
-    aria-label={"SelectAllControlGroup"}
-    style={{ display: "flex", flexDirection: "row" }}
-  >
-    <div
-      id={_.uniqueId("SelectAllControl_SelectText")}
-      style={{ lineHeight: 2 }}
-    >
+  <div role="group" style={{ display: "flex", flexDirection: "row" }}>
+    <div style={{ lineHeight: 2 }}>
       <TrivialTM k="select" />:
     </div>
     <button

--- a/client/src/charts/legends/SelectAllControl.js
+++ b/client/src/charts/legends/SelectAllControl.js
@@ -3,10 +3,13 @@ import { TrivialTM } from "../../components/index.js";
 export const SelectAllControl = ({ SelectAllOnClick, SelectNoneOnClick }) => (
   <div
     role="group"
-    aria-labelledby={"SelectAllControlGroup"}
+    aria-label={"SelectAllControlGroup"}
     style={{ display: "flex", flexDirection: "row" }}
   >
-    <div id={"SelectAllControl"} style={{ lineHeight: 2 }}>
+    <div
+      id={_.uniqueId("SelectAllControl_SelectText")}
+      style={{ lineHeight: 2 }}
+    >
       <TrivialTM k="select" />:
     </div>
     <button

--- a/client/src/charts/shared.js
+++ b/client/src/charts/shared.js
@@ -23,13 +23,19 @@ export const get_formatter = (
         if (full) {
           return (value) => formats.dollar_raw(value);
         } else {
-          return (value) => formats.compact2_raw(value);
+          return (value) =>
+            window.is_a11y_mode
+              ? formats.compact2_written_raw(value)
+              : formats.compact2_raw(value);
         }
       } else {
         if (full) {
           return (value) => formats.dollar(value);
         } else {
-          return (value) => formats.compact2(value);
+          return (value) =>
+            window.is_a11y_mode
+              ? formats.compact2_written_raw
+              : formats.compact2(value);
         }
       }
     }

--- a/client/src/charts/wrapped_nivo/CircleProportionChart.js
+++ b/client/src/charts/wrapped_nivo/CircleProportionChart.js
@@ -225,7 +225,7 @@ export class CircleProportionChart extends React.Component {
       { label: parent_name, value: parent_value },
       { label: child_name, value: child_value },
     ];
-    const table = !disable_table_view && (
+    const table = (window.is_a11y_mode || !disable_table_view) && (
       <SmartDisplayTable
         table_name={table_name || text_maker("default_table_name")}
         column_configs={column_configs}

--- a/client/src/charts/wrapped_nivo/CircleProportionChart.js
+++ b/client/src/charts/wrapped_nivo/CircleProportionChart.js
@@ -225,7 +225,7 @@ export class CircleProportionChart extends React.Component {
       { label: parent_name, value: parent_value },
       { label: child_name, value: child_value },
     ];
-    const table = (window.is_a11y_mode || !disable_table_view) && (
+    const table = !disable_table_view && (
       <SmartDisplayTable
         table_name={table_name || text_maker("default_table_name")}
         column_configs={column_configs}

--- a/client/src/charts/wrapped_nivo/NivoLineBarToggle.js
+++ b/client/src/charts/wrapped_nivo/NivoLineBarToggle.js
@@ -228,13 +228,11 @@ export class NivoLineBarToggle extends React.Component {
           style={{ width: "100%", position: "relative" }}
           tabIndex="-1"
         >
-          <div aria-hidden={true}>
-            {extra_graph_options.bar ? (
-              <WrappedNivoBar {...extended_graph_options_bar} />
-            ) : (
-              <WrappedNivoLine {...extended_graph_options_line} />
-            )}
-          </div>
+          {extra_graph_options.bar ? (
+            <WrappedNivoBar {...extended_graph_options_bar} />
+          ) : (
+            <WrappedNivoLine {...extended_graph_options_line} />
+          )}
         </div>
       </div>
     );

--- a/client/src/charts/wrapped_nivo/WrappedNivoLine.js
+++ b/client/src/charts/wrapped_nivo/WrappedNivoLine.js
@@ -103,7 +103,7 @@ export class WrappedNivoLine extends React.Component {
       const line_table_value_formatter = (value) =>
         _.isUndefined(value)
           ? ""
-          : get_formatter(is_money, text_formatter, true, true)(value);
+          : get_formatter(is_money, text_formatter, true, false)(value);
       const column_configs = {
         label: {
           index: 0,

--- a/client/src/charts/wrapped_nivo/WrappedNivoLine.js
+++ b/client/src/charts/wrapped_nivo/WrappedNivoLine.js
@@ -131,9 +131,7 @@ export class WrappedNivoLine extends React.Component {
       );
     };
 
-    const table =
-      (window.is_a11y_mode || !disable_table_view) &&
-      (custom_table || get_table());
+    const table = !disable_table_view && (custom_table || get_table());
 
     const zoom_button =
       !disable_y_axis_zoom && !enableArea ? (

--- a/client/src/charts/wrapped_nivo/WrappedNivoLine.js
+++ b/client/src/charts/wrapped_nivo/WrappedNivoLine.js
@@ -131,7 +131,9 @@ export class WrappedNivoLine extends React.Component {
       );
     };
 
-    const table = !disable_table_view && (custom_table || get_table());
+    const table =
+      (window.is_a11y_mode || !disable_table_view) &&
+      (custom_table || get_table());
 
     const zoom_button =
       !disable_y_axis_zoom && !enableArea ? (

--- a/client/src/charts/wrapped_nivo/WrappedNivoPie.js
+++ b/client/src/charts/wrapped_nivo/WrappedNivoPie.js
@@ -89,7 +89,7 @@ export class WrappedNivoPie extends React.Component {
       },
     };
 
-    const table = !disable_table_view && (
+    const table = (window.is_a11y_mode || !disable_table_view) && (
       <SmartDisplayTable
         data={table_data}
         column_configs={column_configs}

--- a/client/src/charts/wrapped_nivo/WrappedNivoPie.js
+++ b/client/src/charts/wrapped_nivo/WrappedNivoPie.js
@@ -79,7 +79,7 @@ export class WrappedNivoPie extends React.Component {
         header: nivo_common_text_maker("value"),
         formatter: (value) =>
           value
-            ? get_formatter(is_money, text_formatter, true, true)(value)
+            ? get_formatter(is_money, text_formatter, true, false)(value)
             : "",
       },
       percentage: {

--- a/client/src/charts/wrapped_nivo/WrappedNivoPie.js
+++ b/client/src/charts/wrapped_nivo/WrappedNivoPie.js
@@ -89,7 +89,7 @@ export class WrappedNivoPie extends React.Component {
       },
     };
 
-    const table = (window.is_a11y_mode || !disable_table_view) && (
+    const table = !disable_table_view && (
       <SmartDisplayTable
         data={table_data}
         column_configs={column_configs}

--- a/client/src/charts/wrapped_nivo/wrapped_nivo_bar.js
+++ b/client/src/charts/wrapped_nivo/wrapped_nivo_bar.js
@@ -88,7 +88,7 @@ export class WrappedNivoBar extends React.Component {
     } = this.props;
 
     const table =
-      !disable_table_view &&
+      (window.is_a11y_mode || !disable_table_view) &&
       (custom_table ||
         bar_table(
           data,
@@ -203,7 +203,7 @@ export class WrappedNivoHBar extends React.Component {
     } = this.props;
 
     const table =
-      !disable_table_view &&
+      (window.is_a11y_mode || !disable_table_view) &&
       bar_table(
         data,
         keys,

--- a/client/src/charts/wrapped_nivo/wrapped_nivo_bar.js
+++ b/client/src/charts/wrapped_nivo/wrapped_nivo_bar.js
@@ -94,7 +94,7 @@ export class WrappedNivoBar extends React.Component {
           data,
           keys,
           indexBy,
-          get_formatter(is_money, text_formatter, true, true),
+          get_formatter(is_money, text_formatter, true, false),
           table_name,
           table_first_column_name
         ));

--- a/client/src/charts/wrapped_nivo/wrapped_nivo_bar.js
+++ b/client/src/charts/wrapped_nivo/wrapped_nivo_bar.js
@@ -88,7 +88,7 @@ export class WrappedNivoBar extends React.Component {
     } = this.props;
 
     const table =
-      (window.is_a11y_mode || !disable_table_view) &&
+      !disable_table_view &&
       (custom_table ||
         bar_table(
           data,
@@ -203,7 +203,7 @@ export class WrappedNivoHBar extends React.Component {
     } = this.props;
 
     const table =
-      (window.is_a11y_mode || !disable_table_view) &&
+      !disable_table_view &&
       bar_table(
         data,
         keys,

--- a/client/src/charts/wrapped_nivo/wrapped_nivo_common.yaml
+++ b/client/src/charts/wrapped_nivo/wrapped_nivo_common.yaml
@@ -3,5 +3,5 @@ show_table:
   fr: Afficher le tableau de données
 
 default_table_name:
-  en: Table for graph
-  fr: Tableau pour graphique
+  en: Table of data
+  fr: Tableau des données

--- a/client/src/common_text/common_lang.yaml
+++ b/client/src/common_text/common_lang.yaml
@@ -92,6 +92,9 @@ name:
 table_name:
   en: Name of the dataset table
   fr: Nom du tableau des données
+text_input:
+  en: Text input
+  fr: Saisie de texte
 
 estimates:
   en: Estimates

--- a/client/src/common_text/common_lang.yaml
+++ b/client/src/common_text/common_lang.yaml
@@ -1049,7 +1049,9 @@ build_a_report:
 you_are_here:
   en: You are here
   fr: Vous êtes ici
-
+dataset_navigation:
+  en: Dataset navigation
+  fr: TODO
 
 infographic_for:
   transform: [handlebars]

--- a/client/src/common_text/common_lang.yaml
+++ b/client/src/common_text/common_lang.yaml
@@ -208,9 +208,12 @@ change:
 click:
   en: Click
   fr: Cliquez
+open:
+  en: Open
+  fr: Ouvert
 close:
-  en: close
-  fr: fermer
+  en: Close
+  fr: Fermer
 people:
   en: People
   fr: Personnes

--- a/client/src/components/Accordions.js
+++ b/client/src/components/Accordions.js
@@ -90,7 +90,7 @@ const StatelessPullDownAccordion = ({
   children,
   onToggle,
 }) => (
-  <div className="pull-down-accordion">
+  <div aria-label={title} className="pull-down-accordion">
     <div className="pull-down-accordion-header" onClick={onToggle}>
       <button aria-label={get_accordion_label(isExpanded)}>{title}</button>
     </div>

--- a/client/src/components/DebouncedTextInput.js
+++ b/client/src/components/DebouncedTextInput.js
@@ -1,5 +1,4 @@
 import classNames from "classnames";
-import { Fragment } from "react";
 
 import { text_maker } from "../tables/table_common";
 
@@ -26,22 +25,15 @@ class DebouncedTextInput extends React.Component {
     const unique_id = _.uniqueId("input-");
 
     return (
-      <Fragment>
-        {a11y_label && (
-          <label className="sr-only" htmlFor={unique_id}>
-            {a11y_label}
-          </label>
-        )}
-        <input
-          id={unique_id}
-          type="text"
-          aria_label={a11y_label || text_maker("text_input")}
-          className={classNames("form-control", inputClassName)}
-          placeholder={placeHolder || ""}
-          defaultValue={defaultValue || undefined}
-          onChange={handle_change}
-        />
-      </Fragment>
+      <input
+        id={unique_id}
+        type="text"
+        aria_label={a11y_label || text_maker("text_input")}
+        className={classNames("form-control", inputClassName)}
+        placeholder={placeHolder || ""}
+        defaultValue={defaultValue || undefined}
+        onChange={handle_change}
+      />
     );
   }
   componentWillUnmount() {

--- a/client/src/components/DebouncedTextInput.js
+++ b/client/src/components/DebouncedTextInput.js
@@ -1,6 +1,8 @@
 import classNames from "classnames";
 import { Fragment } from "react";
 
+import { text_maker } from "../tables/table_common";
+
 class DebouncedTextInput extends React.Component {
   render() {
     const {
@@ -33,6 +35,7 @@ class DebouncedTextInput extends React.Component {
         <input
           id={unique_id}
           type="text"
+          aria_label={a11y_label || text_maker("text_input")}
           className={classNames("form-control", inputClassName)}
           placeholder={placeHolder || ""}
           defaultValue={defaultValue || undefined}

--- a/client/src/components/DisplayTable/DisplayTable.js
+++ b/client/src/components/DisplayTable/DisplayTable.js
@@ -332,6 +332,7 @@ export class DisplayTable extends React.Component {
                         <DebouncedTextInput
                           inputClassName={"search input-sm"}
                           placeHolder={text_maker("filter_data")}
+                          a11y_label={text_maker("filter_data")}
                           defaultValue={current_search_input}
                           updateCallback={(search_value) => {
                             const updated_searches = _.mapValues(

--- a/client/src/components/DisplayTable/DisplayTable.js
+++ b/client/src/components/DisplayTable/DisplayTable.js
@@ -15,9 +15,10 @@ import {
   DisplayTableColumnToggle,
 } from "./DisplayTableUtils.js";
 
+import text from "./DisplayTable.yaml";
 import "./DisplayTable.scss";
 
-const { text_maker, TM } = create_text_maker_component();
+const { text_maker, TM } = create_text_maker_component(text);
 
 const column_config_defaults = {
   initial_visible: true,
@@ -267,12 +268,6 @@ export class DisplayTable extends React.Component {
           util_components_with_defaults && "display-table-container--with-utils"
         )}
       >
-        {util_components_with_defaults && (
-          <div className={"display-table-container__utils"}>
-            {_.map(util_components_with_defaults)}
-          </div>
-        )}
-
         <table
           className={classNames(
             "table",
@@ -290,6 +285,25 @@ export class DisplayTable extends React.Component {
             </div>
           </caption>
           <thead>
+            {util_components_with_defaults && (
+              <tr>
+                <td
+                  style={{ padding: "8px 8px 0px 0px" }}
+                  colSpan={_.size(visible_col_keys)}
+                >
+                  <div className={"display-table-container__utils"}>
+                    <button
+                      tabIndex={0}
+                      className={"skip-to-data"}
+                      onClick={() => this.refs.first_data.focus()}
+                    >
+                      {text_maker("skip_to_data")}
+                    </button>
+                    {_.map(util_components_with_defaults)}
+                  </div>
+                </td>
+              </tr>
+            )}
             <tr className="table-header">
               {_.map(visible_ordered_col_keys, (column_key, i) => (
                 <th key={i} className={"center-text"}>
@@ -358,13 +372,15 @@ export class DisplayTable extends React.Component {
             <tbody>
               {_.map(sorted_filtered_data, (row, i) => (
                 <tr key={i}>
-                  {_.map(visible_ordered_col_keys, (col_key) => (
+                  {_.map(visible_ordered_col_keys, (col_key, idx) => (
                     <td
                       style={{
                         fontSize: "14px",
                         textAlign: determine_text_align(row, col_key),
                       }}
                       key={col_key}
+                      tabIndex={-1}
+                      ref={idx === 0 && i === 0 ? "first_data" : null}
                     >
                       {col_configs_with_defaults[col_key].formatter ? (
                         _.isString(

--- a/client/src/components/DisplayTable/DisplayTable.js
+++ b/client/src/components/DisplayTable/DisplayTable.js
@@ -309,7 +309,7 @@ export class DisplayTable extends React.Component {
                     (searchable && searches[column_key]) || null;
 
                   return (
-                    <th key={column_key} style={{ textAlign: "center" }}>
+                    <td key={column_key} style={{ textAlign: "center" }}>
                       {sortable && (
                         <div
                           onClick={() =>
@@ -346,7 +346,7 @@ export class DisplayTable extends React.Component {
                           debounceTime={300}
                         />
                       )}
-                    </th>
+                    </td>
                   );
                 })}
               </tr>

--- a/client/src/components/DisplayTable/DisplayTable.scss
+++ b/client/src/components/DisplayTable/DisplayTable.scss
@@ -42,7 +42,7 @@ table.display-table > thead > tr {
   &:not(:last-child) > th {
     border-bottom: none;
   }
-  & > th {
+  & > th, td {
     border-top: none;
 
     color: $textLightColor;

--- a/client/src/components/DisplayTable/DisplayTable.scss
+++ b/client/src/components/DisplayTable/DisplayTable.scss
@@ -1,5 +1,20 @@
 @import '../../common_css/common-variables';
 
+.skip-to-data {
+  color: $textColor;
+  overflow: hidden;
+  height: 0px;
+  width: 0px;
+  padding: 0;
+  border: 0;
+}
+.skip-to-data:focus, .skip-to-data:active {
+  height: auto;
+  width: auto;
+  overflow: auto;
+}
+
+
 td {
   background-color: inherit;
 }
@@ -19,7 +34,6 @@ td {
 .display-table-container__utils {
   display: flex;
   justify-content: flex-end;
-  padding: 8px 10px 2px;
 }
 .no-data-msg {
   display: flex;

--- a/client/src/components/DisplayTable/DisplayTable.yaml
+++ b/client/src/components/DisplayTable/DisplayTable.yaml
@@ -7,3 +7,6 @@ download_table_data_desc:
 select_columns:
   en: Select columns
   fr: Choisir les colonnes
+skip_to_data:
+  en: Skip to main content of this table
+  fr: TODO

--- a/client/src/components/DisplayTable/DisplayTable.yaml
+++ b/client/src/components/DisplayTable/DisplayTable.yaml
@@ -9,4 +9,4 @@ select_columns:
   fr: Choisir les colonnes
 skip_to_data:
   en: Skip to main content of this table
-  fr: TODO
+  fr: Passer au contenu principal du tableau

--- a/client/src/components/DropdownMenu.js
+++ b/client/src/components/DropdownMenu.js
@@ -1,5 +1,7 @@
 import classNames from "classnames";
+
 import "./DropdownMenu.scss";
+import { trivial_text_maker } from "../models/text.js";
 
 export class DropdownMenu extends React.Component {
   constructor(props) {
@@ -7,6 +9,12 @@ export class DropdownMenu extends React.Component {
     this.state = {
       isOpen: false,
     };
+  }
+  componentDidUpdate() {
+    const { isOpen } = this.state;
+    if (isOpen) {
+      this.refs.dropdown_area.focus();
+    }
   }
   render() {
     const {
@@ -26,19 +34,37 @@ export class DropdownMenu extends React.Component {
             isOpen ? opened_button_class_name : closed_button_class_name
           }
           style={{ marginRight: 5 }}
-          onClick={() => this.setState({ isOpen: !isOpen })}
+          onClick={() => {
+            this.refs.dropdown_area.focus();
+            this.setState({ isOpen: !isOpen });
+          }}
           title={button_description}
         >
           {isOpen ? (
             <div className="close-dropdown">
-              <span className="close-dropdown__x">X </span>
-              {dropdown_trigger_txt}
+              <span
+                aria-label={`${trivial_text_maker(
+                  "close"
+                )} ${dropdown_trigger_txt}`}
+                className="close-dropdown__x"
+              >
+                X {dropdown_trigger_txt}
+              </span>
             </div>
           ) : (
-            dropdown_trigger_txt
+            <span
+              aria-label={`${trivial_text_maker(
+                "open"
+              )} ${dropdown_trigger_txt}`}
+            >
+              {dropdown_trigger_txt}
+            </span>
           )}
         </button>
         <div
+          tabIndex={0}
+          aria-label={dropdown_trigger_txt}
+          ref={"dropdown_area"}
           className={classNames(
             dropdown_content_class_name,
             "dropdown__content",
@@ -46,6 +72,9 @@ export class DropdownMenu extends React.Component {
           )}
         >
           {dropdown_content}
+          <button onClick={() => this.setState({ isOpen: !isOpen })}>
+            {`${trivial_text_maker("close")} ${dropdown_trigger_txt}`}
+          </button>
         </div>
       </div>
     );

--- a/client/src/components/DropdownMenu.scss
+++ b/client/src/components/DropdownMenu.scss
@@ -7,6 +7,7 @@
 .dropdown__content {
   display: none;
   position: absolute;
+  color: $textColor;
   background-color: #f9f9f9;
   min-width: 260px;
   box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2);

--- a/client/src/components/EmailFrontend.js
+++ b/client/src/components/EmailFrontend.js
@@ -227,6 +227,7 @@ class EmailFrontend extends React.Component {
                   field_id={get_field_id(field_key)}
                   selected_enums_for_field={completed_template[field_key]}
                   disabled={disable_forms}
+                  aria-hidden={disable_forms}
                   state_update_callback={(selected_enums) =>
                     this.mergeIntoCompletedTemplateState(
                       field_key,
@@ -268,6 +269,7 @@ class EmailFrontend extends React.Component {
                 style={{ marginBottom: "1rem" }}
                 id={get_field_id(field_key)}
                 disabled={disable_forms || connected_disabled}
+                aria-hidden={disable_forms || connected_disabled}
                 rows="5"
                 cols="33"
                 defaultValue={completed_template[field_key] || ""}

--- a/client/src/components/FootnoteList.js
+++ b/client/src/components/FootnoteList.js
@@ -63,10 +63,7 @@ const topic_keys_to_plain_text = (topic_keys) =>
   _.chain(topic_keys).map(text_maker).sort().uniq().value();
 
 const FootnoteMeta = ({ meta_items }) => (
-  <div
-    className={"footnote-list__meta_container"}
-    aria-label={!_.isEmpty(meta_items) ? text_maker("footnote_meta") : null}
-  >
+  <div className={"footnote-list__meta_container"} aria-hidden={true}>
     {_.map(meta_items, (meta_item_text, ix) => (
       <div key={ix} className="footnote-list__meta_item tag-badge">
         {meta_item_text}

--- a/client/src/components/HeightClipper.js
+++ b/client/src/components/HeightClipper.js
@@ -73,6 +73,7 @@ export class HeightClipper extends React.Component {
   measureHeightAndUpdateState() {
     const { main } = this.refs;
     if (
+      main &&
       !this.state.exceedsHeight &&
       this.state.shouldClip &&
       main.offsetHeight > this.props.clipHeight
@@ -94,7 +95,9 @@ export class HeightClipper extends React.Component {
 
     const isClipped = exceedsHeight && shouldClip;
 
-    return (
+    return window.is_a11y_mode ? (
+      children
+    ) : (
       <div
         ref="main"
         style={{

--- a/client/src/components/HeightClipper.js
+++ b/client/src/components/HeightClipper.js
@@ -138,7 +138,7 @@ export class HeightClipper extends React.Component {
             </button>
           </div>
         )}
-        <div aria-hidden={!!isClipped} tabIndex={-1} ref="content">
+        <div aria-hidden={isClipped} tabIndex={-1} ref="content">
           <div className={isClipped ? "untabbable_children" : ""}>
             {children}
           </div>

--- a/client/src/components/Panel.js
+++ b/client/src/components/Panel.js
@@ -100,7 +100,7 @@ export class Panel extends React.Component {
                 <span aria-hidden>{isOpen ? "▼" : "►"}</span>
               </button>
             }
-            {title && <h3 className="panel-title">{title}</h3>}
+            {title && <h2 className="panel-title">{title}</h2>}
             {isOpen && otherHeaderContent}
           </header>
         )}

--- a/client/src/components/Panel.js
+++ b/client/src/components/Panel.js
@@ -75,7 +75,6 @@ export class Panel extends React.Component {
       glossary_keys,
       footnotes,
     } = this.props;
-    const label_id = _.uniqueId("IBDetails__a11yLabel");
 
     return (
       <section
@@ -90,7 +89,6 @@ export class Panel extends React.Component {
               <button
                 className={classNames("panel-heading-utils")}
                 onClick={() => this.setState({ isOpen: !isOpen })}
-                aria-labelledby={label_id}
                 aria-label={
                   isOpen
                     ? text_maker("collapse_panel")

--- a/client/src/glossary/glossary.js
+++ b/client/src/glossary/glossary.js
@@ -143,9 +143,7 @@ const Glossary_ = ({ active_key, items_by_letter }) => (
                       onClick={(evt) => {
                         evt.preventDefault();
                         document.body.scrollTop = document.documentElement.scrollTop = 0;
-                        document
-                          .querySelector("#glossary_search > div > div > input")
-                          .focus();
+                        document.getElementById("app-focus-root").focus();
                       }}
                     >
                       {text_maker("back_to_top")}
@@ -182,7 +180,9 @@ export default class Glossary extends React.Component {
           <TM k="glossary" />
         </h1>
         <ScrollToTargetContainer target_id={active_key}>
-          <BackToTop focus="#glossary_search > div > div > input" />
+          {!window.is_a11y_mode && (
+            <BackToTop focus="#glossary_search > div > div > input" />
+          )}
           <Glossary_
             active_key={active_key}
             items_by_letter={items_by_letter}

--- a/client/src/glossary/glossary.yaml
+++ b/client/src/glossary/glossary.yaml
@@ -3,7 +3,7 @@ glossary_meta_desc:
   fr: Liste interrogeable des définitions pour les termes employés dans l'InfoBase
 
 jump_to_letter_glossary_entries:
-  en: Jump to glossary entires for the letter
+  en: Jump to glossary entries for the letter
   fr: Aller aux entrées du glossaire pour la lettre
   
 glossary_translation:

--- a/client/src/home/home.js
+++ b/client/src/home/home.js
@@ -80,9 +80,9 @@ const HomeLayout = (props) => (
         <h1>
           <TM k="welcome" />
         </h1>
-        <h3 style={{ marginTop: 0 }}>
+        <h2 style={{ marginTop: 0 }}>
           <TM k="home_sub_title" />
-        </h3>
+        </h2>
         <div className="flag">
           <img aria-hidden="true" src={get_static_url("svg/flagline.svg")} />
         </div>

--- a/client/src/infographic/Infographic.js
+++ b/client/src/infographic/Infographic.js
@@ -241,7 +241,7 @@ class InfoGraph_ extends React.Component {
               ))}
           </div>
         </div>
-        <div>
+        <div role="main" aria-label="Main infographic content TODO">
           {window.is_a11y_mode && (
             <p
               id="infographic-explanation-focus"

--- a/client/src/infographic/Infographic.js
+++ b/client/src/infographic/Infographic.js
@@ -241,7 +241,7 @@ class InfoGraph_ extends React.Component {
               ))}
           </div>
         </div>
-        <div role="main" aria-label="Main infographic content TODO">
+        <div role="main" aria-label={text_maker("main_infographic_content")}>
           {window.is_a11y_mode && (
             <p
               id="infographic-explanation-focus"

--- a/client/src/infographic/Infographic.yaml
+++ b/client/src/infographic/Infographic.yaml
@@ -1,7 +1,9 @@
 ############################################
 # text for infographics
 ############################################
-
+main_infographic_content:
+  en: Main infographic content
+  fr: Contenu principal de l’infographie
 
 bb_menu_title:
   en: Pick a topic to explore

--- a/client/src/infographic/a11y_bubble_menu.js
+++ b/client/src/infographic/a11y_bubble_menu.js
@@ -1,10 +1,12 @@
+import { trivial_text_maker } from "src/models/text.js";
+
 import { TM } from "../components/index.js";
 
 export default class AccessibleBubbleMenu extends React.Component {
   render() {
     const { items } = this.props;
     return (
-      <nav aria-label="Bubble Menu TODO">
+      <nav aria-label={trivial_text_maker("dataset_navigation")}>
         <ul>
           {_.map(items, ({ id, active, title, a11y_description, href }) => (
             <li key={id}>

--- a/client/src/infographic/a11y_bubble_menu.js
+++ b/client/src/infographic/a11y_bubble_menu.js
@@ -4,7 +4,7 @@ export default class AccessibleBubbleMenu extends React.Component {
   render() {
     const { items } = this.props;
     return (
-      <nav>
+      <nav aria-label="Bubble Menu TODO">
         <ul>
           {_.map(items, ({ id, active, title, a11y_description, href }) => (
             <li key={id}>
@@ -16,10 +16,9 @@ export default class AccessibleBubbleMenu extends React.Component {
                 }
                 href={href}
               >
-                {title}{" "}
+                {title}
                 {active && (
                   <span>
-                    {" "}
                     - <TM k="you_are_here" />
                   </span>
                 )}

--- a/client/src/panels/panel_declarations/InfographicPanel.js
+++ b/client/src/panels/panel_declarations/InfographicPanel.js
@@ -67,7 +67,7 @@ class Panel_ extends React.Component {
 
     const header_utils = context && (
       <div style={{ marginLeft: "auto" }}>
-        {context.panel_key && (
+        {context.panel_key && !window.is_a11y_mode && (
           <LogInteractionEvents
             event_type={"PANEL_PDF_DOWNLOADED"}
             event_details={title}

--- a/client/src/panels/panel_declarations/finances/auth_exp_planned_spending/auth_exp_planned_spending.js
+++ b/client/src/panels/panel_declarations/finances/auth_exp_planned_spending/auth_exp_planned_spending.js
@@ -232,23 +232,26 @@ class AuthExpPlannedSpendingGraph extends React.Component {
     return (
       <Fragment>
         <div style={{ padding: "10px 25px 0px 97px" }}>
-          <StandardLegend
-            isHorizontal={true}
-            items={legend_items}
-            onClick={(label) => {
-              const key_corresponding_to_label = _.find(data_series, { label })
-                .key;
+          {!window.is_a11y_mode && (
+            <StandardLegend
+              isHorizontal={true}
+              items={legend_items}
+              onClick={(label) => {
+                const key_corresponding_to_label = _.find(data_series, {
+                  label,
+                }).key;
 
-              this.setState({
-                active_series: {
-                  ...active_series,
-                  [key_corresponding_to_label]:
-                    !active_series[key_corresponding_to_label] ||
-                    !has_multiple_active_series,
-                },
-              });
-            }}
-          />
+                this.setState({
+                  active_series: {
+                    ...active_series,
+                    [key_corresponding_to_label]:
+                      !active_series[key_corresponding_to_label] ||
+                      !has_multiple_active_series,
+                  },
+                });
+              }}
+            />
+          )}
         </div>
 
         <GraphOverlay>

--- a/client/src/panels/panel_declarations/finances/auth_exp_planned_spending/auth_exp_planned_spending.js
+++ b/client/src/panels/panel_declarations/finances/auth_exp_planned_spending/auth_exp_planned_spending.js
@@ -231,27 +231,24 @@ class AuthExpPlannedSpendingGraph extends React.Component {
 
     return (
       <Fragment>
-        <div style={{ padding: "10px 25px 0px 97px" }} aria-hidden={true}>
-          {!window.is_a11y_mode && (
-            <StandardLegend
-              isHorizontal={true}
-              items={legend_items}
-              onClick={(label) => {
-                const key_corresponding_to_label = _.find(data_series, {
-                  label,
-                }).key;
+        <div style={{ padding: "10px 25px 0px 97px" }}>
+          <StandardLegend
+            isHorizontal={true}
+            items={legend_items}
+            onClick={(label) => {
+              const key_corresponding_to_label = _.find(data_series, { label })
+                .key;
 
-                this.setState({
-                  active_series: {
-                    ...active_series,
-                    [key_corresponding_to_label]:
-                      !active_series[key_corresponding_to_label] ||
-                      !has_multiple_active_series,
-                  },
-                });
-              }}
-            />
-          )}
+              this.setState({
+                active_series: {
+                  ...active_series,
+                  [key_corresponding_to_label]:
+                    !active_series[key_corresponding_to_label] ||
+                    !has_multiple_active_series,
+                },
+              });
+            }}
+          />
         </div>
 
         <GraphOverlay>

--- a/client/src/panels/panel_declarations/finances/detailed_program_spending_split/detailed_program_spending_split.js
+++ b/client/src/panels/panel_declarations/finances/detailed_program_spending_split/detailed_program_spending_split.js
@@ -94,7 +94,7 @@ class HistoricalProgramBars extends React.Component {
             index: idx + 1,
             header: tick,
             is_summable: true,
-            formatter: "dollar",
+            formatter: "compact2_written",
           },
         ])
         .fromPairs()
@@ -220,6 +220,7 @@ class DetailedProgramSplit extends React.Component {
           header: `${run_template("{{pa_last_year}}")} ${text_maker(
             "expenditures"
           )}`,
+          formatter: "compact2_written",
         },
       };
       return (

--- a/client/src/panels/panel_declarations/finances/drr_dp_resources/dp_rev_split.js
+++ b/client/src/panels/panel_declarations/finances/drr_dp_resources/dp_rev_split.js
@@ -24,7 +24,7 @@ const dp_cols = [...planning_years, ...special_cols];
 const spending_formatter = (value) => (
   <Format
     style={{ color: window.infobase_color_constants.textGreen }}
-    type={"dollar"}
+    type={"compact2_written"}
     content={value}
   />
 );
@@ -32,7 +32,7 @@ const spending_formatter = (value) => (
 const revenue_formatter = (value, custom_color = null) => (
   <Format
     style={{ color: window.infobase_color_constants.textRed }}
-    type={"dollar"}
+    type={"compact2_written"}
     content={value}
   />
 );
@@ -111,7 +111,7 @@ export const declare_dp_rev_split_panel = () =>
             index: 4,
             header: text_maker("dp_net"),
             is_summable: true,
-            formatter: "dollar",
+            formatter: "compact2_written",
           },
         };
 

--- a/client/src/panels/panel_declarations/finances/goco/goco.js
+++ b/client/src/panels/panel_declarations/finances/goco/goco.js
@@ -106,8 +106,8 @@ class Goco extends React.Component {
       .sortBy((d) => -d[spending_text])
       .value();
 
-    const spending_table_formatter = get_formatter(true, undefined, true, true);
-    const fte_table_formatter = get_formatter(false, undefined, true, true);
+    const spend_table_formatter = get_formatter(true, undefined, true, false);
+    const fte_table_formatter = get_formatter(false, undefined, true, false);
 
     const parent_table_data = _.map(Tag.gocos_by_spendarea, (sa) => ({
       [sa_text]: sa.name,
@@ -123,7 +123,7 @@ class Goco extends React.Component {
       [spending_text]: {
         index: 1,
         header: spending_text,
-        formatter: (value) => spending_table_formatter(value),
+        formatter: (value) => spend_table_formatter(value),
       },
       [ftes_text]: {
         index: 2,

--- a/client/src/panels/panel_declarations/finances/goco/goco.js
+++ b/client/src/panels/panel_declarations/finances/goco/goco.js
@@ -375,7 +375,7 @@ class Goco extends React.Component {
 
         const child_graph = (
           <Fragment>
-            <h4 style={{ textAlign: "center" }}>{node.indexValue}</h4>
+            <h3 style={{ textAlign: "center" }}>{node.indexValue}</h3>
             <WrappedNivoBar
               {...nivo_default_props}
               data={node.data.children}

--- a/client/src/panels/panel_declarations/finances/sobj/spend_by_so_hist.js
+++ b/client/src/panels/panel_declarations/finances/sobj/spend_by_so_hist.js
@@ -42,7 +42,7 @@ const get_custom_table = (data, active_sobjs) => {
           index: idx + 1,
           header: year,
           is_summable: true,
-          formatter: "dollar",
+          formatter: "compact2_written",
         },
       ])
       .fromPairs()

--- a/client/src/panels/panel_declarations/finances/transfer_payments/historical_g_and_c.js
+++ b/client/src/panels/panel_declarations/finances/transfer_payments/historical_g_and_c.js
@@ -163,7 +163,7 @@ class DetailedHistTPItems extends React.Component {
             index: idx + 1,
             header: year,
             is_summable: true,
-            formatter: "dollar",
+            formatter: "compact1_written",
           },
         ])
         .fromPairs()

--- a/client/src/panels/panel_declarations/finances/transfer_payments/tp_by_region.js
+++ b/client/src/panels/panel_declarations/finances/transfer_payments/tp_by_region.js
@@ -22,8 +22,6 @@ import text from "./tp_by_region.yaml";
 
 const { std_years } = year_templates;
 
-const formatter = formats["compact2_raw"];
-
 const { text_maker, TM } = create_text_maker_component(text);
 const { provinces, le_provinces, de_provinces } = businessConstants;
 
@@ -128,7 +126,7 @@ const TransferPaymentsByRegionGraph = ({ data }) => (
       data,
       color_scale: get_color_scale(data),
       years: std_years,
-      formatter: formatter,
+      formatter: formats.compact2_raw,
     }}
   />
 );
@@ -214,8 +212,10 @@ class TPMap extends React.Component {
               header: run_template(yr),
               formatter: (value) =>
                 is_per_capita
-                  ? `${formatter(value)} ${text_maker("per_capita")}`
-                  : formatter(value),
+                  ? `${formats.compact1_written_raw(value)} ${text_maker(
+                      "per_capita"
+                    )}`
+                  : formats.compact2_written_raw(value),
             },
           ])
           .fromPairs()

--- a/client/src/panels/panel_declarations/finances/vote_stat/in_year_vote_stat_breakdown.js
+++ b/client/src/panels/panel_declarations/finances/vote_stat/in_year_vote_stat_breakdown.js
@@ -127,7 +127,7 @@ const planned_vote_or_stat_render = (vs) =>
         index: 2,
         header: text_maker("authorities"),
         is_summable: true,
-        formatter: "dollar",
+        formatter: "compact2_written",
       },
     };
 

--- a/client/src/panels/panel_declarations/finances/vote_stat/in_year_vote_stat_breakdown.js
+++ b/client/src/panels/panel_declarations/finances/vote_stat/in_year_vote_stat_breakdown.js
@@ -61,7 +61,6 @@ const tooltip_render = (vs) =>
     sel.attrs({
       className: "link-unstyled",
       tabIndex: "0",
-      "aria-hidden": "true",
       // this can't be called "title" (what tooltip.js uses) because of some other hover effects that fire on titles.
       "data-ibtt-text": ` 
       <div class="FlatTreeMap__ToolTip">

--- a/client/src/panels/panel_declarations/finances/vote_stat/vote_stat_text.yaml
+++ b/client/src/panels/panel_declarations/finances/vote_stat/vote_stat_text.yaml
@@ -89,7 +89,7 @@ gov_in_year_estimates_split_text:
     This fiscal year ({{est_in_year}}), a total of **{{fmt_compact1_written gov_tabled_est_in_year}}** in planned budgetary expenditures have been presented in the 
     following {{gl_tt "estimates processes" "EST_PROC"}} and {{gl_tt "adjustments and transfers" "ADJUS"}}:
     {{#each gov_in_year_estimates_split}}
-    * {{ this.[0]}}: **{{fmt_compact1 this.[1] }}** 
+    * {{ this.[0]}}: **{{fmt_compact1_written this.[1] }}** 
     {{/each}}
     
     {{#if gov_tabled_est_next_year}}
@@ -99,7 +99,7 @@ gov_in_year_estimates_split_text:
    Pour l’exercice courant ({{est_in_year}}), le total de dépenses budgétaires prévues s’élève à 
    **{{fmt_compact1_written gov_tabled_est_in_year}}** dans le(s) {{gl_tt "processus budgétaire(s)" "EST_PROC"}} et {{gl_tt "redressements et virements" "ADJUS"}} suivants:
    {{#each gov_in_year_estimates_split}}
-   * {{ this.[0]}}: **{{fmt_compact1 this.[1] }}** 
+   * {{ this.[0]}}: **{{fmt_compact1_written this.[1] }}** 
    {{/each}}
 
    {{#if gov_tabled_est_next_year}}

--- a/client/src/panels/panel_declarations/people/employee_age.js
+++ b/client/src/panels/panel_declarations/people/employee_age.js
@@ -176,9 +176,7 @@ export const declare_employee_age_panel = () =>
                   tab_pane_contents={{
                     age_group: (
                       <div id={"emp_age_tab_pane"}>
-                        <GraphOverlay>
-                          <NivoLineBarToggle {...age_group_options} />
-                        </GraphOverlay>
+                        <NivoLineBarToggle {...age_group_options} />
                         <div className="clearfix"></div>
                       </div>
                     ),

--- a/client/src/panels/panel_declarations/people/employee_age.js
+++ b/client/src/panels/panel_declarations/people/employee_age.js
@@ -175,7 +175,9 @@ export const declare_employee_age_panel = () =>
                 tab_pane_contents={{
                   age_group: (
                     <div id={"emp_age_tab_pane"}>
-                      <NivoLineBarToggle {...age_group_options} />
+                      <GraphOverlay>
+                        <NivoLineBarToggle {...age_group_options} />
+                      </GraphOverlay>
                       <div className="clearfix"></div>
                     </div>
                   ),

--- a/client/src/panels/panel_declarations/people/employee_age.js
+++ b/client/src/panels/panel_declarations/people/employee_age.js
@@ -166,29 +166,27 @@ export const declare_employee_age_panel = () =>
               <TM k={level + "_employee_age_text"} args={info} />
             </Col>
             <Col size={12} isGraph extraClasses="zero-padding">
-              <div aria-hidden="true">
-                <TabbedContent
-                  tab_keys={["age_group", "avgage"]}
-                  tab_labels={{
-                    age_group: text_maker("age_group"),
-                    avgage: text_maker("avgage"),
-                  }}
-                  tab_pane_contents={{
-                    age_group: (
-                      <div id={"emp_age_tab_pane"}>
-                        <NivoLineBarToggle {...age_group_options} />
-                        <div className="clearfix"></div>
-                      </div>
-                    ),
-                    avgage: (
-                      <div id={"emp_age_tab_pane"}>
-                        <NivoLineBarToggle {...avg_age_options} />
-                        <div className="clearfix"></div>
-                      </div>
-                    ),
-                  }}
-                />
-              </div>
+              <TabbedContent
+                tab_keys={["age_group", "avgage"]}
+                tab_labels={{
+                  age_group: text_maker("age_group"),
+                  avgage: text_maker("avgage"),
+                }}
+                tab_pane_contents={{
+                  age_group: (
+                    <div id={"emp_age_tab_pane"}>
+                      <NivoLineBarToggle {...age_group_options} />
+                      <div className="clearfix"></div>
+                    </div>
+                  ),
+                  avgage: (
+                    <div id={"emp_age_tab_pane"}>
+                      <NivoLineBarToggle {...avg_age_options} />
+                      <div className="clearfix"></div>
+                    </div>
+                  ),
+                }}
+              />
             </Col>
           </StdPanel>
         );

--- a/client/src/panels/panel_declarations/results/result_components.js
+++ b/client/src/panels/panel_declarations/results/result_components.js
@@ -308,7 +308,7 @@ const StatusIconTable = ({
   active_list,
 }) => (
   <div>
-    <div aria-hidden={true} className="status-icon-table">
+    <div className="status-icon-table">
       <FilterTable
         items={_.map(ordered_status_keys, (status_key) => ({
           key: status_key,
@@ -319,7 +319,7 @@ const StatusIconTable = ({
           text: !window.is_a11y_mode ? (
             <span
               className="link-unstyled"
-              tabIndex={0}
+              tabIndex={-1}
               aria-hidden="true"
               data-toggle="tooltip"
               data-ibtt-glossary-key={status_key_to_glossary_key[status_key]}

--- a/client/src/panels/panel_declarations/results/results_intro.js
+++ b/client/src/panels/panel_declarations/results/results_intro.js
@@ -44,7 +44,7 @@ const ResultsIntroPanel = ({
             }}
           >
             <img
-              alt={"TODO"}
+              alt={text_maker("results_intro_img_text")}
               src={get_static_url(`png/result-taxonomy-${window.lang}.png`)}
               style={{
                 width: "100%",

--- a/client/src/panels/panel_declarations/results/results_intro.js
+++ b/client/src/panels/panel_declarations/results/results_intro.js
@@ -44,6 +44,7 @@ const ResultsIntroPanel = ({
             }}
           >
             <img
+              alt={"TODO"}
               src={get_static_url(`png/result-taxonomy-${window.lang}.png`)}
               style={{
                 width: "100%",

--- a/client/src/panels/panel_declarations/results/results_intro_text.yaml
+++ b/client/src/panels/panel_declarations/results/results_intro_text.yaml
@@ -20,6 +20,14 @@ results_intro_text:
     Les organisations ont des {{gl_tt "responsabilités essentielles" "CR"}} auxquelles des {{gl_tt "programmes" "PROG"}} sont rattachés.
     Les responsabilités essentielles et les programmes donnent des {{gl_tt "résultats" "RESULT"}}. Pour chaque résultat, les progrès
     sont mesurés à l'aide d'un ou de plusieurs {{gl_tt "indicateurs" "IND_RESULT"}}, chacun d'eux comportant une cible.
+results_intro_img_text:
+  en: |
+    Organizations are made up of Core Responsibilities and Programs within each Core Responsibility. Core Responsibilities and Programs
+    have results. Progress for each result is measured by one or more indicators, each of which has a target.
+  fr: |
+    Les organisations ont des responsabilités essentielles auxquelles des programmes sont rattachés.
+    Les responsabilités essentielles et les programmes donnent des résultats. Pour chaque résultat, les progrès
+    sont mesurés à l'aide d'un ou de plusieurs indicateurs, chacun d'eux comportant une cible.
 
 
 dp_summary_text:

--- a/client/src/rpb/TablePicker.js
+++ b/client/src/rpb/TablePicker.js
@@ -8,7 +8,7 @@ import { AlertBanner, GlossaryIcon } from "../components";
 import { Table } from "../core/TableClass.js";
 import { GlossaryEntry } from "../models/glossary.js";
 
-import { TextMaker } from "./rpb_text_provider.js";
+import { TextMaker, text_maker } from "./rpb_text_provider.js";
 import {
   categories,
   concepts_by_category,
@@ -36,6 +36,7 @@ export const AccessibleTablePicker = ({
       value={selected}
       onChange={(evt) => onSelect(evt.target.value)}
     >
+      <option value="select_data">{text_maker("rpb_pick_data")}</option>
       {_.map(tables, ({ id, name }) => (
         <option key={id} value={id}>
           {name}

--- a/client/src/rpb/TablePicker.js
+++ b/client/src/rpb/TablePicker.js
@@ -134,9 +134,9 @@ class TablePicker extends React.Component {
 
     return (
       <div ref="main" id="tbp-main">
-        <h2 id="tbp-title">
+        <h1 id="tbp-title">
           <TextMaker text_key="table_picker_title" />
-        </h2>
+        </h1>
         {broken_url && <BrokenLinkBanner />}
         <p className="medium_panel_text">
           <TextMaker text_key="table_picker_top_instructions" />

--- a/client/src/rpb/granular_view.js
+++ b/client/src/rpb/granular_view.js
@@ -40,7 +40,13 @@ class GranularView extends React.Component {
         </LabeledBox>
 
         {table.rpb_banner && <AlertBanner>{table.rpb_banner}</AlertBanner>}
-        <div id="rpb-main-content">{this.get_table_content()}</div>
+        <div
+          role="main"
+          aria-label="Report Builder content TODO"
+          id="rpb-main-content"
+        >
+          {this.get_table_content()}
+        </div>
       </div>
     );
   }

--- a/client/src/rpb/granular_view.js
+++ b/client/src/rpb/granular_view.js
@@ -42,7 +42,7 @@ class GranularView extends React.Component {
         {table.rpb_banner && <AlertBanner>{table.rpb_banner}</AlertBanner>}
         <div
           role="main"
-          aria-label="Report Builder content TODO"
+          aria-label={text_maker("main_rpb_content")}
           id="rpb-main-content"
         >
           {this.get_table_content()}

--- a/client/src/rpb/index.js
+++ b/client/src/rpb/index.js
@@ -138,7 +138,7 @@ class RPB extends React.Component {
   };
 
   pickTable(table_id) {
-    if (this.state.loading) {
+    if (this.state.loading || table_id === "select_data") {
       return;
     }
     if (table_id === this.props.state.table) {
@@ -293,7 +293,11 @@ class RPB extends React.Component {
         </div>
         <LabeledBox label={<TextMaker text_key="rpb_pick_data" />}>
           <div style={{ display: "flex", alignItems: "center" }}>
-            <div className="centerer md-half-width">
+            <div
+              role="region"
+              aria-label={text_maker("rpb_pick_data")}
+              className="centerer md-half-width"
+            >
               {window.is_a11y_mode ? (
                 <AccessibleTablePicker
                   onSelect={(id) => this.pickTable(id)}

--- a/client/src/rpb/rpb.yaml
+++ b/client/src/rpb/rpb.yaml
@@ -2,6 +2,10 @@ report_builder_title:
   en: Report Builder
   fr: Outil de création de rapport
 
+main_rpb_content:
+  en: Main Report Builder content
+  fr: Contenu principal de l'outil de création de rapport
+
 report_builder_meta_desc:
   en: Create a customized and exportable report on the data you want to analyze
   fr: Créer un rapport adapté et exportable sur les données que vous voulez analyser
@@ -20,7 +24,7 @@ table_picker_none_selected_summary:
 
 select_dataset_type:
   en: Select type of Dataset
-  fr: TODO
+  fr: Sélectionnez le type de données
 
 select_table_button:
   en: Select a table or topic
@@ -75,7 +79,7 @@ sort_by:
 
 group_data:
   en: Group data
-  fr: TODO
+  fr: Trier les donées
 
 filter:
   en: Filter

--- a/client/src/search/BaseTypeahead.js
+++ b/client/src/search/BaseTypeahead.js
@@ -14,7 +14,6 @@ import { InfoBaseHighlighter } from "./search_utils.js";
 
 import text from "./BaseTypeahead.yaml";
 
-
 const text_maker = create_text_maker(text);
 const TextMaker = (props) => <TM tmf={text_maker} {...props} />;
 
@@ -147,6 +146,9 @@ export class BaseTypeahead extends React.Component {
         return false;
       }
     };
+    if (this.typeahead_node) {
+      this.typeahead_node.setAttribute("autocomplete", "off");
+    }
 
     return (
       <Typeahead

--- a/client/src/search/BaseTypeahead.js
+++ b/client/src/search/BaseTypeahead.js
@@ -146,9 +146,6 @@ export class BaseTypeahead extends React.Component {
         return false;
       }
     };
-    if (this.typeahead_node) {
-      this.typeahead_node.setAttribute("autocomplete", "off");
-    }
 
     return (
       <Typeahead


### PR DESCRIPTION
Main changes:
1. Bunch of little a11y changes (aria-label, aria-hidden, alt text, heading order, etc)
2. compact_written instead of other formats
3. Landmarks
4. Displaytable changes:
- Moved utils into table, so that screen reader reads table -> utils for table. Instead of Utils for table -> table (Just makes a bit more sense)
- Skip to data util
5. DropdownMenu a11y-ify
