### PR TITLE
Add no-throw-literal lint rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,6 +12,7 @@
         { "args": "none" }
     ],
     "no-use-before-define": ["error", { "functions": true, "classes": true }],
+    "no-throw-literal": "error",
     "lodash/no-double-unwrap": ["error"],
     "lodash/no-unbound-this": ["error"],
     "lodash/unwrap": ["error"],

--- a/client/src/InfoBase/App.js
+++ b/client/src/InfoBase/App.js
@@ -158,7 +158,7 @@ export class App extends React.Component {
                 <Route
                   path="/error-boundary-test"
                   component={() => {
-                    throw "This route throws errors!";
+                    throw new Error("This route throws errors!");
                   }}
                 />
                 <Route path="/metadata/:data_source?" component={MetaData} />

--- a/client/src/components/AlertBanner.js
+++ b/client/src/components/AlertBanner.js
@@ -12,7 +12,9 @@ export const AlertBanner = ({
   style,
 }) => {
   if (banner_class && !_.includes(banner_classes, banner_class)) {
-    throw `AlertBanner received invalid banner_class prop of ${banner_class}`;
+    throw new Error(
+      `AlertBanner received invalid banner_class prop of ${banner_class}`
+    );
   }
 
   const banner_class_name = `alert-${banner_class || "info"}`;

--- a/client/src/core/ErrorBoundary.js
+++ b/client/src/core/ErrorBoundary.js
@@ -65,7 +65,7 @@ export class ErrorBoundary extends React.Component {
       testing_for_stale_client: false,
     });
 
-    throw this.state.error;
+    throw new Error(this.state.error);
   }
   render() {
     const { error, testing_for_stale_client } = this.state;

--- a/client/src/core/analytics.js
+++ b/client/src/core/analytics.js
@@ -69,7 +69,7 @@ const dummy_event_obj = _.chain(["SUBAPP", "SUBJECT_GUID", "MISC1", "MISC2"])
 
 function log_standard_event(dims) {
   if (!initialized) {
-    throw "analytics is uninitialized";
+    throw new Error("analytics is uninitialized");
   }
 
   const send_obj = {
@@ -89,7 +89,7 @@ function log_standard_event(dims) {
 
 function log_page_view(page) {
   if (!initialized) {
-    throw "analytics is uninitialized";
+    throw new Error("analytics is uninitialized");
   }
 
   ga("set", "page", page);

--- a/client/src/explorer_common/abstract_explorer_scheme.js
+++ b/client/src/explorer_common/abstract_explorer_scheme.js
@@ -260,7 +260,7 @@ export class AbstractExplorerScheme {
   }
 
   get_base_hierarchy_selector() {
-    throw "NotImplemented";
+    throw new Error("NotImplemented");
   }
 
   @cached_property

--- a/client/src/general_utils.js
+++ b/client/src/general_utils.js
@@ -178,7 +178,7 @@ export const generate_href = (url) =>
 export function cached_property(elementDescriptor) {
   const { kind, key, descriptor } = elementDescriptor;
   if (kind !== "method") {
-    throw Error("@cached_property decorator can only be used on methods");
+    throw new Error("@cached_property decorator can only be used on methods");
   }
   const og_method = descriptor.value;
   const cache_name = `_${key}_cached_val`;
@@ -196,7 +196,7 @@ export function bound(elementDescriptor) {
   //see https://github.com/mbrowne/bound-decorator/blob/master/src/bound.js
   const { kind, key, descriptor } = elementDescriptor;
   if (kind !== "method") {
-    throw Error("@bound decorator can only be used on methods");
+    throw new Error("@bound decorator can only be used on methods");
   }
   const method = descriptor.value;
   const initializer =

--- a/client/src/models/results.js
+++ b/client/src/models/results.js
@@ -245,25 +245,25 @@ const ResultCounts = {
   data: null,
   get_dept_counts(org_id) {
     if (_.isEmpty(this.data)) {
-      throw results_counts_not_loaded_error;
+      throw new Error(results_counts_not_loaded_error);
     }
     return _.chain(this.data).find({ id: org_id.toString() }).value();
   },
   get_gov_counts() {
     if (_.isEmpty(this.data)) {
-      throw results_counts_not_loaded_error;
+      throw new Error(results_counts_not_loaded_error);
     }
     return _.chain(this.data).find({ id: "total" }).value();
   },
   get_data() {
     if (_.isEmpty(this.data)) {
-      throw results_counts_not_loaded_error;
+      throw new Error(results_counts_not_loaded_error);
     }
     return this.data;
   },
   set_data(data) {
     if (!_.isEmpty(this.data)) {
-      throw "data has already been set";
+      throw new Error("data has already been set");
     }
     this.data = data;
   },
@@ -279,19 +279,19 @@ const GranularResultCounts = {
   data: null,
   get_subject_counts(subject_id) {
     if (_.isEmpty(this.data)) {
-      throw granular_results_counts_not_loaded_error;
+      throw new Error(granular_results_counts_not_loaded_error);
     }
     return _.chain(this.data).find({ id: subject_id }).value();
   },
   get_data() {
     if (_.isEmpty(this.data)) {
-      throw granular_results_counts_not_loaded_error;
+      throw new Error(granular_results_counts_not_loaded_error);
     }
     return this.data;
   },
   set_data(data) {
     if (!_.isEmpty(this.data)) {
-      throw "data has already been set";
+      throw new Error("data has already been set");
     }
     this.data = data;
   },
@@ -318,7 +318,9 @@ const get_doc_name = (doc_type, year) => {
   if (doc_type === "drr" && lang === "fr") {
     return `rapport sur les résultats ministériels de ${run_template(year)}`;
   }
-  throw "Error: document type should be 'dp' or 'drr' and lang should be 'en' or 'fr'";
+  throw new Error(
+    "Error: document type should be 'dp' or 'drr' and lang should be 'en' or 'fr'"
+  );
 };
 
 const build_doc_info_objects = (doc_type, docs) =>

--- a/client/src/models/storeMixins.js
+++ b/client/src/models/storeMixins.js
@@ -43,7 +43,9 @@ export const exstensibleStoreMixin = (superclass) => {
       if (target_member) {
         completeAssign(target_member, extension_object);
       } else {
-        throw `Can not extend ${id} on ${this}, ${id} is not a registered member`;
+        throw new Error(
+          `Can not extend ${id} on ${this}, ${id} is not a registered member`
+        );
       }
     }
     static extend_or_register(id, object) {
@@ -125,21 +127,29 @@ export const CanHaveServerData = (data_types) => (superclass) => {
         if (store_value_is_unset) {
           this._has_data[data_type] = has_data;
         } else {
-          throw `"${data_type}" has_data already set with value of "${store_value}" for this instance`;
+          throw new Error(
+            `"${data_type}" has_data already set with value of "${store_value}" for this instance`
+          );
         }
       } else {
-        throw `"${data_type}" is not a valid API data type for this subject`;
+        throw new Error(
+          `"${data_type}" is not a valid API data type for this subject`
+        );
       }
     }
     has_data(data_type) {
       if (_.includes(this._API_data_types, data_type)) {
         if (_.isNull(this._has_data[data_type])) {
-          throw `"has data" status for data type "${data_type}" has yet to be loaded!`;
+          throw new Error(
+            `"has data" status for data type "${data_type}" has yet to be loaded!`
+          );
         } else {
           return this._has_data[data_type];
         }
       } else {
-        throw `"${data_type}" is not a valid API data type for this subject`;
+        throw new Error(
+          `"${data_type}" is not a valid API data type for this subject`
+        );
       }
     }
   };

--- a/client/src/models/text.js
+++ b/client/src/models/text.js
@@ -201,7 +201,7 @@ const _create_text_maker = (deps = template_store) => (key, context = {}) => {
   const text_obj = deps[key];
 
   if (_.isUndefined(text_obj)) {
-    throw `ERROR: undefined text_maker key "${key}"`;
+    throw new Error(`undefined text_maker key "${key}"`);
   }
 
   if (_.isString(text_obj)) {

--- a/client/src/panels/PanelRegistry.js
+++ b/client/src/panels/PanelRegistry.js
@@ -62,14 +62,18 @@ class PanelRegistry {
     const { key, full_key, level, title, is_static } = instance;
 
     if (!_.includes(subjects, level)) {
-      throw `panel ${key}'s level (${level}) is not valid; level is required and must correspond to a valid subject.`;
+      throw new Error(
+        `panel ${key}'s level (${level}) is not valid; level is required and must correspond to a valid subject.`
+      );
     }
     if (!is_static && _.isUndefined(title)) {
-      throw `panel ${key}'s title is undefined; title is required, unless the panel is "static"`;
+      throw new Error(
+        `panel ${key}'s title is undefined; title is required, unless the panel is "static"`
+      );
     }
 
     if (full_key in panels) {
-      throw `panel ${instance.key} has already been defined`;
+      throw new Error(`panel ${instance.key} has already been defined`);
     }
 
     panels[full_key] = instance;

--- a/client/src/panels/get_panels_for_subject/index.js
+++ b/client/src/panels/get_panels_for_subject/index.js
@@ -40,7 +40,7 @@ export function get_panels_for_subject(subject) {
             const panel_obj = PanelRegistry.lookup(key, subject.level);
 
             if (!panel_obj && is_dev) {
-              throw `${key} is not a valid panel`;
+              throw new Error(`${key} is not a valid panel`);
             }
 
             return panel_obj && key;

--- a/client/src/panels/panel_declarations/misc/resource_structure/rooted_resource_scheme.js
+++ b/client/src/panels/panel_declarations/misc/resource_structure/rooted_resource_scheme.js
@@ -47,7 +47,7 @@ function create_rooted_resource_hierarchy({ year, root_subject }) {
     switch (subject.level) {
       case "tag": {
         if (!subject.is_lowest_level_tag) {
-          throw "Only lowest_level_tag tags allowed here";
+          throw new Error("Only lowest_level_tag tags allowed here");
         }
 
         return _.chain(subject.programs)

--- a/client/src/panels/panel_declarations/results/result_drilldown/results_scheme.js
+++ b/client/src/panels/panel_declarations/results/result_drilldown/results_scheme.js
@@ -34,7 +34,7 @@ export default class ResultsExplorer extends AbstractExplorerScheme {
           status_key_whitelist: [], //reset filtering when doc changes
         };
       case "set_doc_REJECTED":
-        throw `Ensure loaded for ${state.doc} results failed!`;
+        throw new Error(`Ensure loaded for ${state.doc} results failed!`);
       case "status_click":
         return {
           ...state,

--- a/client/src/panels/panel_declarations/results/result_flat_table.js
+++ b/client/src/panels/panel_declarations/results/result_flat_table.js
@@ -58,7 +58,9 @@ const get_actual_parent = (indicator_node, full_results_hierarchy) => {
   } else if (parent.data.type === "dr" || parent.data.type === "result") {
     return get_actual_parent(parent, full_results_hierarchy);
   } else {
-    throw `Result component ${indicator_node} has no (sub)program or CR parent`;
+    throw new Error(
+      `Result component ${indicator_node} has no (sub)program or CR parent`
+    );
   }
 };
 

--- a/client/src/partition/partition_subapp/perspectives/PartitionPerspective.js
+++ b/client/src/partition/partition_subapp/perspectives/PartitionPerspective.js
@@ -19,7 +19,9 @@ export class PartitionPerspective {
     );
 
     if (required_arg_is_missing) {
-      throw `Partition diagram perspective ${args.name} is missing required arguments.`;
+      throw new Error(
+        `Partition diagram perspective ${args.name} is missing required arguments.`
+      );
     } else {
       const optional_args = {
         data_wrapper_node_rules: args.data_wrapper_node_rules || false,

--- a/client/src/search/search_configs.js
+++ b/client/src/search/search_configs.js
@@ -127,7 +127,9 @@ const make_orgs_search_config = (options) => {
       case "without_data":
         return Dept.depts_without_data();
       default:
-        throw `Error: make_orgs_search_config option orgs_to_include is an enum, {"all", "with_data", "without_data"}. Given value of "${orgs_to_include}" is invalid.`;
+        throw new Error(
+          `Error: make_orgs_search_config option orgs_to_include is an enum, {"all", "with_data", "without_data"}. Given value of "${orgs_to_include}" is invalid.`
+        );
     }
   })();
   const get_data = () =>

--- a/server/src/models/covid/populate.js
+++ b/server/src/models/covid/populate.js
@@ -56,7 +56,9 @@ export default async function ({ models }) {
         .uniq()
         .thru((calendar_month) => {
           if (calendar_month.length > 1) {
-            throw `covid_expenditures.csv contains more than one uniqe calendar_month (${calendar_month}) for ${fiscal_year}`;
+            throw new Error(
+              `covid_expenditures.csv contains more than one uniqe calendar_month (${calendar_month}) for ${fiscal_year}`
+            );
           } else {
             return _.first(calendar_month) - 1;
           }

--- a/server/src/models/people/models.js
+++ b/server/src/models/people/models.js
@@ -8,11 +8,11 @@ export default function define_resource_models(model_singleton) {
       Object.assign(this, obj);
     }
     static model_name() {
-      throw `
+      throw new Error(`
         Error: bad OOP alert, don't use HeadcountModels class directly.
         Need to create a new class extending it that overwrites the static 
         model_name() function with one that returns the name of the actual model.
-      `;
+      `);
     }
     static get_model_name() {
       try {

--- a/server/src/models/results/schema.js
+++ b/server/src/models/results/schema.js
@@ -227,7 +227,7 @@ export default function ({ models, loaders }) {
     } else if (subject instanceof Program) {
       id_val = subject.program_id;
     } else {
-      throw "bad subject";
+      throw new Error("bad subject");
     }
     let records = await result_by_subj_loader.load(id_val);
 


### PR DESCRIPTION
Pretty simple, mostly for consistency (but thrown literals can also produce more opaque error messages in older browsers). 