### PR TITLE
Remove eslint import extension error for tsx

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -66,8 +66,7 @@
         ]          
       }
     ],
-    "import/no-commonjs": 2,
-    "import/extensions": ["error", "always"]
+    "import/no-commonjs": 2
   },
   "settings": {
     "import/resolver":{


### PR DESCRIPTION
Just noticed this new rule. From what I understand, you cannot explicitly put file extensions in import statements, so we can't have this rule. Correct me if I'm wrong!