### PR TITLE
Change height clipper to cover dropdown menu buttons

### DIFF
--- a/client/src/components/HeightClipper/HeightClipper.js
+++ b/client/src/components/HeightClipper/HeightClipper.js
@@ -123,7 +123,7 @@ export class HeightClipper extends React.Component {
               left: "0px",
               height: pixelClipHeight,
               cursor: "pointer",
-              zIndex: 100,
+              zIndex: 1005,
             }}
             className={gradientClasses ? gradientClasses : "gradient"}
             onClick={() => {


### PR DESCRIPTION
Minor annoyance

before: 
![image](https://user-images.githubusercontent.com/25855114/112042858-64b81f00-8b1e-11eb-809c-d476eb1e6cbf.png)

after:
![image](https://user-images.githubusercontent.com/25855114/112042878-6bdf2d00-8b1e-11eb-9a22-2d9cf92ee7fb.png)

