### PR TITLE
Tweak memory usage of CirclCI build job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,7 +148,7 @@ jobs:
           keys:
             - prod-build-{{ .Branch }}-{{ .Revision }}
       - run:
-          command: |
+          command: | # if the build job starts failing with exit code 137 (running out of memory), add the build_all.sh option --concurrency="half"
             [ -f "client/$BUILD_DIR/InfoBase/app/app-a11y-en.min.js" ] || (cd client && ./deploy_scripts/build_all.sh --max_old_space_size=256)
       - save_cache:
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -159,7 +159,7 @@ jobs:
             - prod-build-{{ .Branch }}-{{ .Revision }}
       - run:
           command: |
-            [ -f "client/$BUILD_DIR/InfoBase/app/app-a11y-en.min.js" ] || (cd client && ./deploy_scripts/build_all.sh)
+            [ -f "client/$BUILD_DIR/InfoBase/app/app-a11y-en.min.js" ] || (cd client && ./deploy_scripts/build_all.sh --max_old_space_size=256)
       - save_cache:
           paths:
             - client/build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,6 +117,16 @@ jobs:
       - checkout:
           path: "~/InfoBase"
       
+      - run:
+          command: |
+            while true; do
+              sleep 5
+              echo "====="
+              ps -eo comm,vsz,rss | sort -k 3 -nr
+              echo "====="
+            done 
+          background: true
+
       - restore_cache:
           keys:
             - top-level-dependencies-{{ checksum "package-lock.json" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,16 +116,6 @@ jobs:
     steps:
       - checkout:
           path: "~/InfoBase"
-      
-      - run:
-          command: |
-            while true; do
-              sleep 5
-              echo "====="
-              ps -eo comm,vsz,rss | sort -k 3 -nr
-              echo "====="
-            done 
-          background: true
 
       - restore_cache:
           keys:

--- a/client/deploy_scripts/build_all.sh
+++ b/client/deploy_scripts/build_all.sh
@@ -9,16 +9,16 @@ npm run IB_base
 # Run standard and a11y builds in parallel as background processes, store thieir stdout and stderr in temp files and hold on to their pids
 scratch=$(mktemp -d -t captured_build_output.XXXXXXXXXX)
 
-npm run IB_prod_no_watch_en --max_old_space_size=800 > $scratch/ib_prod_en_build_out 2> $scratch/ib_prod_en_build_err &
+npm run IB_prod_no_watch_en --max_old_space_size=600 > $scratch/ib_prod_en_build_out 2> $scratch/ib_prod_en_build_err &
 ib_prod_en_pid=$!
 
-npm run IB_prod_no_watch_fr --max_old_space_size=800 > $scratch/ib_prod_fr_build_out 2> $scratch/ib_prod_fr_build_err &
+npm run IB_prod_no_watch_fr --max_old_space_size=600 > $scratch/ib_prod_fr_build_out 2> $scratch/ib_prod_fr_build_err &
 ib_prod_fr_pid=$!
 
-npm run a11y_prod_no_watch_en --max_old_space_size=800 > $scratch/a11y_prod_en_build_out 2> $scratch/a11y_prod_en_build_err &
+npm run a11y_prod_no_watch_en --max_old_space_size=600 > $scratch/a11y_prod_en_build_out 2> $scratch/a11y_prod_en_build_err &
 a11y_prod_en_pid=$!
 
-npm run a11y_prod_no_watch_fr --max_old_space_size=800 > $scratch/a11y_prod_fr_build_out 2> $scratch/a11y_prod_fr_build_err &
+npm run a11y_prod_no_watch_fr --max_old_space_size=600 > $scratch/a11y_prod_fr_build_out 2> $scratch/a11y_prod_fr_build_err &
 a11y_prod_fr_pid=$!
 
 

--- a/client/deploy_scripts/build_all.sh
+++ b/client/deploy_scripts/build_all.sh
@@ -9,16 +9,16 @@ npm run IB_base
 # Run standard and a11y builds in parallel as background processes, store thieir stdout and stderr in temp files and hold on to their pids
 scratch=$(mktemp -d -t captured_build_output.XXXXXXXXXX)
 
-npm run IB_prod_no_watch_en > $scratch/ib_prod_en_build_out 2> $scratch/ib_prod_en_build_err &
+npm run IB_prod_no_watch_en --max_old_space_size=800 > $scratch/ib_prod_en_build_out 2> $scratch/ib_prod_en_build_err &
 ib_prod_en_pid=$!
 
-npm run IB_prod_no_watch_fr > $scratch/ib_prod_fr_build_out 2> $scratch/ib_prod_fr_build_err &
+npm run IB_prod_no_watch_fr --max_old_space_size=800 > $scratch/ib_prod_fr_build_out 2> $scratch/ib_prod_fr_build_err &
 ib_prod_fr_pid=$!
 
-npm run a11y_prod_no_watch_en > $scratch/a11y_prod_en_build_out 2> $scratch/a11y_prod_en_build_err &
+npm run a11y_prod_no_watch_en --max_old_space_size=800 > $scratch/a11y_prod_en_build_out 2> $scratch/a11y_prod_en_build_err &
 a11y_prod_en_pid=$!
 
-npm run a11y_prod_no_watch_fr > $scratch/a11y_prod_fr_build_out 2> $scratch/a11y_prod_fr_build_err &
+npm run a11y_prod_no_watch_fr --max_old_space_size=800 > $scratch/a11y_prod_fr_build_out 2> $scratch/a11y_prod_fr_build_err &
 a11y_prod_fr_pid=$!
 
 

--- a/client/deploy_scripts/build_all.sh
+++ b/client/deploy_scripts/build_all.sh
@@ -1,30 +1,22 @@
 #!/bin/bash
 set -e # will exit if any command has non-zero exit value 
 
+concurrency="full"
+max_old_space_size=512
+
+while getopts ":c:concurrency:m:max_old_space_size:" arg; do
+  case $arg in
+    c) concurrency=$OPTARG;;
+    concurrency) concurrency=$OPTARG;;
+    m) max_old_space_size=$OPTARG;;
+    max_old_space_size) max_old_space_size=$OPTARG;;
+  esac
+done
+
+
 [ -e $BUILD_DIR/InfoBase ] && rm -r $BUILD_DIR/InfoBase # clean up build dir
 
 npm run IB_base
