### PR TITLE
Storybook webpack fix/cleanup

### DIFF
--- a/client/.storybook/main.js
+++ b/client/.storybook/main.js
@@ -6,6 +6,8 @@ const {
   bundle_extended_bootstrap_css,
 } = require("../build_code/bundle_extended_bootstrap_css.js");
 
+const LANG = "en";
+
 module.exports = {
   stories: ["../src/**/*.stories.mdx", "../src/**/*.stories.@(js|jsx|ts|tsx)"],
   addons: [
@@ -13,49 +15,46 @@ module.exports = {
     "@storybook/addon-essentials",
     "@storybook/addon-a11y",
   ],
-  webpackFinal: async (config, { configType }) => {
-    // `configType` has a value of 'DEVELOPMENT' or 'PRODUCTION'
-    // You can change the configuration based on that.
-    // 'PRODUCTION' is used when building the static version of storybook.
+  webpackFinal: async (config) => ({
+    ...config,
 
-    config.resolve = {
-      ...config.resolve,
-      modules: [std_lib_path.resolve(__dirname, "../"), "node_modules/"],
-    };
-
-    // TODO hacky, this is essentially to set injected_build_constants.js's lang export.
-    // Going to have components that need other injected build constants though, and might
-    // even want some that have stories for different sets of build constants (a11y vs standard mode, etc.)
-    // so we need a less hacky and more exstensible way to mock these constants (in general + case by case?)
-    config.plugins.push(
-      new webpack.DefinePlugin({
-        APPLICATION_LANGUAGE: JSON.stringify("en"),
-        IS_A11Y_MODE: process.env.STORYBOOK_A11Y,
-      })
-    );
-
-    // As in the real client, the extended bootstrap stylesheet is precompiled and loaded by the initial html file
-    // (see prieview-head.html) rather than part of the app bundles themselves. This hook ensures the extended bootstrap
-    // stylesheet is updated* and exists where the storybook index.html expects it
-    // * small caveat, unlike normal builds nothing is watching the extended bootstrap files themselves, only output when
-    // something changes in a file the storybook webpack IS watching
-    config.plugins.push({
-      apply: (compiler) => {
-        compiler.hooks.emit.tap("EmitPlugin", () =>
-          bundle_extended_bootstrap_css(config.output.path)
-        );
-      },
-    });
-
-    config.module.rules = [
-      ...config.module.rules,
-      ...get_rules({
-        language: "en",
+    module: {
+      ...config.module,
+      // fully override default storybook rules with the client's rules
+      rules: get_rules({
+        language: LANG,
         is_prod_build: false,
         target_ie11: true,
       }),
-    ];
+    },
 
-    return config;
-  },
+    resolve: {
+      ...config.resolve,
+      modules: [std_lib_path.resolve(__dirname, "../"), "node_modules/"],
+    },
+
+    plugins: [
+      ...config.plugins,
+      new webpack.DefinePlugin({
+        // TODO hacky, this is essentially to set injected_build_constants.js's lang export.
+        // Going to have components that need other injected build constants though, and might
+        // even want some that have stories for different sets of build constants (a11y vs standard mode, etc.)
+        // so we need a less hacky and more exstensible way to mock these constants (in general + case by case?)
+        APPLICATION_LANGUAGE: JSON.stringify(LANG),
+        IS_A11Y_MODE: process.env.STORYBOOK_A11Y,
+      }),
+      {
+        // As in the real client, the extended bootstrap stylesheet is precompiled and loaded by the initial html file
+        // (see prieview-head.html) rather than part of the app bundles themselves. This hook ensures the extended bootstrap
+        // stylesheet is updated* and exists where the storybook index.html expects it
+        // * small caveat, unlike normal builds nothing is watching the extended bootstrap files themselves, only output when
+        // something changes in a files the storybook webpack IS watching
+        apply: (compiler) => {
+          compiler.hooks.emit.tap("EmitPlugin", () =>
+            bundle_extended_bootstrap_css(config.output.path)
+          );
+        },
+      },
+    ],
+  }),
 };

--- a/client/.storybook/main.js
+++ b/client/.storybook/main.js
@@ -50,7 +50,7 @@ module.exports = {
         // * small caveat, unlike normal builds nothing is watching the extended bootstrap files themselves, only output when
         // something changes in a files the storybook webpack IS watching
         apply: (compiler) => {
-          compiler.hooks.emit.tap("EmitPlugin", () =>
+          compiler.hooks.entryOption.tap("watchRun", () =>
             bundle_extended_bootstrap_css(config.output.path)
           );
         },

--- a/client/build_code/bundle_extended_bootstrap_css.js
+++ b/client/build_code/bundle_extended_bootstrap_css.js
@@ -26,10 +26,6 @@ function bundle_extended_bootstrap_css(output_path) {
           test: /\.css$|\.scss$/,
           use: [MiniCssExtractPlugin.loader, "css-loader", "sass-loader"],
         },
-        {
-          test: /\.(eot|svg|ttf|woff|woff2)$/, // Temporary, throw out all bootstrap3 glyphicons, won't need in bootstrap4
-          loader: "null-loader",
-        },
       ],
     },
     plugins: [

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -21742,7 +21742,6 @@
           "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
           "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
           "dev": true,
-          "optional": true,
           "requires": {
             "arr-flatten": "^1.1.0",
             "array-unique": "^0.3.2",
@@ -21761,7 +21760,6 @@
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
-              "optional": true,
               "requires": {
                 "is-extendable": "^0.1.0"
               }
@@ -21794,7 +21792,6 @@
           "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
           "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
           "dev": true,
-          "optional": true,
           "requires": {
             "extend-shallow": "^2.0.1",
             "is-number": "^3.0.0",
@@ -21807,7 +21804,6 @@
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
-              "optional": true,
               "requires": {
                 "is-extendable": "^0.1.0"
               }
@@ -21863,7 +21859,6 @@
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
-          "optional": true,
           "requires": {
             "kind-of": "^3.0.2"
           },
@@ -21873,7 +21868,6 @@
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
-              "optional": true,
               "requires": {
                 "is-buffer": "^1.1.5"
               }
@@ -21885,7 +21879,6 @@
           "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
           "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
           "dev": true,
-          "optional": true,
           "requires": {
             "arr-diff": "^4.0.0",
             "array-unique": "^0.3.2",
@@ -21919,7 +21912,6 @@
           "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
           "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
           "dev": true,
-          "optional": true,
           "requires": {
             "is-number": "^3.0.0",
             "repeat-string": "^1.6.1"

--- a/client/package.json
+++ b/client/package.json
@@ -81,7 +81,6 @@
     "null-loader": "^4.0.1",
     "patch-package": "^6.4.5",
     "popper.js": "^1.14.6",
-    "postcss": "^8.1.6",
     "prop-types": "^15.6.2",
     "qrcode-generator": "^1.4.3",
     "raw-loader": "^4.0.2",


### PR DESCRIPTION
The fix is for a bug that was uncovered in #921, bonus cleanup along the way.

Storybook's default rules included processing CSS modules with PostCSS. I was previously merging our webpack config rules with storybook's defaults on the assumption that they would have specific scoped rules in there necessary for storybook itself, but that wasn't the case. Turns out they just had a general set of rules that would maybe work for many apps, and they conflicted with our rules when trying to apply them all. Should have checked that sooner, but things were working until a case with a plain CSS file was added, at which point our css loaders choked when trying to re-parse a CSS module that was already parsed by their PostCSS.

Fully dropped their default rules in favour of our's.