### PR TITLE
Unpin key concepts if quick link to panel

### DIFF
--- a/client/src/hoc/PinnedContent.js
+++ b/client/src/hoc/PinnedContent.js
@@ -1,4 +1,5 @@
 import classNames from "classnames";
+import { withRouter } from "react-router";
 import { InView } from "react-intersection-observer";
 import "intersection-observer";
 import ReactResizeDetector from "react-resize-detector";
@@ -13,123 +14,130 @@ import text from "./PinnedContent.yaml";
 
 const text_maker = create_text_maker(text);
 
-export class PinnedContent extends React.Component {
-  constructor(props) {
-    super(props);
+export const PinnedContent = withRouter(
+  class extends React.Component {
+    constructor(props) {
+      super(props);
 
-    const local_storage_name = props.local_storage_name;
+      const {
+        match: {
+          params: { options: panel_link },
+        },
+      } = props;
 
-    let user_enabled_pinning;
-    if (has_local_storage) {
-      try {
-        user_enabled_pinning = JSON.parse(
-          localStorage.getItem(local_storage_name)
-        );
-        user_enabled_pinning = _.isBoolean(user_enabled_pinning)
-          ? user_enabled_pinning
-          : true;
-      } catch {
-        user_enabled_pinning = true;
+      const local_storage_name = props.local_storage_name;
+
+      let user_enabled_pinning;
+      if (has_local_storage) {
+        try {
+          user_enabled_pinning = JSON.parse(
+            localStorage.getItem(local_storage_name)
+          );
+          user_enabled_pinning = _.isBoolean(user_enabled_pinning)
+            ? user_enabled_pinning
+            : true;
+        } catch {
+          user_enabled_pinning = true;
+        }
       }
+
+      if (panel_link) {
+        user_enabled_pinning = false;
+      }
+
+      this.state = {
+        user_enabled_pinning: user_enabled_pinning,
+      };
     }
 
-    this.state = {
-      user_enabled_pinning: user_enabled_pinning,
+    pin_pressed = () => {
+      const { local_storage_name } = this.props;
+      const { user_enabled_pinning } = this.state;
+      this.setState({
+        user_enabled_pinning: !user_enabled_pinning,
+      });
+      localStorage.setItem(local_storage_name, !user_enabled_pinning);
     };
-  }
 
-  componentDidUpdate(prev_props, prev_state) {
-    localStorage.setItem(
-      prev_props.local_storage_name,
-      !prev_state.user_enabled_pinning
-    );
-  }
+    handleKeyDown = (e) => {
+      if (e.key == "Tab") {
+        this.setState({ user_enabled_pinning: false });
+      }
+    };
 
-  pin_pressed = () => {
-    const { user_enabled_pinning } = this.state;
-    this.setState({
-      user_enabled_pinning: !user_enabled_pinning,
-    });
-  };
+    render() {
+      const { user_enabled_pinning } = this.state;
+      const { children } = this.props;
 
-  handleKeyDown = (e) => {
-    if (e.key == "Tab") {
-      this.setState({ user_enabled_pinning: false });
-    }
-  };
-
-  render() {
-    const { user_enabled_pinning } = this.state;
-    const { children } = this.props;
-
-    return !window.is_a11y_mode ? (
-      <ReactResizeDetector handleWidth>
-        {({ width }) => (
-          <InView>
-            {({ inView, ref, entry }) => (
-              // this div is for the intersection check
-              <div ref={ref}>
-                {/* this div is for sticky styline */}
-                <div
-                  className={classNames(
-                    !inView &&
-                      user_enabled_pinning &&
-                      entry &&
-                      entry.boundingClientRect.top < 0 &&
-                      "sticky"
-                  )}
-                  style={{
-                    width: width,
-                  }}
-                >
-                  <div style={{ position: "relative" }}>
-                    {children}
-                    <div
-                      style={{
-                        position: "absolute",
-                        top: "1rem",
-                        right: "1rem",
-                      }}
-                    >
-                      <button
-                        onClick={this.pin_pressed}
+      return !window.is_a11y_mode ? (
+        <ReactResizeDetector handleWidth>
+          {({ width }) => (
+            <InView>
+              {({ inView, ref, entry }) => (
+                // this div is for the intersection check
+                <div ref={ref}>
+                  {/* this div is for sticky styline */}
+                  <div
+                    className={classNames(
+                      !inView &&
+                        user_enabled_pinning &&
+                        entry &&
+                        entry.boundingClientRect.top < 0 &&
+                        "sticky"
+                    )}
+                    style={{
+                      width: width,
+                    }}
+                  >
+                    <div style={{ position: "relative" }}>
+                      {children}
+                      <div
                         style={{
-                          background: "none",
-                          border: "none",
+                          position: "absolute",
+                          top: "1rem",
+                          right: "1rem",
                         }}
-                        aria-label={text_maker(
-                          user_enabled_pinning ? "unpin" : "pin"
-                        )}
-                        onKeyDown={this.handleKeyDown}
                       >
-                        {user_enabled_pinning ? (
-                          <IconPin
-                            height="25px"
-                            width="25px"
-                            vertical_align="top"
-                            color={backgroundColor}
-                            alternate_color="false"
-                          />
-                        ) : (
-                          <IconUnpin
-                            height="25px"
-                            width="25px"
-                            vertical_align="top"
-                            color={backgroundColor}
-                            alternate_color="false"
-                          />
-                        )}
-                      </button>
+                        <button
+                          onClick={this.pin_pressed}
+                          style={{
+                            background: "none",
+                            border: "none",
+                          }}
+                          aria-label={text_maker(
+                            user_enabled_pinning ? "unpin" : "pin"
+                          )}
+                          onKeyDown={this.handleKeyDown}
+                        >
+                          {user_enabled_pinning ? (
+                            <IconPin
+                              height="25px"
+                              width="25px"
+                              vertical_align="top"
+                              color={backgroundColor}
+                              alternate_color="false"
+                            />
+                          ) : (
+                            <IconUnpin
+                              height="25px"
+                              width="25px"
+                              vertical_align="top"
+                              color={backgroundColor}
+                              alternate_color="false"
+                            />
+                          )}
+                        </button>
+                      </div>
                     </div>
                   </div>
                 </div>
-              </div>
-            )}
-          </InView>
-        )}
-      </ReactResizeDetector>
-    ) : (
-      children
-    );
+              )}
+            </InView>
+          )}
+        </ReactResizeDetector>
+      ) : (
+        children
+      );
+    }
   }
-}
+);

--- a/client/src/hoc/PinnedContent.js
+++ b/client/src/hoc/PinnedContent.js
@@ -1,8 +1,8 @@
 import classNames from "classnames";
-import { withRouter } from "react-router";
 import { InView } from "react-intersection-observer";
 import "intersection-observer";
 import ReactResizeDetector from "react-resize-detector";
+import { withRouter } from "react-router";
 
 import { has_local_storage } from "src/core/feature_detection.js";
 
@@ -23,9 +23,8 @@ export const PinnedContent = withRouter(
         match: {
           params: { options: panel_link },
         },
+        local_storage_name,
       } = props;
-
-      const local_storage_name = props.local_storage_name;
 
       let user_enabled_pinning;
       if (has_local_storage) {
@@ -53,10 +52,10 @@ export const PinnedContent = withRouter(
     pin_pressed = () => {
       const { local_storage_name } = this.props;
       const { user_enabled_pinning } = this.state;
+      localStorage.setItem(local_storage_name, !user_enabled_pinning);
       this.setState({
         user_enabled_pinning: !user_enabled_pinning,
       });
-      localStorage.setItem(local_storage_name, !user_enabled_pinning);
     };
 
     handleKeyDown = (e) => {


### PR DESCRIPTION
I had to move the localstorage code from `componentdidupdate` back into the `pinpressed` to prevent the key concepts from unpinning when changing to another page or staying pinned when changing from a previous page.

The only time it would pin now is if the user is already on the page where the panel is.
For example going to a panel in results while in results will keep the key concepts pinned (assuming that the pin was already active)