-
-
-# Run standard and a11y builds in parallel as background processes, store thieir stdout and stderr in temp files and hold on to their pids
-scratch=$(mktemp -d -t captured_build_output.XXXXXXXXXX)
-
-npm run IB_prod_no_watch_en --max_old_space_size=600 > $scratch/ib_prod_en_build_out 2> $scratch/ib_prod_en_build_err &
-ib_prod_en_pid=$!
-
-npm run IB_prod_no_watch_fr --max_old_space_size=600 > $scratch/ib_prod_fr_build_out 2> $scratch/ib_prod_fr_build_err &
-ib_prod_fr_pid=$!
-
-npm run a11y_prod_no_watch_en --max_old_space_size=600 > $scratch/a11y_prod_en_build_out 2> $scratch/a11y_prod_en_build_err &
-a11y_prod_en_pid=$!
-
-npm run a11y_prod_no_watch_fr --max_old_space_size=600 > $scratch/a11y_prod_fr_build_out 2> $scratch/a11y_prod_fr_build_err &
-a11y_prod_fr_pid=$!
-
-
-# Start a spinner going in the terminal meanwhile, hold on to its pid to stop it later
-spinner_pid=$(sh ../scripts/spinner.sh)
-
 
 # When exiting, either from finishing, being killed, or throwing an error, kill the spinner and dump the captured build process output to terminal
 function print_captured_output {
@@ -42,11 +34,75 @@ function print_captured_output {
   cat $scratch/a11y_prod_fr_build_out
   cat $scratch/a11y_prod_fr_build_err
 }
-trap print_captured_output EXIT
 
 
-wait $ib_prod_en_pid
-wait $ib_prod_fr_pid
-wait $a11y_prod_en_pid
-wait $a11y_prod_fr_pid
+scratch=$(mktemp -d -t captured_build_output.XXXXXXXXXX)
+if [ $concurrency == "full" ]; then
+  # Run standard and a11y builds in parallel as background processes, store thieir stdout and stderr in temp files and hold on to their pids, 
+  # clean up and dump output on exit
+  trap print_captured_output EXIT
+
+  echo ""
+  echo "Running prod builds in background, full concurrency..."
+  spinner_pid=$(sh ../scripts/spinner.sh)
+
+  npm run IB_prod_no_watch_en --max_old_space_size=$max_old_space_size > $scratch/ib_prod_en_build_out 2> $scratch/ib_prod_en_build_err &
+  ib_prod_en_pid=$!
+  
+  npm run IB_prod_no_watch_fr --max_old_space_size=$max_old_space_size > $scratch/ib_prod_fr_build_out 2> $scratch/ib_prod_fr_build_err &
+  ib_prod_fr_pid=$!
+  
+  npm run a11y_prod_no_watch_en --max_old_space_size=$max_old_space_size > $scratch/a11y_prod_en_build_out 2> $scratch/a11y_prod_en_build_err &
+  a11y_prod_en_pid=$!
+  
+  npm run a11y_prod_no_watch_fr --max_old_space_size=$max_old_space_size > $scratch/a11y_prod_fr_build_out 2> $scratch/a11y_prod_fr_build_err &
+  a11y_prod_fr_pid=$!
+
+  wait $ib_prod_en_pid
+  wait $ib_prod_fr_pid
+  wait $a11y_prod_en_pid
+  wait $a11y_prod_fr_pid
+elif [ $concurrency == "half" ]; then
+  # Same as "full" concurrency, but only run two builds at a time 
+  trap print_captured_output EXIT
+
+  echo ""
+  echo "Running prod builds in background, half concurrency..."
+  spinner_pid=$(sh ../scripts/spinner.sh)
+
+  npm run IB_prod_no_watch_en --max_old_space_size=$max_old_space_size > $scratch/ib_prod_en_build_out 2> $scratch/ib_prod_en_build_err &
+  ib_prod_en_pid=$!
+  
+  npm run IB_prod_no_watch_fr --max_old_space_size=$max_old_space_size > $scratch/ib_prod_fr_build_out 2> $scratch/ib_prod_fr_build_err &
+  ib_prod_fr_pid=$!
+
+  spinner_pid=$(sh ../scripts/spinner.sh)
+
+  wait $ib_prod_en_pid
+  wait $ib_prod_fr_pid
+  
+  npm run a11y_prod_no_watch_en --max_old_space_size=$max_old_space_size > $scratch/a11y_prod_en_build_out 2> $scratch/a11y_prod_en_build_err &
+  a11y_prod_en_pid=$!
+  
+  npm run a11y_prod_no_watch_fr --max_old_space_size=$max_old_space_size > $scratch/a11y_prod_fr_build_out 2> $scratch/a11y_prod_fr_build_err &
+  a11y_prod_fr_pid=$!
+  
+  wait $a11y_prod_en_pid
+  wait $a11y_prod_fr_pid
+elif [ $concurrency == "none" ]; then
+  # Just running all builds one at a time, no backgrounding or output redirection
+
+  npm run IB_prod_no_watch_en --max_old_space_size=$max_old_space_size 
+  
+  npm run IB_prod_no_watch_fr --max_old_space_size=$max_old_space_size 
+  
+  npm run a11y_prod_no_watch_en --max_old_space_size=$max_old_space_size 
+
+  npm run a11y_prod_no_watch_fr --max_old_space_size=$max_old_space_size
+else
+  echo ""
+  echo "Bad concurrency (c) option. Must be one of full, half, or none"
+  exit 1
+fi
+
 exit

--- a/client/deploy_scripts/build_all.sh
+++ b/client/deploy_scripts/build_all.sh
@@ -76,8 +76,6 @@ elif [ $concurrency == "half" ]; then
   npm run IB_prod_no_watch_fr --max_old_space_size=$max_old_space_size > $scratch/ib_prod_fr_build_out 2> $scratch/ib_prod_fr_build_err &
   ib_prod_fr_pid=$!
 
-  spinner_pid=$(sh ../scripts/spinner.sh)
-
   wait $ib_prod_en_pid
   wait $ib_prod_fr_pid
   

--- a/scripts/spinner.sh
+++ b/scripts/spinner.sh
@@ -8,23 +8,15 @@
   i=0
   echo "\n"
   while [ true ]; do
-    c=`expr ${i} % 9`
-    case ${c} in
-      0) echo "⠋\c" ;;
-      1) echo "⠙\c" ;;
-      2) echo "⠹\c" ;;
-      3) echo "⠸\c" ;;
-      4) echo "⠼\c" ;;
-      5) echo "⠴\c" ;;
-      6) echo "⠦\c" ;;
-      7) echo "⠧\c" ;;
-      8) echo "⠇\c" ;;
-      9) echo "⠏\c" ;;
-    esac
-    i=`expr ${i} + 1`
-    # change the speed of the spinner by altering the 1 below
-    sleep 1
-    echo "\b\c"
+    spinner="⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"
+    while :
+    do
+      for i in `seq 0 9`
+      do
+        printf "\b${spinner:$i:1}"
+        sleep 1 # change the speed of the spinner by altering the sleep time
+      done
+    done
   done
 ) 1>&2 &
 

