### PR TITLE
Changed dropdown animation in tag explorer

### DIFF
--- a/client/src/components/Accordion/Accordions.js
+++ b/client/src/components/Accordion/Accordions.js
@@ -32,19 +32,19 @@ class AccordionEnterExit extends React.Component {
     const node = ReactDOM.findDOMNode(component);
     const initialHeight = node.offsetHeight;
     select(node)
-      .style("opacity", 1)
+      .style("opacity", this.props.closing_opacity)
       .style("max-height", initialHeight + "px")
       .transition()
       .ease(easeLinear)
       .duration(this.props.collapseDuration)
-      .style("opacity", this.props.opacity)
+      .style("opacity", this.props.opening_opacity)
       .style("max-height", "1px");
   };
   onEntering = (component) => {
     const node = ReactDOM.findDOMNode(component);
     select(node)
       .style("max-height", "0px")
-      .style("opacity", this.props.opacity)
+      .style("opacity", this.props.opening_opacity)
       .transition()
       .ease(easeLinear)
       .duration(this.props.expandDuration)
@@ -90,7 +90,8 @@ class AccordionEnterExit extends React.Component {
 
 AccordionEnterExit.defaultProps = {
   max_height: "80vh",
-  opacity: 1e-6,
+  opening_opacity: 1e-6,
+  closing_opacity: 1,
 };
 
 const StatelessPullDownAccordion = ({

--- a/client/src/components/Accordion/Accordions.js
+++ b/client/src/components/Accordion/Accordions.js
@@ -31,21 +31,20 @@ class AccordionEnterExit extends React.Component {
   onExiting = (component) => {
     const node = ReactDOM.findDOMNode(component);
     const initialHeight = node.offsetHeight;
-
     select(node)
       .style("opacity", 1)
       .style("max-height", initialHeight + "px")
       .transition()
       .ease(easeLinear)
       .duration(this.props.collapseDuration)
-      .style("opacity", 1e-6)
+      .style("opacity", this.props.opacity)
       .style("max-height", "1px");
   };
   onEntering = (component) => {
     const node = ReactDOM.findDOMNode(component);
     select(node)
       .style("max-height", "0px")
-      .style("opacity", 1e-6)
+      .style("opacity", this.props.opacity)
       .transition()
       .ease(easeLinear)
       .duration(this.props.expandDuration)
@@ -91,6 +90,7 @@ class AccordionEnterExit extends React.Component {
 
 AccordionEnterExit.defaultProps = {
   max_height: "80vh",
+  opacity: 1e-6,
 };
 
 const StatelessPullDownAccordion = ({

--- a/client/src/explorer_common/explorer_components.js
+++ b/client/src/explorer_common/explorer_components.js
@@ -192,12 +192,13 @@ export const ExplorerNode = ({
             <AccordionEnterExit
               expandDuration={300}
               collapseDuration={100}
-              opening_opacity={1e-20}
-              closing_opacity={0.2}
+              style={{ overflowY: "hidden" }}
             >
-              <div className="ExplorerNode__SuppContent">
-                {_.isFunction(get_non_col_content) &&
-                  get_non_col_content({ node })}
+              <div style={{ overflowY: "auto" }}>
+                <div className="ExplorerNode__SuppContent">
+                  {_.isFunction(get_non_col_content) &&
+                    get_non_col_content({ node })}
+                </div>
               </div>
             </AccordionEnterExit>
           )}
@@ -209,14 +210,15 @@ export const ExplorerNode = ({
         <AccordionEnterExit
           expandDuration={300}
           collapseDuration={100}
-          opening_opacity={1e-20}
-          closing_opacity={0.2}
+          style={{ overflowY: "hidden" }}
         >
-          {get_children_content({
-            node,
-            depth: depth + 1,
-            explorer_context,
-          })}
+          <div style={{ overflowY: "auto" }}>
+            {get_children_content({
+              node,
+              depth: depth + 1,
+              explorer_context,
+            })}
+          </div>
         </AccordionEnterExit>
       )}
     </TransitionGroup>

--- a/client/src/explorer_common/explorer_components.js
+++ b/client/src/explorer_common/explorer_components.js
@@ -181,7 +181,7 @@ export const ExplorerNode = ({
                 }
               >
                 {_.isFunction(val_display)
-                  ? val_display(get_val(node))
+                  ? val_display(get_val(node), node)
                   : get_val(node)}
               </div>
             ))}

--- a/client/src/explorer_common/explorer_components.js
+++ b/client/src/explorer_common/explorer_components.js
@@ -192,7 +192,8 @@ export const ExplorerNode = ({
             <AccordionEnterExit
               expandDuration={300}
               collapseDuration={100}
-              opacity={1e-20}
+              opening_opacity={1e-20}
+              closing_opacity={0.2}
             >
               <div className="ExplorerNode__SuppContent">
                 {_.isFunction(get_non_col_content) &&
@@ -208,7 +209,8 @@ export const ExplorerNode = ({
         <AccordionEnterExit
           expandDuration={300}
           collapseDuration={100}
-          opacity={1e-20}
+          opening_opacity={1e-20}
+          closing_opacity={0.2}
         >
           {get_children_content({
             node,

--- a/client/src/explorer_common/explorer_components.js
+++ b/client/src/explorer_common/explorer_components.js
@@ -99,7 +99,7 @@ const get_children_content = ({
           typeName="ul"
           className="ExplorerNodeContainer__ChildrenList"
           staggerDurationBy="0"
-          duration={500}
+          duration={400}
           disableAllAnimations={node_group.length > 150} /* for perf reasons */
         >
           {_.map(node_group, (child_node, ix) => (
@@ -181,7 +181,7 @@ export const ExplorerNode = ({
                 }
               >
                 {_.isFunction(val_display)
-                  ? val_display(get_val(node), node)
+                  ? val_display(get_val(node))
                   : get_val(node)}
               </div>
             ))}
@@ -189,7 +189,11 @@ export const ExplorerNode = ({
         </div>
         <TransitionGroup component={FirstChild}>
           {isExpanded && (
-            <AccordionEnterExit expandDuration={500} collapseDuration={300}>
+            <AccordionEnterExit
+              expandDuration={300}
+              collapseDuration={100}
+              opacity={1e-20}
+            >
               <div className="ExplorerNode__SuppContent">
                 {_.isFunction(get_non_col_content) &&
                   get_non_col_content({ node })}
@@ -201,7 +205,11 @@ export const ExplorerNode = ({
     </div>
     <TransitionGroup component={FirstChild}>
       {isExpanded && (
-        <AccordionEnterExit expandDuration={500} collapseDuration={300}>
+        <AccordionEnterExit
+          expandDuration={300}
+          collapseDuration={100}
+          opacity={1e-20}
+        >
           {get_children_content({
             node,
             depth: depth + 1,


### PR DESCRIPTION
[The page in question](http://localhost:8080/build/InfoBase/index-eng.html#tag-explorer/dept/planned)
Currently, the dropdown menu has a fade effect/animation that causes text to overlap when opening and closing. To fix this, I just made both the speed faster and the opacity lower.

I experimented with getting a 'blanket' effect working (like on the [FAQ](http://localhost:8080/build/InfoBase/index-eng.html#orgs/gov/gov/infograph/financial) drop-down, where the content gets more exposed as the dropdown moves) but I couldn't seem to get it working. I'm still open to getting that feature added, I just wanted to make a PR of what I currently have.