### PR TITLE
Remove top margin from SomeThingsToKeepInMind

### DIFF
--- a/client/src/panels/panel_declarations/common_panel_components.js
+++ b/client/src/panels/panel_declarations/common_panel_components.js
@@ -61,7 +61,7 @@ const SomeThingsToKeepInMind = ({ children, is_initially_expanded }) => (
   <MediaQuery maxWidth={breakpoints.maxMediumDevice}>
     {(matches) => (
       <PinnedContent local_storage_name={"user_enabled_pinning_key_concepts"}>
-        <div className={classNames("mrgn-bttm-md", matches && "mrgn-tp-md")}>
+        <div className={classNames("mrgn-bttm-md")}>
           <ButtonToolbar style={{ margin: 0 }}>
             <AutoAccordion
               title={trivial_text_maker("infographic_faq")}


### PR DESCRIPTION
Previously, the top margin was used to put some space on between the cards and the `SomeThingsToKeepInMind`. Now the filter panel dropdown provides some margin of its own

before
![image](https://user-images.githubusercontent.com/25855114/112657105-72c0b500-8e28-11eb-9813-05a46bdf5413.png)

with changes
![image](https://user-images.githubusercontent.com/25855114/112657139-7bb18680-8e28-11eb-895d-b5ca0134493d.png)