--- a/scripts/spinner.sh
+++ b/scripts/spinner.sh
@@ -4,21 +4,32 @@
 # Keep track of that PID, you need to use it to kill the spinner when you want it stopped
 
 (
-  # based on https://unix.stackexchange.com/a/512170
   i=0
   echo "\n"
   while [ true ]; do
-    spinner="⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"
-    while :
-    do
-      for i in `seq 0 9`
-      do
-        printf "\b${spinner:$i:1}"
-        sleep 1 # change the speed of the spinner by altering the sleep time
-      done
-    done
+    c=`expr ${i} % 9`
+    case ${c} in
+      0) printf "\b⠋" ;;
+      1) printf "\b⠙" ;;
+      2) printf "\b⠹" ;;
+      3) printf "\b⠸" ;;
+      4) printf "\b⠼" ;;
+      5) printf "\b⠴" ;;
+      6) printf "\b⠦" ;;
+      7) printf "\b⠧" ;;
+      8) printf "\b⠇" ;;
+      9) printf "\b⠏" ;;
+    esac
+    i=`expr ${i} + 1`
+    # change the speed of the spinner by altering the 1 below
+    sleep 1
   done
 ) 1>&2 &
+
+function exit_newline {
+  echo ""
+}
+trap exit_newline EXIT
 
 spinner_pid=$!
 


