### PR TITLE
Treemap page flex layout

### DIFF
--- a/client/src/TreeMap/TreeMap.js
+++ b/client/src/TreeMap/TreeMap.js
@@ -521,9 +521,9 @@ export default class TreeMapper extends React.Component {
               </button>
               <TreeMapInstructions />
               {actual_to_planned_gap_year && <GapYearWarning />}
-              <div className="row">
-                <div className="col-md-10">
-                  <div className="row">
+              <div className="frow">
+                <div className="fcol-md-10">
+                  <div className="frow">
                     <div
                       className="TreeMap__TopBar"
                       style={{ minHeight: `${topbar_height}px` }}
@@ -558,7 +558,7 @@ export default class TreeMapper extends React.Component {
                       viz_height={app_height - topbar_height}
                     />
                   </div>
-                  <div className="row">
+                  <div className="frow">
                     <TreeMapLegend
                       perspective={perspective}
                       legend_cols={get_legend_cols(
@@ -578,7 +578,7 @@ export default class TreeMapper extends React.Component {
                   </div>
                 </div>
                 <div
-                  className="col-md-2 TreeMap__SideBar"
+                  className="fcol-md-2 TreeMap__SideBar"
                   style={{ padding: "0px", minHeight: `${app_height + 9}px` }}
                 >
                   <TreeMapSidebar

--- a/client/src/TreeMap/TreeMap.scss
+++ b/client/src/TreeMap/TreeMap.scss
@@ -14,10 +14,14 @@ $treeMapTooltipColor: $primaryColor;
 .TreeMap__Wrapper {
   background: none;
 }
+.TreeMap__Root {
+  width:100%;
+}
 .TreeMap__TopBar {
   background-color: $treeMapBackgroundColor;
   height: 100%;
   border: 2px solid white;
+  width:100%;
 }
 .TreeMap__Mainviz{
   background-color: $treeMapBackgroundColor;

--- a/client/src/TreeMap/TreeMapInstructions.js
+++ b/client/src/TreeMap/TreeMapInstructions.js
@@ -14,8 +14,8 @@ export class TreeMapInstructions extends React.Component {
   render() {
     return (
       <Fragment>
-        <div className="row">
-          <div className="col-sm-12 col-md-12">
+        <div className="frow">
+          <div className="fcol-sm-12 fcol-md-12">
             <div
               className="explore_description"
               dangerouslySetInnerHTML={{

--- a/client/src/TreeMap/TreeMapLegend.js
+++ b/client/src/TreeMap/TreeMapLegend.js
@@ -89,27 +89,27 @@ export class TreeMapLegend extends React.Component {
     const { perspective, legend_cols, legend_measure_text } = this.props;
     return (
       <Fragment>
-        <div className="row" style={{ marginLeft: "0px", marginRight: "0px" }}>
-          <div className="col-sm-5">
+        <div className="frow" style={{ marginLeft: "0px", marginRight: "0px" }}>
+          <div className="fcol-sm-5">
             <div
-              className="row"
+              className="frow"
               style={{ marginLeft: "0px", marginRight: "0px" }}
             >
               <div
-                className="col-sm-4"
+                className="fcol-sm-4"
                 style={{ textAlign: "right", paddingRight: "0px" }}
               >
                 {proportional_block()}
               </div>
-              <div className="col-sm-8">
+              <div className="fcol-sm-8">
                 {`${text_maker("treemap_legend_text")} ${
                   size_controls[perspective]
                 }.`}
               </div>
             </div>
           </div>
-          <div className="col-sm-7">
-            <div className="row" style={{ textAlign: "center" }}>
+          <div className="fcol-sm-7">
+            <div className="frow" style={{ textAlign: "center" }}>
               <svg width={`${legend_cols.length * 60 + 10}`} height="50">
                 <g className="mutLegendGroup" transform="translate(0,0)">
                   <rect
@@ -125,7 +125,7 @@ export class TreeMapLegend extends React.Component {
                 </g>
               </svg>
             </div>
-            <div className="row" style={{ textAlign: "center" }}>
+            <div className="frow" style={{ textAlign: "center" }}>
               <span style={{ paddingTop: "40px", paddingBottom: "40px" }}>
                 {legend_measure_text}
               </span>

--- a/client/src/TreeMap/TreeMapViz.js
+++ b/client/src/TreeMap/TreeMapViz.js
@@ -14,7 +14,7 @@ export class TreeMap extends React.Component {
     this.state = { org_route: [...props.org_route] };
   }
   render() {
-    return <div ref={(div) => (this.el = div)} />;
+    return <div className="TreeMap__Root" ref={(div) => (this.el = div)} />;
   }
   _update = () => {
     this._imperative_render();


### PR DESCRIPTION
Got the treemap working with bootstrap4. The treemap page has always had problems with flex, so we probably used the old classes (`col-*-*`,`row`, not  `fcol` and `frow`) to in order to use float-based columns instead. Once we upgraded to bootstrap 4, the float styles were replaced with flex, and the treemap was once again broken. It looks like we just needed to add a few `width:100%` to get the whole thing working again

Tested it with chrome and FF. Assuming we're going to test the rest of the BS4 upgrade against IE11, we should have a quick glance at this page too. 