### PR TITLE
Virtualized displaytable

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -2697,6 +2697,11 @@
         "mimic-response": "^1.0.0"
       }
     },
+    "clsx": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.1.1.tgz",
+      "integrity": "sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA=="
+    },
     "coa": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/coa/-/coa-2.0.2.tgz",
@@ -9245,6 +9250,19 @@
         "dom-helpers": "^5.0.1",
         "loose-envify": "^1.4.0",
         "prop-types": "^15.6.2"
+      }
+    },
+    "react-virtualized": {
+      "version": "9.22.3",
+      "resolved": "https://registry.npmjs.org/react-virtualized/-/react-virtualized-9.22.3.tgz",
+      "integrity": "sha512-MKovKMxWTcwPSxE1kK1HcheQTWfuCxAuBoSTf2gwyMM21NdX/PXUhnoP8Uc5dRKd+nKm8v41R36OellhdCpkrw==",
+      "requires": {
+        "@babel/runtime": "^7.7.2",
+        "clsx": "^1.0.4",
+        "dom-helpers": "^5.1.3",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.7.2",
+        "react-lifecycles-compat": "^3.0.4"
       }
     },
     "read-file-relative": {

--- a/client/package.json
+++ b/client/package.json
@@ -100,6 +100,7 @@
     "react-router": "^5",
     "react-router-dom": "^5",
     "react-transition-group": "^4.0",
+    "react-virtualized": "^9.22.3",
     "redux": "^3.7.1",
     "redux-promise-middleware": "^6.1.0",
     "reselect": "^3.0.1",

--- a/client/src/components/DisplayTable/DisplayTable.js
+++ b/client/src/components/DisplayTable/DisplayTable.js
@@ -49,8 +49,6 @@ const get_col_configs_with_defaults = (column_configs) =>
     ...supplied_column_config,
   }));
 
-const cell_measurer_cache = new CellMeasurerCache({ fixedWidth: true });
-
 /* Assumption: DisplayTable assumes 1st column to be string that describes its row
   - If total row exists, 1st column will have the word "Total"
   - 1st column cannot be toggled off by user
@@ -90,6 +88,8 @@ export class DisplayTable extends React.Component {
       descending: false,
       searches,
     };
+
+    this.cell_measurer_cache = new CellMeasurerCache({ fixedWidth: true });
   }
 
   render() {
@@ -331,7 +331,7 @@ export class DisplayTable extends React.Component {
     }) => {
       return (
         <CellMeasurer
-          cache={cell_measurer_cache}
+          cache={this.cell_measurer_cache}
           columnIndex={columnIndex}
           key={dataKey}
           parent={parent}
@@ -501,8 +501,8 @@ export class DisplayTable extends React.Component {
           headerHeight={100}
           rowCount={_.size(sorted_filtered_data)}
           rowGetter={({ index }) => sorted_filtered_data[index]}
-          rowHeight={cell_measurer_cache.rowHeight}
-          deferredMeasurementCache={cell_measurer_cache}
+          rowHeight={this.cell_measurer_cache.rowHeight}
+          deferredMeasurementCache={this.cell_measurer_cache}
         >
           {_.map(visible_ordered_col_keys, (col_key, idx) => (
             <Column

--- a/client/src/components/DisplayTable/DisplayTable.js
+++ b/client/src/components/DisplayTable/DisplayTable.js
@@ -6,7 +6,7 @@ import {
   AutoSizer,
   CellMeasurerCache,
   CellMeasurer,
-  MultiGrid,
+  Grid,
 } from "react-virtualized";
 import "react-virtualized/styles.css";
 
@@ -29,7 +29,6 @@ import {
 
 import text from "./DisplayTable.yaml";
 import "./DisplayTable.scss";
-import ReactResizeDetector from "react-resize-detector";
 
 const { text_maker, TM } = create_text_maker_component(text);
 
@@ -90,7 +89,9 @@ export class DisplayTable extends React.Component {
       searches,
     };
 
-    this.cell_measurer_cache = new CellMeasurerCache({ fixedWidth: true });
+    this.cell_measurer_cache = new CellMeasurerCache({
+      fixedWidth: true,
+    });
   }
 
   render() {
@@ -338,6 +339,7 @@ export class DisplayTable extends React.Component {
                 sorted_filtered_data[rowIndex],
                 visible_ordered_col_keys[columnIndex]
               ),
+              height: "fit-content",
             }}
             tabIndex={-1}
             ref={columnIndex === 0 && rowIndex === 0 ? "first_data" : null}
@@ -513,14 +515,18 @@ export class DisplayTable extends React.Component {
         </table> */}
         <AutoSizer disableHeight>
           {({ width }) => (
-            <MultiGrid
+            <Grid
               width={width}
               height={500}
               rowCount={_.size(sorted_filtered_data)}
               rowHeight={this.cell_measurer_cache.rowHeight}
               deferredMeasurementCache={this.cell_measurer_cache}
               cellRenderer={cell_render}
-              columnWidth={200}
+              columnWidth={
+                _.size(visible_ordered_col_keys) <= 5
+                  ? (1 / _.size(visible_ordered_col_keys)) * width
+                  : 150
+              }
               columnCount={_.size(visible_ordered_col_keys)}
             />
           )}

--- a/client/src/components/misc_util_components.js
+++ b/client/src/components/misc_util_components.js
@@ -1,7 +1,6 @@
 import _ from "lodash";
 import React, { Fragment } from "react";
 
-
 import { formats } from "../core/format.js";
 import { text_abbrev } from "../general_utils.js";
 import {


### PR DESCRIPTION
related #890 

Couldn't get it working so I'm gonna close this immediately but have it here for reference in case I or others want to look back on where I was.

When using the `Table` component, it wasn't possible to get the column widths to be more than what the size of the table widths were (in this case we would've wanted to be able to scroll on the x axis).

When using the `Grid` component, it wasn't possible to get the CellMeasurer to measure the row heights properly. In this case there is a huge overlap on the text within the grid.

If the measuring manages to be working eventually, the next step would be to use a `MultiGrid` where we would want to have 2 fixed rows (one for the header text and one for the header controls).