### PR DESCRIPTION
Ugh, this alpine linux image has a real weird implementation of `ps`, couldn't find the right man pages for it and it's help command is useless. A bit of trial and error though and I landed on the following for a decent logging of memory usage during the build job:

```
- run:
          command: |
            while true; do
              sleep 5
              echo "====="
              ps -eo comm,vsz,rss | sort -k 3 -nr
              echo "====="
            done 
          background: true
```

(sorting's not perfect because the output mixes units, ah well)
![image](https://user-images.githubusercontent.com/11301919/98963866-20fd3b00-24d6-11eb-84f8-679f4c85e32a.png)

Ignore the `sh`. Those four nodes are the parallel prod builds. First memory column is "vsz", basically the max amount the system will let the process use. Second is actual usage. Whole container only has 4GB available though and will exit if it's all used (CircleCI doesn't allow swap/virtual memory, boo).

Not clear what changed to push the build jobs to suddenly start eating up more than a gig each. Individually, they still barely hit 1 gig in general though, so when it's failing it's only just barely. 

Options:
  1) stop running all four build in parallel
  2) dig in to the node/V8 config options, may be able to limit the individual memory limits (but will the builds be able to run to completion with limited memory? Gonna take some testing)

**Edit:** so what I've done is add some new options to the InfoBase `build_all.sh` script. One for choosing build concurrency ("full" for all four at once, "half" to run the two standard and two a11y in pairs, and "none" to run all four in series), and one's just an easy way to pass down the `max_old_space_size` value to the node process for each build.

Setting a `max_old_space_size` of 256 is maybe enough to get us back under memory budget (default is 512). `max_old_space_size` doesn't set a hard limit, it just tells V8 when to start spending time on garbage collection. If the build process actually need all the memory they've been using then it can't help us. Worst case we start using the "half" flag in CI and live with a slightly longer build step.