### PR TITLE
Append tooltip to app instead of parent

### DIFF
--- a/client/src/glossary/TooltipActivator.js
+++ b/client/src/glossary/TooltipActivator.js
@@ -18,7 +18,7 @@ const create_tooltip = (node) =>
     duration: 0,
     allowHTML: true,
     hideOnClick: false,
-    appendTo: "parent",
+    appendTo: app,
   });
 
 const TooltipActivator = _.isUndefined(MutationObserver)


### PR DESCRIPTION
Without this, voice over kinda jumps all over the place once a tooltip opens up.

(at least for me it does)