### PR TITLE
Switch @wry/equality from 0.3.2 pin to ^0.3.4 in client package.json

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -7999,9 +7999,9 @@
       }
     },
     "@wry/equality": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.3.2.tgz",
-      "integrity": "sha512-yi0VRqw+ygqM/WVZUze5meAhe2evOHBFXqK8onNVdNNB+Tyn8/07FZpeDklECBHeT9KN9DY2JpCVGNQY6RCRDg==",
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.3.4.tgz",
+      "integrity": "sha512-1gQQhCPenzxw/1HzLlvSIs/59eBHJf9ZDIussjjZhqNSqQuPKQIzN6SWt4kemvlBPDi7RqMuUa03pId7MAE93g==",
       "requires": {
         "tslib": "^1.14.1"
       }
@@ -24398,7 +24398,6 @@
           "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
           "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
           "dev": true,
-          "optional": true,
           "requires": {
             "arr-flatten": "^1.1.0",
             "array-unique": "^0.3.2",
@@ -24417,7 +24416,6 @@
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
-              "optional": true,
               "requires": {
                 "is-extendable": "^0.1.0"
               }
@@ -24450,7 +24448,6 @@
           "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
           "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
           "dev": true,
-          "optional": true,
           "requires": {
             "extend-shallow": "^2.0.1",
             "is-number": "^3.0.0",
@@ -24463,7 +24460,6 @@
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
-              "optional": true,
               "requires": {
                 "is-extendable": "^0.1.0"
               }
@@ -24519,7 +24515,6 @@
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
-          "optional": true,
           "requires": {
             "kind-of": "^3.0.2"
           },
@@ -24529,7 +24524,6 @@
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
-              "optional": true,
               "requires": {
                 "is-buffer": "^1.1.5"
               }
@@ -24541,7 +24535,6 @@
           "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
           "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
           "dev": true,
-          "optional": true,
           "requires": {
             "arr-diff": "^4.0.0",
             "array-unique": "^0.3.2",
@@ -24575,7 +24568,6 @@
           "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
           "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
           "dev": true,
-          "optional": true,
           "requires": {
             "is-number": "^3.0.0",
             "repeat-string": "^1.6.1"

--- a/client/package.json
+++ b/client/package.json
@@ -9,7 +9,6 @@
   },
   "dependencies": {
     "@apollo/client": "^3.2.5",
-    "@wry/equality": "0.3.2",
     "@babel/core": "^7.12.3",
     "@babel/plugin-proposal-class-properties": "^7.12.1",
     "@babel/plugin-proposal-decorators": "^7.12.1",

--- a/client/package.json
+++ b/client/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "@apollo/client": "^3.2.5",
+    "@wry/equality": "^0.3.4",
     "@babel/core": "^7.12.3",
     "@babel/plugin-proposal-class-properties": "^7.12.1",
     "@babel/plugin-proposal-decorators": "^7.12.1",


### PR DESCRIPTION
@wry/equality transpilation fixed in 0.3.4 via https://github.com/benjamn/wryware/pull/102

Trivial, but waiting for dev link to double check.

- [x] ... hmm, small chance any other open branch with its own set of `client/package.json` changes and corresponding new `package-lock.json` could clobber this and regress to 0.3.3. Would be safest to explicitly pin to `^0.3.4`.