### PR TITLE
Runtime global polyfill for resize observer

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -21742,7 +21742,6 @@
           "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
           "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
           "dev": true,
-          "optional": true,
           "requires": {
             "arr-flatten": "^1.1.0",
             "array-unique": "^0.3.2",
@@ -21761,7 +21760,6 @@
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
-              "optional": true,
               "requires": {
                 "is-extendable": "^0.1.0"
               }
@@ -21794,7 +21792,6 @@
           "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
           "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
           "dev": true,
-          "optional": true,
           "requires": {
             "extend-shallow": "^2.0.1",
             "is-number": "^3.0.0",
@@ -21807,7 +21804,6 @@
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
-              "optional": true,
               "requires": {
                 "is-extendable": "^0.1.0"
               }
@@ -21863,7 +21859,6 @@
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
-          "optional": true,
           "requires": {
             "kind-of": "^3.0.2"
           },
@@ -21873,7 +21868,6 @@
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
-              "optional": true,
               "requires": {
                 "is-buffer": "^1.1.5"
               }
@@ -21885,7 +21879,6 @@
           "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
           "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
           "dev": true,
-          "optional": true,
           "requires": {
             "arr-diff": "^4.0.0",
             "array-unique": "^0.3.2",
@@ -21919,7 +21912,6 @@
           "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
           "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
           "dev": true,
-          "optional": true,
           "requires": {
             "is-number": "^3.0.0",
             "repeat-string": "^1.6.1"

--- a/client/package.json
+++ b/client/package.json
@@ -9,7 +9,6 @@
   },
   "dependencies": {
     "@apollo/client": "^3.2.5",
-    "@wry/equality": "^0.3.4",
     "@babel/core": "^7.12.3",
     "@babel/plugin-proposal-class-properties": "^7.12.1",
     "@babel/plugin-proposal-decorators": "^7.12.1",
@@ -24,6 +23,7 @@
     "@nivo/line": "^0.67.0",
     "@nivo/pie": "^0.67.0",
     "@nivo/treemap": "^0.67.0",
+    "@wry/equality": "^0.3.4",
     "axios": "^0.21.1",
     "babel-loader": "^8.1.0",
     "bootstrap": "^4.5.3",
@@ -102,6 +102,7 @@
     "redux": "^3.7.1",
     "redux-promise-middleware": "^6.1.0",
     "reselect": "^3.0.1",
+    "resize-observer-polyfill": "^1.5.1",
     "sass": "^1.29.0",
     "sass-loader": "^10.0.5",
     "script-loader": "^0.7.0",

--- a/client/src/InfoBase/add_runtime_polyfills.js
+++ b/client/src/InfoBase/add_runtime_polyfills.js
@@ -1,0 +1,11 @@
+const add_resize_observer_polyfill = () => {
+  if (window.ResizeObserver === undefined) {
+    return import("src/TextDiff/TextDiff.js").then(
+      (ResizeObserver) => (window.ResizeObserver = ResizeObserver)
+    );
+  }
+};
+
+export const add_runtime_polyfills = () => {
+  return Promise.all([add_resize_observer_polyfill]);
+};

--- a/client/src/InfoBase/bootstrapper.js
+++ b/client/src/InfoBase/bootstrapper.js
@@ -40,6 +40,8 @@ import programSobjs from "src/tables/programSobjs.js";
 import programSpending from "src/tables/programSpending.js";
 import programVoteStat from "src/tables/programVoteStat.js";
 
+import { add_runtime_polyfills } from "./add_runtime_polyfills.js";
+
 const table_defs = [
   orgVoteStatPa,
   orgSobjs,
@@ -68,6 +70,8 @@ const load_fonts = () =>
 
 function bootstrapper(App, app_reducer, done) {
   load_fonts();
+
+  add_runtime_polyfills();
 
   populate_stores().then(() => {
     _.each(table_defs, (table_def) => Table.create_and_register(table_def));


### PR DESCRIPTION
Haha, a second after pushing this I realized there was an alternate export for the problematic `react-resize-detector` library that already included a polyfill, so a global fix wasn't necessary. Dropping this in favour of ce3f0bc
