### PR TITLE
changed local_mongod.sh to work better with WSL2

### DIFF
--- a/scripts/dev_scripts/local_mongod.sh
+++ b/scripts/dev_scripts/local_mongod.sh
@@ -11,18 +11,18 @@ while getopts ":p:" opt; do
       ;;
   esac
 done
-if [[ -z "$port" ]]; then
+if [ -z "$port" ]; then
    port="27017"
    echo "No -p option, defaulting to port 27017"
 fi
 
 
-if [[ ! -e ./local_mongo ]]; then 
+if [ ! -e ./local_mongo ]; then 
   mkdir -p ./local_mongo/db
 fi
 
 
-if [[ -e ./local_mongo/db/mongod.lock ]]; then 
+if [ -e ./local_mongo/db/mongod.lock ]; then 
   running_mongod_pid=$(lsof ./local_mongo/db/mongod.lock | awk 'NR == 2 {print $2}')
 
   # sticks in loop until the process is actually dead, otherwise it's a race between the 


### PR DESCRIPTION
While experimenting on getting the project up and running using WSL2, I noticed that the `local_mongod.sh` script was causing syntax errors. It seemed to work just fine on my MacBook, but let me know if there are any issues with this.