### PR TITLE
Line graph overlapping segments with dashes

### DIFF
--- a/client/src/charts/wrapped_nivo/WrappedNivoLine.js
+++ b/client/src/charts/wrapped_nivo/WrappedNivoLine.js
@@ -136,7 +136,7 @@ export class WrappedNivoLine extends React.Component {
               )}
               fill="none"
               style={{
-                stroke: colors({ id }),
+                stroke: _.isFunction(colors) ? colors({ id }) : colors,
                 strokeWidth: 2.5,
                 strokeDasharray: total_overlaps
                   ? `${dash_size} ${total_overlaps * dash_size}`
@@ -153,8 +153,8 @@ export class WrappedNivoLine extends React.Component {
     const layers = [
       "grid",
       "markers",
-      "areas",
       lines_with_dashed_overlaps,
+      "areas",
       "slices",
       "points",
       "axes",

--- a/client/src/charts/wrapped_nivo/WrappedNivoLine.js
+++ b/client/src/charts/wrapped_nivo/WrappedNivoLine.js
@@ -123,6 +123,8 @@ export class WrappedNivoLine extends React.Component {
       _.map(
         line_segments,
         ({ id, data, total_overlaps, z_index, overlaps_below }, index) => {
+          const gap_between_points = xScale(data[1].x) - xScale(data[0].x);
+          const dash_size = gap_between_points / (total_overlaps + 1) / 2;
           return (
             <path
               key={index}
@@ -137,9 +139,11 @@ export class WrappedNivoLine extends React.Component {
                 stroke: colors({ id }),
                 strokeWidth: 2.5,
                 strokeDasharray: total_overlaps
-                  ? `20 ${total_overlaps * 20}`
+                  ? `${dash_size} ${total_overlaps * dash_size}`
                   : null,
-                strokeDashoffset: total_overlaps ? overlaps_below * 20 : null,
+                strokeDashoffset: total_overlaps
+                  ? overlaps_below * dash_size
+                  : null,
               }}
             />
           );

--- a/client/src/panels/panel_declarations/finances/transfer_payments/historical_g_and_c.js
+++ b/client/src/panels/panel_declarations/finances/transfer_payments/historical_g_and_c.js
@@ -225,11 +225,18 @@ class DetailedHistTPItems extends React.Component {
           y: 200000,
         })),
       },
+      // {
+      //   id: "Stuff",
+      //   data: _.map([0, 1, 2, 3, 4], (index) => ({
+      //     x: text_years[index],
+      //     y: 200000,
+      //   })),
+      // },
       {
-        id: "Stuff",
+        id: "Hello",
         data: _.map([0, 1, 2, 3, 4], (index) => ({
           x: text_years[index],
-          y: 200000,
+          y: index === 3 ? 0 : index === 4 ? 431966 : 200000,
         })),
       },
     ];

--- a/client/src/panels/panel_declarations/finances/transfer_payments/historical_g_and_c.js
+++ b/client/src/panels/panel_declarations/finances/transfer_payments/historical_g_and_c.js
@@ -200,9 +200,8 @@ class DetailedHistTPItems extends React.Component {
       }))
     );
 
-    const detail_expend_data = _.map(
-      graph_series,
-      (expend_array, expend_label) => {
+    const detail_expend_data = [
+      ..._.map(graph_series, (expend_array, expend_label) => {
         return {
           id: expend_label,
           data: expend_array.map((expend_value, year_index) => ({
@@ -210,8 +209,30 @@ class DetailedHistTPItems extends React.Component {
             x: text_years[year_index],
           })),
         };
-      }
-    );
+      }),
+      //Used for testing. Remove this before merging
+      {
+        id: "Test",
+        data: _.map([0, 1, 2, 3, 4], (index) => ({
+          x: text_years[index],
+          y: 200000,
+        })),
+      },
+      {
+        id: "Thing",
+        data: _.map([0, 1, 2, 3, 4], (index) => ({
+          x: text_years[index],
+          y: 200000,
+        })),
+      },
+      {
+        id: "Stuff",
+        data: _.map([0, 1, 2, 3, 4], (index) => ({
+          x: text_years[index],
+          y: 200000,
+        })),
+      },
+    ];
 
     const title_el = (
       <div className="h3">
@@ -257,6 +278,7 @@ class DetailedHistTPItems extends React.Component {
       };
 
       const nivo_props = {
+        ...empty_data_nivo_props,
         data: detail_expend_data,
         raw_data: raw_data,
         margin: {
@@ -272,7 +294,6 @@ class DetailedHistTPItems extends React.Component {
             column_configs={column_configs}
           />
         ),
-        ...empty_data_nivo_props,
       };
 
       return (

--- a/client/src/panels/panel_declarations/finances/transfer_payments/historical_g_and_c.js
+++ b/client/src/panels/panel_declarations/finances/transfer_payments/historical_g_and_c.js
@@ -200,8 +200,9 @@ class DetailedHistTPItems extends React.Component {
       }))
     );
 
-    const detail_expend_data = [
-      ..._.map(graph_series, (expend_array, expend_label) => {
+    const detail_expend_data = _.map(
+      graph_series,
+      (expend_array, expend_label) => {
         return {
           id: expend_label,
           data: expend_array.map((expend_value, year_index) => ({
@@ -209,37 +210,8 @@ class DetailedHistTPItems extends React.Component {
             x: text_years[year_index],
           })),
         };
-      }),
-      //Used for testing. Remove this before merging
-      {
-        id: "Test",
-        data: _.map([0, 1, 2, 3, 4], (index) => ({
-          x: text_years[index],
-          y: 200000,
-        })),
-      },
-      {
-        id: "Thing",
-        data: _.map([0, 1, 2, 3, 4], (index) => ({
-          x: text_years[index],
-          y: 200000,
-        })),
-      },
-      // {
-      //   id: "Stuff",
-      //   data: _.map([0, 1, 2, 3, 4], (index) => ({
-      //     x: text_years[index],
-      //     y: 200000,
-      //   })),
-      // },
-      {
-        id: "Hello",
-        data: _.map([0, 1, 2, 3, 4], (index) => ({
-          x: text_years[index],
-          y: index === 3 ? 0 : index === 4 ? 431966 : 200000,
-        })),
-      },
-    ];
+      }
+    );
 
     const title_el = (
       <div className="h3">


### PR DESCRIPTION
closes #557 

Handle overlapping segments for all line graphs and change code to support overlaps of more than 3 lines


### Live case
[Dev link](http://dev.ea-ad.ca/master/index-eng.html#orgs/dept/186/infograph/financial)
[Local](http://localhost:8080/build/InfoBase/index-eng.html#orgs/dept/186/infograph/financial)
![image](https://user-images.githubusercontent.com/25855114/114450472-0c67c080-9ba4-11eb-84dd-fe858eb03535.png)


### Test case
[Local](http://localhost:8080/build/InfoBase/index-eng.html#orgs/dept/326/infograph/financial)
![image](https://user-images.githubusercontent.com/25855114/114450548-24d7db00-9ba4-11eb-8785-a71cf105b8e9.png)
