### PR TITLE
Infographic search behaviour

### DIFF
--- a/client/src/infographic/Infographic.js
+++ b/client/src/infographic/Infographic.js
@@ -162,7 +162,19 @@ class InfoGraph_ extends React.Component {
       <div>
         <AnalyticsSynchronizer {...this.props} />
         <div className="row infographic-search-container">
-          <EverythingSearch href_template={this.search_href_template} />
+          <EverythingSearch
+            href_template={this.search_href_template}
+            initial_search_options={{
+              include_orgs_normal_data: true,
+              include_orgs_limited_data: true,
+              include_crsos: true,
+              include_programs: true,
+              include_tags_goco: true,
+              include_tags_hi: true,
+              include_tags_hwh: true,
+              include_tags_wwh: true,
+            }}
+          />
         </div>
         <div>
           <div>

--- a/client/src/infographic/Infographic.js
+++ b/client/src/infographic/Infographic.js
@@ -32,7 +32,7 @@ import "./Infographic.scss";
 
 const sub_app_name = "infographic_org";
 
-const { text_maker, TM } = create_text_maker_component(text);
+const { text_maker } = create_text_maker_component(text);
 const { Dept, Gov } = Subject;
 
 class AnalyticsSynchronizer extends React.Component {
@@ -161,17 +161,9 @@ class InfoGraph_ extends React.Component {
     return (
       <div>
         <AnalyticsSynchronizer {...this.props} />
-        {is_a11y_mode && (
-          <div>
-            <TM k="a11y_search_other_infographs" />
-            <EverythingSearch />
-          </div>
-        )}
-        {!is_a11y_mode && (
-          <div className="row infographic-search-container">
-            <EverythingSearch />
-          </div>
-        )}
+        <div className="row infographic-search-container">
+          <EverythingSearch href_template={this.search_href_template} />
+        </div>
         <div>
           <div>
             {loading && <SpinnerWrapper config_name={"route"} />}
@@ -317,6 +309,8 @@ class InfoGraph_ extends React.Component {
       }
     );
   }
+  search_href_template = (selected_subject) =>
+    infograph_href_template(selected_subject, this.props.active_bubble_id, "/");
 }
 
 const is_fake_infographic = (subject) =>

--- a/client/src/infographic/Infographic.yaml
+++ b/client/src/infographic/Infographic.yaml
@@ -98,13 +98,6 @@ a11y_infograph_description:
   en: Infographic content lies below
   fr: Le contenue de l'infographie se trouve ci-dessous
 
-a11y_search_other_infographs:
-  en: |
-    Search for other infographics:
-  fr: |
-    Recherchez d'autres infographies:
-
-
 results_infograph_desc_meta_attr:
   en: The government’s go to tool for all program level resources and results data from Departmental Plans and Departmental Results Reports for the Government of Canada. 
   fr: Fonction « Aller à l'outil » du gouvernement du Canada pour toutes les données du niveau des programmes sur les résultats et les ressources, ainsi que les données sur les résultats figurant dans les plans ministériels et les rapports ministériels sur les résultats. 

--- a/client/src/search/EverythingSearch.js
+++ b/client/src/search/EverythingSearch.js
@@ -286,6 +286,8 @@ EverythingSearch.defaultProps = {
   reject_gov: false,
   reject_dead_orgs: true,
 
+  // true and it's on by default, false and it's off but can still potentially be turned on in the options menu,
+  // excluded from the initial_search_options object and it is off AND not available in the option menu
   initial_search_options: {
     include_orgs_normal_data: true,
     include_orgs_limited_data: true,


### PR DESCRIPTION
With the old search, selecting a new infographic subject from an infographic route would (try to) keep you on the same bubble. This behaviour was lost in the port. 

Slightly more annoying than just re-adding a custom `href_template` prop to the infographic's `EverythingSearch`, realized that there was no way to fully disable/exclude config options from the search options menu, which would have meant any custom `href_template` prop would need to be able to handle any sort of searchable subject... boo.

Tweaked `EverythingSearch` so that totally excluding an option key from `initial_search_options` would both remove it from the default search configs AND remove it from the options menu.