### PR TITLE
People panel text calculation cleanup

### DIFF
--- a/client/src/panels/panel_declarations/people/calculate_common_text_args.js
+++ b/client/src/panels/panel_declarations/people/calculate_common_text_args.js
@@ -1,7 +1,10 @@
 import { run_template, year_templates } from "../shared.js";
 const { people_years } = year_templates;
 
-export const text_calculate = (all_data, alternate_five_year_total = false) => {
+export const calculate_common_text_args = (
+  all_data,
+  alternate_five_year_total = false
+) => {
   const [first_active_year_index, last_active_year_index] = _.chain(all_data)
     .map("data")
     .thru((data_by_group) => _.zip(...data_by_group))

--- a/client/src/panels/panel_declarations/people/employee_age.js
+++ b/client/src/panels/panel_declarations/people/employee_age.js
@@ -135,7 +135,7 @@ export const declare_employee_age_panel = () =>
           ...common_text_calculations,
           ..._.chain(["top", "bottom"])
             .map((key_prefix) => {
-              const key = `${key_prefix}_group`;
+              const key = `${key_prefix}_avg_group`;
               return [
                 key,
                 window.lang === "en"

--- a/client/src/panels/panel_declarations/people/employee_age.js
+++ b/client/src/panels/panel_declarations/people/employee_age.js
@@ -14,7 +14,7 @@ import {
   NivoLineBarToggle,
 } from "../shared.js";
 
-import { text_calculate } from "./text_calculator.js";
+import { calculate_common_text_args } from "./calculate_common_text_args.js";
 
 import text from "./employee_age.yaml";
 
@@ -129,18 +129,18 @@ export const declare_employee_age_panel = () =>
         const gov_avgage_last_year_5 = _.first(avg_age[0].data);
         const gov_avgage_last_year = _.last(avg_age[0].data);
 
-        const common_text_calculations = text_calculate(age_group);
+        const common_text_args = calculate_common_text_args(age_group);
 
         const text_calculations = {
-          ...common_text_calculations,
+          ...common_text_args,
           ..._.chain(["top", "bottom"])
             .map((key_prefix) => {
               const key = `${key_prefix}_avg_group`;
               return [
                 key,
                 window.lang === "en"
-                  ? common_text_calculations[key]?.replace("Age ", "")
-                  : common_text_calculations[key],
+                  ? common_text_args[key]?.replace("Age ", "")
+                  : common_text_args[key],
               ];
             })
             .fromPairs()

--- a/client/src/panels/panel_declarations/people/employee_age.js
+++ b/client/src/panels/panel_declarations/people/employee_age.js
@@ -129,8 +129,22 @@ export const declare_employee_age_panel = () =>
         const gov_avgage_last_year_5 = _.first(avg_age[0].data);
         const gov_avgage_last_year = _.last(avg_age[0].data);
 
+        const common_text_calculations = text_calculate(age_group);
+
         const text_calculations = {
-          ...text_calculate(age_group),
+          ...common_text_calculations,
+          ..._.chain(["top", "bottom"])
+            .map((key_prefix) => {
+              const key = `${key_prefix}_group`;
+              return [
+                key,
+                window.lang === "en"
+                  ? common_text_calculations[key]?.replace("Age ", "")
+                  : common_text_calculations[key],
+              ];
+            })
+            .fromPairs()
+            .value(),
           dept_avg_first_active_year,
           dept_avg_last_active_year,
           gov_avgage_last_year_5,

--- a/client/src/panels/panel_declarations/people/employee_age.yaml
+++ b/client/src/panels/panel_declarations/people/employee_age.yaml
@@ -6,23 +6,23 @@ employee_age_title:
 gov_employee_age_text:
   transform: [handlebars,markdown]
   en: |
-   From **{{ppl_last_year_5}}** to **{{ppl_last_year}}**, people aged **{{fmt_big_int top_group}}** accounted for the largest average share (**{{fmt_percentage1 top_group_avg_pct}}**) of **Federal Public Service** employees.
+   From **{{ppl_last_year_5}}** to **{{ppl_last_year}}**, people aged **{{fmt_big_int top_avg_group}}** accounted for the largest average share (**{{fmt_percentage1 top_avg_group_share}}**) of **Federal Public Service** employees.
    
    Over this period, the **average age** of **Federal Public Service** employees **{{two_value_changed_to gov_avgage_last_year_5 gov_avgage_last_year "fmt_decimal1"}}**.
   fr: |
-   De **{{ppl_last_year_5}}** à **{{ppl_last_year}}**, les personnes âgées de **{{fmt_big_int top_group}}** constituaient en moyenne le plus fort contingent (**{{fmt_percentage1 top_group_avg_pct}}**) du personnel de la **fonction publique fédérale**.
+   De **{{ppl_last_year_5}}** à **{{ppl_last_year}}**, les personnes âgées de **{{fmt_big_int top_avg_group}}** constituaient en moyenne le plus fort contingent (**{{fmt_percentage1 top_avg_group_share}}**) du personnel de la **fonction publique fédérale**.
 
    Au cours de cette période, **l’âge moyen** des employés de la **fonction publique fédérale** **{{fr_two_value_changed_to gov_avgage_last_year_5 gov_avgage_last_year "m" "s" "fmt_decimal1"}}**.
 
 dept_employee_age_text:
   transform: [handlebars,markdown]
   en: |
-   From **{{fmt_big_int first_active_year}}** to **{{fmt_big_int last_active_year}}**, people aged **{{fmt_big_int top_group}}** accounted for the largest average share (**{{fmt_percentage1 top_group_avg_pct}}**) of **{{subject.name}}** employees.
+   From **{{fmt_big_int first_active_year}}** to **{{fmt_big_int last_active_year}}**, people aged **{{fmt_big_int top_avg_group}}** accounted for the largest average share (**{{fmt_percentage1 top_avg_group_share}}**) of **{{subject.name}}** employees.
 
    Over this period, the **average age** of **{{subject.name}}** employees **{{two_value_changed_to dept_avg_first_active_year dept_avg_last_active_year "fmt_decimal1"}}**.
    For comparison, the average age of all **Federal Public Service** employees **{{two_value_changed_to gov_avgage_last_year_5 gov_avgage_last_year "fmt_decimal1"}}**.
   fr: |
-   De **{{fmt_big_int first_active_year}}** à **{{fmt_big_int last_active_year}}**, les personnes âgées de **{{fmt_big_int top_group}}** constituaient en moyenne le plus fort contingent (**{{fmt_percentage1 top_group_avg_pct}}**) d’employés **{{subject.name}}**.
+   De **{{fmt_big_int first_active_year}}** à **{{fmt_big_int last_active_year}}**, les personnes âgées de **{{fmt_big_int top_avg_group}}** constituaient en moyenne le plus fort contingent (**{{fmt_percentage1 top_avg_group_share}}**) d’employés **{{subject.name}}**.
 
    Au cours de cette période, **l’âge moyen** des employés **{{subject.name}}** **{{fr_two_value_changed_to dept_avg_first_active_year dept_avg_last_active_year "m" "s" "fmt_decimal1"}}**.
    Aux fins de comparaison, l’âge moyen de tous les employés de la **fonction publique fédérale** **{{fr_two_value_changed_to gov_avgage_last_year_5 gov_avgage_last_year "m" "s" "fmt_decimal1"}}**.
@@ -30,15 +30,15 @@ dept_employee_age_text:
 gov_employee_age_text_temporary_no_avg_age:
   transform: [handlebars,markdown]
   en: |
-   From **{{ppl_last_year_5}}** to **{{ppl_last_year}}**, people aged **{{fmt_big_int top_group}}** accounted for the largest average share (**{{fmt_percentage1 top_group_avg_pct}}**) of **Federal Public Service** employees.
+   From **{{ppl_last_year_5}}** to **{{ppl_last_year}}**, people aged **{{fmt_big_int top_avg_group}}** accounted for the largest average share (**{{fmt_percentage1 top_avg_group_share}}**) of **Federal Public Service** employees.
    
   fr: |
-   De **{{ppl_last_year_5}}** à **{{ppl_last_year}}**, les personnes âgées de **{{fmt_big_int top_group}}** constituaient en moyenne le plus fort contingent (**{{fmt_percentage1 top_group_avg_pct}}**) du personnel de la **fonction publique fédérale**.
+   De **{{ppl_last_year_5}}** à **{{ppl_last_year}}**, les personnes âgées de **{{fmt_big_int top_avg_group}}** constituaient en moyenne le plus fort contingent (**{{fmt_percentage1 top_avg_group_share}}**) du personnel de la **fonction publique fédérale**.
 
 dept_employee_age_text_temporary_no_avg_age:
   transform: [handlebars,markdown]
   en: |
-   From **{{fmt_big_int first_active_year}}** to **{{fmt_big_int last_active_year}}**, people aged **{{fmt_big_int top_group}}** accounted for the largest average share (**{{fmt_percentage1 top_group_avg_pct}}**) of **{{subject.name}}** employees.
+   From **{{fmt_big_int first_active_year}}** to **{{fmt_big_int last_active_year}}**, people aged **{{fmt_big_int top_avg_group}}** accounted for the largest average share (**{{fmt_percentage1 top_avg_group_share}}**) of **{{subject.name}}** employees.
 
   fr: |
-   De **{{fmt_big_int first_active_year}}** à **{{fmt_big_int last_active_year}}**, les personnes âgées de **{{fmt_big_int top_group}}** constituaient en moyenne le plus fort contingent (**{{fmt_percentage1 top_group_avg_pct}}**) d’employés **{{subject.name}}**.
+   De **{{fmt_big_int first_active_year}}** à **{{fmt_big_int last_active_year}}**, les personnes âgées de **{{fmt_big_int top_avg_group}}** constituaient en moyenne le plus fort contingent (**{{fmt_percentage1 top_avg_group_share}}**) d’employés **{{subject.name}}**.

--- a/client/src/panels/panel_declarations/people/employee_executive_level.js
+++ b/client/src/panels/panel_declarations/people/employee_executive_level.js
@@ -10,7 +10,7 @@ import {
   NivoLineBarToggle,
 } from "../shared.js";
 
-import { text_calculate } from "./text_calculator.js";
+import { calculate_common_text_args } from "./calculate_common_text_args.js";
 
 import text from "./employee_executive_level.yaml";
 
@@ -97,7 +97,7 @@ export const declare_employee_executive_level_panel = () =>
         const text_calculations = (() => {
           if (has_non_ex_only) {
             return {
-              ...text_calculate(series),
+              ...calculate_common_text_args(series),
               subject,
               avg_num_non_ex: _.chain(series)
                 .first(({ label }) => label === "Non-EX")
@@ -116,7 +116,7 @@ export const declare_employee_executive_level_panel = () =>
               0
             );
 
-            const standard_text_calculations = text_calculate(
+            const common_text_args = calculate_common_text_args(
               ex_only_series,
               sum_exec
             );
@@ -124,7 +124,7 @@ export const declare_employee_executive_level_panel = () =>
             const {
               first_active_year_index,
               last_active_year_index,
-            } = standard_text_calculations;
+            } = common_text_args;
 
             const avg_num_employees =
               _.reduce(
@@ -139,7 +139,7 @@ export const declare_employee_executive_level_panel = () =>
             const avg_pct_execs = avg_num_execs / avg_num_employees;
 
             return {
-              ...standard_text_calculations,
+              ...common_text_args,
               subject,
               avg_num_execs,
               avg_pct_execs,

--- a/client/src/panels/panel_declarations/people/employee_executive_level.yaml
+++ b/client/src/panels/panel_declarations/people/employee_executive_level.yaml
@@ -8,13 +8,13 @@ gov_employee_executive_level_text:
   en: |
    From **{{ppl_last_year_5}}** to **{{ppl_last_year}}**, an average of **{{fmt_big_int avg_num_execs}}** **Federal Public Service** employees occupied a position at the executive level, representing an average of **{{fmt_percentage1 avg_pct_execs}}** of the total **Federal Public Service** population.
    
-   Over this period, employees at the **{{fmt_big_int top_group}}** level accounted for the largest executive group with an average share of **{{fmt_percentage1 top_group_avg_pct}}** of the total executive population.
-   The smallest executive group was the **{{fmt_big_int bottom_group}}** level, with an average share of **{{fmt_percentage1 bottom_group_avg_pct}}** of the total executive population.
+   Over this period, employees at the **{{fmt_big_int top_avg_group}}** level accounted for the largest executive group with an average share of **{{fmt_percentage1 top_avg_group_share}}** of the total executive population.
+   The smallest executive group was the **{{fmt_big_int bottom_avg_group}}** level, with an average share of **{{fmt_percentage1 bottom_avg_group_share}}** of the total executive population.
   fr: |
    De **{{ppl_last_year_5}}** à **{{ppl_last_year}}**, en moyenne, **{{fmt_big_int avg_num_execs}}** employés de la **fonction publique fédérale** occupaient un poste de direction, soit **{{fmt_percentage1 avg_pct_execs}}** du nombre moyen de personnel. 
    
-   Au cours de cette période, les employés de niveau **{{fmt_big_int top_group}}** constituaient le plus fort contingent, avec une moyenne de **{{fmt_percentage1 top_group_avg_pct}}** du nombre total de cadres de direction. 
-   Le niveau **{{fmt_big_int bottom_group}}** formait le plus petit contingent, avec une moyenne de **{{fmt_percentage1 bottom_group_avg_pct}}** du numbre total de cadres de direction.
+   Au cours de cette période, les employés de niveau **{{fmt_big_int top_avg_group}}** constituaient le plus fort contingent, avec une moyenne de **{{fmt_percentage1 top_avg_group_share}}** du nombre total de cadres de direction. 
+   Le niveau **{{fmt_big_int bottom_avg_group}}** formait le plus petit contingent, avec une moyenne de **{{fmt_percentage1 bottom_avg_group_share}}** du numbre total de cadres de direction.
 
 
 dept_employee_executive_level_text:
@@ -22,16 +22,16 @@ dept_employee_executive_level_text:
   en: |
    From **{{fmt_big_int first_active_year}}** to **{{fmt_big_int last_active_year}}**, an average of **{{fmt_big_int avg_num_execs}}** **{{subject.name}}** employees occupied a position at the executive level, representing an average share of **{{fmt_percentage1 avg_pct_execs}}** of its total population.
    
-   Over this period, employees at the **{{fmt_big_int top_group}}** level accounted for the largest executive group with an average share of **{{fmt_percentage1 top_group_avg_pct}}** of **{{subject.name}}'s** executive population.
-   {{#if bottom_group}}
-     The smallest executive group was the **{{fmt_big_int bottom_group}}** level, with an average share of **{{fmt_percentage1 bottom_group_avg_pct}}** of **{{subject.name}}'s** executive population.
+   Over this period, employees at the **{{fmt_big_int top_avg_group}}** level accounted for the largest executive group with an average share of **{{fmt_percentage1 top_avg_group_share}}** of **{{subject.name}}'s** executive population.
+   {{#if bottom_avg_group}}
+     The smallest executive group was the **{{fmt_big_int bottom_avg_group}}** level, with an average share of **{{fmt_percentage1 bottom_avg_group_share}}** of **{{subject.name}}'s** executive population.
    {{/if}}
   fr: |
    De **{{fmt_big_int first_active_year}}** à **{{fmt_big_int last_active_year}}**, en moyenne, **{{fmt_big_int avg_num_execs}}** employés **{{subject.name}}** occupaient un poste de direction, soit **{{fmt_percentage1 avg_pct_execs}}** du nombre moyen de personnel.
    
-   Au cours de cette période, les employés de niveau **{{fmt_big_int top_group}}** constituaient le plus fort contingent, avec une moyenne de **{{fmt_percentage1 top_group_avg_pct}}** du nombre total de cadres de direction **{{subject.name}}**. 
-   {{#if bottom_group}}
-     Le niveau **{{fmt_big_int bottom_group}}** formait le plus petit contingent, avec une moyenne de **{{fmt_percentage1 bottom_group_avg_pct}}** du numbre total de cadres de direction.
+   Au cours de cette période, les employés de niveau **{{fmt_big_int top_avg_group}}** constituaient le plus fort contingent, avec une moyenne de **{{fmt_percentage1 top_avg_group_share}}** du nombre total de cadres de direction **{{subject.name}}**. 
+   {{#if bottom_avg_group}}
+     Le niveau **{{fmt_big_int bottom_avg_group}}** formait le plus petit contingent, avec une moyenne de **{{fmt_percentage1 bottom_avg_group_share}}** du numbre total de cadres de direction.
    {{/if}}
 
 all_non_executive_employee_text:

--- a/client/src/panels/panel_declarations/people/employee_executive_level.yaml
+++ b/client/src/panels/panel_declarations/people/employee_executive_level.yaml
@@ -36,5 +36,5 @@ dept_employee_executive_level_text:
 
 all_non_executive_employee_text:
   transform: [handlebars,markdown]
-  en: From **{{fmt_big_int first_active_year}}** to **{{fmt_big_int last_active_year}}**, an average of **{{fmt_big_int avg_num_non_ex}}** **{{subject.name}}** employees occupied a position at the Non-EX level (100%).
-  fr: De **{{fmt_big_int first_active_year}}** à **{{fmt_big_int last_active_year}}**, en moyenne, **{{fmt_big_int avg_num_non_ex}}** employés **{{subject.name}}** occupaient un poste de non-direction (100%).
+  en: From **{{fmt_big_int first_active_year}}** to **{{fmt_big_int last_active_year}}**, an average of **{{fmt_big_int avg_num_non_ex}}** **{{subject.name}}** employees occupied a position at the Non-EX level, representing **100%** of its total population.
+  fr: De **{{fmt_big_int first_active_year}}** à **{{fmt_big_int last_active_year}}**, en moyenne, **{{fmt_big_int avg_num_non_ex}}** employés **{{subject.name}}** occupaient un poste de non-direction, soit **100%** du nombre de personnel.

--- a/client/src/panels/panel_declarations/people/employee_fol.js
+++ b/client/src/panels/panel_declarations/people/employee_fol.js
@@ -10,7 +10,7 @@ import {
   NivoLineBarToggle,
 } from "../shared.js";
 
-import { text_calculate } from "./text_calculator.js";
+import { calculate_common_text_args } from "./calculate_common_text_args.js";
 
 import text from "./employee_fol.yaml";
 
@@ -99,7 +99,7 @@ export const declare_employee_fol_panel = () =>
         })();
 
         const text_calculations = {
-          ...text_calculate(text_groups),
+          ...calculate_common_text_args(text_groups),
           single_type_flag: text_groups.length === 1,
           subject,
         };

--- a/client/src/panels/panel_declarations/people/employee_fol.yaml
+++ b/client/src/panels/panel_declarations/people/employee_fol.yaml
@@ -6,14 +6,14 @@ employee_fol_title:
 gov_employee_fol_text:
   transform: [handlebars,markdown]
   en: |
-    From **{{ppl_last_year_5}}** to **{{ppl_last_year}}**, an average of **{{fmt_percentage1 top_group_avg_pct}}** of **Federal Public Service** employees had **{{top_group}}** as their {{gl_tt "First Official Language" "FOL"}},
-    while an average of **{{fmt_percentage1 bottom_group_avg_pct}}** had **{{bottom_group}}**.
+    From **{{ppl_last_year_5}}** to **{{ppl_last_year}}**, an average of **{{fmt_percentage1 top_avg_group_share}}** of **Federal Public Service** employees had **{{top_avg_group}}** as their {{gl_tt "First Official Language" "FOL"}},
+    while an average of **{{fmt_percentage1 bottom_avg_group_share}}** had **{{bottom_avg_group}}**.
   fr: |
-    De **{{ppl_last_year_5}}** à **{{ppl_last_year}}**, **{{fmt_percentage1 top_group_avg_pct}}** des employés de la **fonction publique fédérale**, en moyenne, avait {{#isEqual top_group "Anglais"}}l'{{else}}le {{/isEqual}}**{{top_group}}** comme {{gl_tt "première langue officielle" "FOL"}}, comparativement à **{{fmt_percentage1 bottom_group_avg_pct}}** pour {{#isEqual bottom_group "Anglais"}}l'{{else}}le {{/isEqual}}**{{bottom_group}}**.
+    De **{{ppl_last_year_5}}** à **{{ppl_last_year}}**, **{{fmt_percentage1 top_avg_group_share}}** des employés de la **fonction publique fédérale**, en moyenne, avait {{#isEqual top_avg_group "Anglais"}}l'{{else}}le {{/isEqual}}**{{top_avg_group}}** comme {{gl_tt "première langue officielle" "FOL"}}, comparativement à **{{fmt_percentage1 bottom_avg_group_share}}** pour {{#isEqual bottom_avg_group "Anglais"}}l'{{else}}le {{/isEqual}}**{{bottom_avg_group}}**.
 
 dept_employee_fol_text:
   transform: [handlebars,markdown]
   en: |
-    From **{{first_active_year}}** to **{{last_active_year}}**, an average of **{{fmt_percentage1 top_group_avg_pct}}** of **{{subject.name}}** employees had **{{top_group}}** as their {{gl_tt "First Official Language" "FOL"}}{{#isEqual single_type_flag true}}.{{else}}, while an average of **{{fmt_percentage1 bottom_group_avg_pct}}** had **{{bottom_group}}**.{{/isEqual}} 
+    From **{{first_active_year}}** to **{{last_active_year}}**, an average of **{{fmt_percentage1 top_avg_group_share}}** of **{{subject.name}}** employees had **{{top_avg_group}}** as their {{gl_tt "First Official Language" "FOL"}}{{#isEqual single_type_flag true}}.{{else}}, while an average of **{{fmt_percentage1 bottom_avg_group_share}}** had **{{bottom_avg_group}}**.{{/isEqual}} 
   fr: |
-    De **{{first_active_year}}** à **{{last_active_year}}**, **{{fmt_percentage1 top_group_avg_pct}}** des employés **{{subject.name}}**, en moyenne, avait {{#isEqual top_group "Anglais"}}l'{{else}}le {{/isEqual}}**{{top_group}}** comme {{gl_tt "première langue officielle" "FOL"}}{{#isEqual single_type_flag true}}.{{else}}, comparativement à **{{fmt_percentage1 bottom_group_avg_pct}}** pour {{#isEqual bottom_group "Anglais"}}l'{{else}}le {{/isEqual}}**{{bottom_group}}**.{{/isEqual}}
+    De **{{first_active_year}}** à **{{last_active_year}}**, **{{fmt_percentage1 top_avg_group_share}}** des employés **{{subject.name}}**, en moyenne, avait {{#isEqual top_avg_group "Anglais"}}l'{{else}}le {{/isEqual}}**{{top_avg_group}}** comme {{gl_tt "première langue officielle" "FOL"}}{{#isEqual single_type_flag true}}.{{else}}, comparativement à **{{fmt_percentage1 bottom_avg_group_share}}** pour {{#isEqual bottom_avg_group "Anglais"}}l'{{else}}le {{/isEqual}}**{{bottom_avg_group}}**.{{/isEqual}}

--- a/client/src/panels/panel_declarations/people/employee_gender.js
+++ b/client/src/panels/panel_declarations/people/employee_gender.js
@@ -10,7 +10,7 @@ import {
   NivoLineBarToggle,
 } from "../shared.js";
 
-import { text_calculate } from "./text_calculator.js";
+import { calculate_common_text_args } from "./calculate_common_text_args.js";
 
 import text from "./employee_gender.yaml";
 
@@ -100,7 +100,7 @@ export const declare_employee_gender_panel = () =>
         })();
 
         const text_calculations = {
-          ...text_calculate(text_groups),
+          ...calculate_common_text_args(text_groups),
           single_type_flag: text_groups.length === 1,
           subject,
         };

--- a/client/src/panels/panel_declarations/people/employee_gender.yaml
+++ b/client/src/panels/panel_declarations/people/employee_gender.yaml
@@ -6,15 +6,15 @@ employee_gender_title:
 gov_employee_gender_text:
   transform: [handlebars,markdown]
   en: |
-    From **{{ppl_last_year_5}}** to **{{ppl_last_year}}**, **{{top_group}}** accounted for an average of **{{fmt_percentage1 top_group_avg_pct}}** of the **Federal Public Service**,
-    while **{{bottom_group}}** accounted for an average of **{{fmt_percentage1 bottom_group_avg_pct}}**.
+    From **{{ppl_last_year_5}}** to **{{ppl_last_year}}**, **{{top_avg_group}}** accounted for an average of **{{fmt_percentage1 top_avg_group_share}}** of the **Federal Public Service**,
+    while **{{bottom_avg_group}}** accounted for an average of **{{fmt_percentage1 bottom_avg_group_share}}**.
   fr: |
-    De **{{ppl_last_year_5}}** à **{{ppl_last_year}}**, les **{{top_group}}** constituaient en moyenne **{{fmt_percentage1 top_group_avg_pct}}** de la **fonction publique fédérale**, 
-    comparativement à **{{fmt_percentage1 bottom_group_avg_pct}}** pour les **{{bottom_group}}**.
+    De **{{ppl_last_year_5}}** à **{{ppl_last_year}}**, les **{{top_avg_group}}** constituaient en moyenne **{{fmt_percentage1 top_avg_group_share}}** de la **fonction publique fédérale**, 
+    comparativement à **{{fmt_percentage1 bottom_avg_group_share}}** pour les **{{bottom_avg_group}}**.
 
 dept_employee_gender_text:
   transform: [handlebars,markdown]
   en: |
-    From **{{first_active_year}}** to **{{last_active_year}}**, **{{top_group}}** accounted for an average of **{{fmt_percentage1 top_group_avg_pct}}** of **{{subject.name}}**’s workforce{{#isEqual single_type_flag true}}.{{else}}, while **{{bottom_group}}** accounted for an average of **{{fmt_percentage1 bottom_group_avg_pct}}**.{{/isEqual}}
+    From **{{first_active_year}}** to **{{last_active_year}}**, **{{top_avg_group}}** accounted for an average of **{{fmt_percentage1 top_avg_group_share}}** of **{{subject.name}}**’s workforce{{#isEqual single_type_flag true}}.{{else}}, while **{{bottom_avg_group}}** accounted for an average of **{{fmt_percentage1 bottom_avg_group_share}}**.{{/isEqual}}
   fr: |
-    De **{{first_active_year}}** à **{{last_active_year}}**, les **{{top_group}}** constituaient en moyenne **{{fmt_percentage1 top_group_avg_pct}}** du personnel **{{subject.name}}**{{#isEqual single_type_flag true}}.{{else}}, comparativement à **{{fmt_percentage1 bottom_group_avg_pct}}** pour les **{{bottom_group}}**.{{/isEqual}}
+    De **{{first_active_year}}** à **{{last_active_year}}**, les **{{top_avg_group}}** constituaient en moyenne **{{fmt_percentage1 top_avg_group_share}}** du personnel **{{subject.name}}**{{#isEqual single_type_flag true}}.{{else}}, comparativement à **{{fmt_percentage1 bottom_avg_group_share}}** pour les **{{bottom_avg_group}}**.{{/isEqual}}

--- a/client/src/panels/panel_declarations/people/employee_last_year_totals.yaml
+++ b/client/src/panels/panel_declarations/people/employee_last_year_totals.yaml
@@ -6,15 +6,17 @@ dept_employee_last_year_totals_title:
 dept_employee_last_year_totals_text:
   transform: [handlebars,markdown]
   en: |
-    In **{{ppl_last_year}}**, **{{fmt_big_int dept_emp_value}}**  {{gl_tt "people" "HEAD"}} were employed by **{{subject.name}} ({{subject.abbr}})**,
-    representing **{{fmt_smart_percentage1 dept_emp_pct}}** of the total {{gl_tt "Federal Public Service" "FPS"}} population.
+    In **{{ppl_last_year}}**, **{{fmt_big_int dept_emp_value}}** {{gl_tt "people" "HEAD"}} were employed by
+    **{{subject.name}}**{{#if subject.abbr}}**({{subject.abbr}})**{{/if}}, representing **{{fmt_smart_percentage1 dept_emp_pct}}**
+    of the total {{gl_tt "Federal Public Service" "FPS"}} population.
   fr: |
-    En **{{ppl_last_year}}**, **{{fmt_big_int dept_emp_value}}** {{gl_tt "personnes" "HEAD"}}  étaient à l’emploi **{{subject.name}} ({{subject.abbr}})**,
-    soit **{{fmt_smart_percentage1 dept_emp_pct}}** du personnel de la {{gl_tt "fonction publique fédérale" "FPS"}}.
+    En **{{ppl_last_year}}**, **{{fmt_big_int dept_emp_value}}** {{gl_tt "personnes" "HEAD"}}  étaient à l’emploi
+    **{{subject.name}}**{{#if subject.abbr}}**({{subject.abbr}})**{{/if}}, soit **{{fmt_smart_percentage1 dept_emp_pct}}**
+    du personnel de la {{gl_tt "fonction publique fédérale" "FPS"}}.
 
 dept_headcount:
   transform: [handlebars]
   en: |
-    {{subject.abbr}} headcount
+    {{#if subject.abbr}}({{subject.abbr}}) headcount{{else}}Headcount{{/if}} 
   fr: |
-    Effectif {{{de_dept_abbr subject}}}
+    Effectif {{#if subject.abbr}}{{{de_dept_abbr subject}}}{{/if}} 

--- a/client/src/panels/panel_declarations/people/employee_prov.js
+++ b/client/src/panels/panel_declarations/people/employee_prov.js
@@ -110,7 +110,7 @@ class ProvPanel extends React.Component {
     const text_calculations = {
       ...pre_text_calculations,
       subject,
-      top_group: provinces[pre_text_calculations.top_group].text,
+      top_avg_group: provinces[pre_text_calculations.top_avg_group].text,
     };
 
     return (

--- a/client/src/panels/panel_declarations/people/employee_prov.js
+++ b/client/src/panels/panel_declarations/people/employee_prov.js
@@ -11,7 +11,7 @@ import {
   util_components,
 } from "../shared.js";
 
-import { text_calculate } from "./text_calculator.js";
+import { calculate_common_text_args } from "./calculate_common_text_args.js";
 
 import text from "./employee_prov.yaml";
 
@@ -105,12 +105,12 @@ class ProvPanel extends React.Component {
         _.sum(region.data) / duration / (_.sum(employees_by_year) / duration),
     }));
 
-    const pre_text_calculations = text_calculate(formatted_data);
+    const common_text_args = calculate_common_text_args(formatted_data);
 
     const text_calculations = {
-      ...pre_text_calculations,
+      ...common_text_args,
       subject,
-      top_avg_group: provinces[pre_text_calculations.top_avg_group].text,
+      top_avg_group: provinces[common_text_args.top_avg_group].text,
     };
 
     return (

--- a/client/src/panels/panel_declarations/people/employee_prov.yaml
+++ b/client/src/panels/panel_declarations/people/employee_prov.yaml
@@ -1,7 +1,7 @@
 gov_employee_prov_text:
   transform: [handlebars,markdown]
   en: |
-   From **{{ppl_last_year_5}}** to **{{ppl_last_year}}**, the largest average share of **Federal Public Service** employees (**{{fmt_percentage1 top_group_avg_pct}}**) worked in **{{fmt_big_int top_group}}**.
+   From **{{ppl_last_year_5}}** to **{{ppl_last_year}}**, the largest average share of **Federal Public Service** employees (**{{fmt_percentage1 top_avg_group_share}}**) worked in **{{fmt_big_int top_avg_group}}**.
    
    
    * The National Capital Region (NCR) includes employees working in both Ottawa (Ontario) and Gatineau (Quebec).
@@ -11,7 +11,7 @@ gov_employee_prov_text:
    
 
   fr: |
-   De **{{ppl_last_year_5}}** à **{{ppl_last_year}}**, le plus fort contingent d’employés de la **fonction publique fédérale** (**{{fmt_percentage1 top_group_avg_pct}}**) travaillait dans **{{fmt_big_int top_group}}**.
+   De **{{ppl_last_year_5}}** à **{{ppl_last_year}}**, le plus fort contingent d’employés de la **fonction publique fédérale** (**{{fmt_percentage1 top_avg_group_share}}**) travaillait dans **{{fmt_big_int top_avg_group}}**.
    
    
    * La région de la capitale nationale (RCN) inclut à la fois les employés qui travaillent à Ottawa (Ontario) et ceux qui travaillent à Gatineau (Québec).
@@ -28,7 +28,7 @@ employee_prov_title:
 dept_employee_prov_text:
   transform: [handlebars,markdown]
   en: |
-   From **{{fmt_big_int first_active_year}}** to **{{fmt_big_int last_active_year}}**, the largest average share of **{{subject.name}}** employees (**{{fmt_percentage1 top_group_avg_pct}}**) worked in **{{fmt_big_int top_group}}**.
+   From **{{fmt_big_int first_active_year}}** to **{{fmt_big_int last_active_year}}**, the largest average share of **{{subject.name}}** employees (**{{fmt_percentage1 top_avg_group_share}}**) worked in **{{fmt_big_int top_avg_group}}**.
 
 
    * The **National Capital Region (NCR)** includes employees working in both Ottawa (Ontario) and Gatineau (Quebec).
@@ -38,7 +38,7 @@ dept_employee_prov_text:
    
 
   fr: |
-   De **{{fmt_big_int first_active_year}}** à **{{fmt_big_int last_active_year}}**, le plus fort contingent d’employés **{{subject.name}}** (**{{fmt_percentage1 top_group_avg_pct}}**) travaillait dans **{{fmt_big_int top_group}}**.  
+   De **{{fmt_big_int first_active_year}}** à **{{fmt_big_int last_active_year}}**, le plus fort contingent d’employés **{{subject.name}}** (**{{fmt_percentage1 top_avg_group_share}}**) travaillait dans **{{fmt_big_int top_avg_group}}**.  
 
    
    * La **région de la capitale nationale (RCN)** inclut à la fois les employés qui travaillent à Ottawa (Ontario) et ceux qui travaillent à Gatineau (Québec).

--- a/client/src/panels/panel_declarations/people/employee_type.js
+++ b/client/src/panels/panel_declarations/people/employee_type.js
@@ -10,7 +10,7 @@ import {
   NivoLineBarToggle,
 } from "../shared.js";
 
-import { text_calculate } from "./text_calculator.js";
+import { calculate_common_text_args } from "./calculate_common_text_args.js";
 
 import text from "./employee_type.yaml";
 
@@ -82,33 +82,29 @@ export const declare_employee_type_panel = () =>
 
         const student_data = student && student.data;
 
-        const pre_text_calculations = text_calculate(panel_args);
+        const common_text_args = calculate_common_text_args(panel_args);
 
         const sum_emp_first_active_year = _.chain(panel_args)
-          .map(
-            (type) => type.data[pre_text_calculations.first_active_year_index]
-          )
+          .map((type) => type.data[common_text_args.first_active_year_index])
           .sum()
           .value();
 
         const sum_emp_last_active_year = _.chain(panel_args)
-          .map(
-            (type) => type.data[pre_text_calculations.last_active_year_index]
-          )
+          .map((type) => type.data[common_text_args.last_active_year_index])
           .sum()
           .value();
 
         const student_first_active_year_pct = student_data
-          ? student_data[pre_text_calculations.first_active_year_index] /
+          ? student_data[common_text_args.first_active_year_index] /
             sum_emp_first_active_year
           : 0;
         const student_last_active_year_pct = student_data
-          ? student_data[pre_text_calculations.last_active_year_index] /
+          ? student_data[common_text_args.last_active_year_index] /
             sum_emp_last_active_year
           : 0;
 
         const text_calculations = {
-          ...pre_text_calculations,
+          ...common_text_args,
           student_first_active_year_pct,
           student_last_active_year_pct,
           subject,

--- a/client/src/panels/panel_declarations/people/employee_type.yaml
+++ b/client/src/panels/panel_declarations/people/employee_type.yaml
@@ -6,21 +6,21 @@ employee_type_title:
 gov_employee_type_text:
   transform: [handlebars,markdown]
   en: |
-   From **{{ppl_last_year_5}}** to **{{ppl_last_year}}**, the **{{fmt_big_int top_group}}** workforce accounted for the largest average share (**{{fmt_percentage1 top_group_avg_pct}}**) of the **Federal Public Service** population. 
+   From **{{ppl_last_year_5}}** to **{{ppl_last_year}}**, the **{{fmt_big_int top_avg_group}}** workforce accounted for the largest average share (**{{fmt_percentage1 top_avg_group_share}}**) of the **Federal Public Service** population. 
    
    Over this period, the proportion of **Students** in the **Federal Public Service** **{{two_value_changed_to student_first_active_year_pct student_last_active_year_pct "fmt_percentage1"}}**.
   fr: |
-   De **{{ppl_last_year_5}}** à  **{{ppl_last_year}}**, les employés nommés pour une «**{{fmt_big_int top_group}}**» constituaient en moyenne le plus fort contingent (**{{fmt_percentage1 top_group_avg_pct}}**) du personnel de la **fonction publique fédérale**.
+   De **{{ppl_last_year_5}}** à  **{{ppl_last_year}}**, les employés nommés pour une «**{{fmt_big_int top_avg_group}}**» constituaient en moyenne le plus fort contingent (**{{fmt_percentage1 top_avg_group_share}}**) du personnel de la **fonction publique fédérale**.
    
    Au cours de cette période, le personnel **« d’étudiants »** dans la **fonction publique fédérale** **{{fr_two_value_changed_to student_first_active_year_pct student_last_active_year_pct "m" "s" "fmt_percentage1"}}**.
 
 dept_employee_type_text:
   transform: [handlebars,markdown] 
   en: |
-   From **{{fmt_big_int first_active_year}}** to **{{fmt_big_int last_active_year}}**, the **{{fmt_big_int top_group}}** workforce accounted for the largest average share (**{{fmt_percentage1 top_group_avg_pct}}**) of **{{subject.name}}'s** total population.
+   From **{{fmt_big_int first_active_year}}** to **{{fmt_big_int last_active_year}}**, the **{{fmt_big_int top_avg_group}}** workforce accounted for the largest average share (**{{fmt_percentage1 top_avg_group_share}}**) of **{{subject.name}}'s** total population.
    
    Over this period, the proportion of **Students** in **{{subject.name}}'s** workforce **{{two_value_changed_to student_first_active_year_pct student_last_active_year_pct "fmt_percentage1"}}**.
   fr: |
-   De **{{fmt_big_int first_active_year}}** à **{{fmt_big_int last_active_year}}**, les employés nommés pour une «**{{fmt_big_int top_group}}**» constituaient en moyenne le plus fort contingent (**{{fmt_percentage1 top_group_avg_pct}}**) du personnel **{{subject.name}}**.
+   De **{{fmt_big_int first_active_year}}** à **{{fmt_big_int last_active_year}}**, les employés nommés pour une «**{{fmt_big_int top_avg_group}}**» constituaient en moyenne le plus fort contingent (**{{fmt_percentage1 top_avg_group_share}}**) du personnel **{{subject.name}}**.
    
    Au cours de cette période, le personnel **« d’étudiants »** **{{subject.name}}** **{{fr_two_value_changed_to student_first_active_year_pct student_last_active_year_pct "m" "s" "fmt_percentage1"}}**.

--- a/client/src/panels/panel_declarations/people/text_calculator.js
+++ b/client/src/panels/panel_declarations/people/text_calculator.js
@@ -57,7 +57,6 @@ export const text_calculate = (all_data, custom_group_pop = null) => {
         ? group.five_year_percent === bottom_group_avg_pct
         : _.sum(group.data) / custom_group_pop === bottom_group_avg_pct
     )
-
     .thru(
       (group) =>
         group && (lang === "en" ? group.label.replace("Age ", "") : group.label)

--- a/client/src/panels/panel_declarations/people/text_calculator.js
+++ b/client/src/panels/panel_declarations/people/text_calculator.js
@@ -2,19 +2,15 @@ import { run_template, year_templates } from "../shared.js";
 const { people_years } = year_templates;
 
 export const text_calculate = (all_data, custom_group_pop = null) => {
-  const group_data = _.map(all_data, (group) => group.data);
-  const group_data_by_year = _.zip(...group_data);
-  const group_data_sums_by_year = _.map(group_data_by_year, (year_group) =>
-    _.sum(year_group)
-  );
-  const first_active_year_index = _.findIndex(
-    group_data_by_year,
-    (year_group) => year_group !== 0
-  );
-  const last_active_year_index = _.findLastIndex(
-    group_data_sums_by_year,
-    (year_group) => year_group !== 0
-  );
+  const [first_active_year_index, last_active_year_index] = _.chain(all_data)
+    .map("data")
+    .thru((data_by_group) => _.zip(...data_by_group))
+    .map(_.sum)
+    .thru((totals_by_year) => [
+      _.findIndex(totals_by_year, (total) => total !== 0),
+      _.findLastIndex(totals_by_year, (total) => total !== 0),
+    ])
+    .value();
 
   const first_active_year = run_template(
     `${people_years[first_active_year_index]}`

--- a/client/src/panels/panel_declarations/people/text_calculator.js
+++ b/client/src/panels/panel_declarations/people/text_calculator.js
@@ -37,10 +37,7 @@ export const text_calculate = (all_data, custom_group_pop = null) => {
         ? group.five_year_percent === top_group_avg_pct
         : _.sum(group.data) / custom_group_pop === top_group_avg_pct
     )
-    .thru(
-      (group) =>
-        group && (lang === "en" ? group.label.replace("Age ", "") : group.label)
-    )
+    .get("label")
     .value();
 
   const bottom_group_avg_pct = _.chain(all_data)
@@ -57,10 +54,7 @@ export const text_calculate = (all_data, custom_group_pop = null) => {
         ? group.five_year_percent === bottom_group_avg_pct
         : _.sum(group.data) / custom_group_pop === bottom_group_avg_pct
     )
-    .thru(
-      (group) =>
-        group && (lang === "en" ? group.label.replace("Age ", "") : group.label)
-    )
+    .get("label")
     .value();
 
   return {


### PR DESCRIPTION
Post-hotfix cleanup, caught and squashed some other minor bugs in the process (first active year index was always calculated as 0, last year total population panel didn't handle departments without abbreviations, etc.).