### PR TITLE
Refine pattern for defining GraphQL queries/hooks in client

### DIFF
--- a/client/src/graphql_utils/graphql_utils.js
+++ b/client/src/graphql_utils/graphql_utils.js
@@ -12,7 +12,6 @@ import {
   local_ip,
   is_dev,
   is_ci,
-  lang,
 } from "src/core/injected_build_constants.ts";
 
 const prod_api_url = `https://us-central1-ib-serverless-api-prod.cloudfunctions.net/prod-api-${sha}/graphql`;
@@ -104,9 +103,8 @@ const make_query_promise = (
     .query({
       query: query,
       variables: {
-        lang,
-        _query_name: query_name,
         ...variables,
+        _query_name: query_name,
       },
     })
     .then(response_resolver)
@@ -154,9 +152,8 @@ const make_query_hook = (
 
   const { loading, error, data } = useQuery(query, {
     variables: {
-      lang,
-      _query_name: query_name,
       ...variables,
+      _query_name: query_name,
     },
   });
 

--- a/client/src/graphql_utils/graphql_utils.js
+++ b/client/src/graphql_utils/graphql_utils.js
@@ -65,42 +65,15 @@ const query_as_get_with_query_header = async (uri, options) => {
     },
   };
 
-  const query_info = _.chain(query)
-    .thru(JSON.parse)
-    .map("variables._query_name")
-    .thru(
-      (batched_query_names) =>
-        `${batched_query_names.length} batched queries: [${_.join(
-          batched_query_names,
-          ", "
-        )}]`
-    )
-    .value();
-  const time_at_request = Date.now();
-
-  return fetch(uriWithVersionAndQueryHash, new_options)
-    .then((response) => {
-      const resp_time = Date.now() - time_at_request;
-
-      log_standard_event({
-        SUBAPP: window.location.hash.replace("#", ""),
-        MISC1: "API_QUERY_SUCCESS",
-        MISC2: `Batch hash ${query_hash}, took ${resp_time} ms. ${query_info}`,
-      });
-
-      return response;
-    })
-    .catch((error) => {
-      const resp_time = Date.now() - time_at_request;
-
-      log_standard_event({
-        SUBAPP: window.location.hash.replace("#", ""),
-        MISC1: "API_QUERY_FAILURE",
-        MISC2: `Batch hash ${query_hash}, took ${resp_time} ms - ${error.toString()}. ${query_info}`,
-      });
-
-      throw error;
+  return fetch(uriWithVersionAndQueryHash, new_options).catch((error) => {
+    log_standard_event({
+      SUBAPP: window.location.hash.replace("#", ""),
+      MISC1: "API_QUERY_FAILURE",
+      MISC2: `Initial batch fetch error: ${error.toString()}`,
     });
+
+    throw error;
+  });
 };
 
 let client = null;
@@ -131,31 +104,127 @@ export function get_client() {
   return client;
 }
 
-export const query_maker = ({
+const make_query_promise = (
   query_name,
   query,
-  response_resolver = _.identity,
-}) => ({
-  [`query_${query_name}`]: (variables) =>
-    get_client()
-      .query({
-        query: query,
-        variables: {
-          ...variables,
-          _query_name: query_name,
-        },
-      })
-      .then(response_resolver),
-  [`use${_.chain(query_name).camelCase().upperFirst().value()}`]: (
-    variables
-  ) => {
-    const { loading, error, data } = useQuery(query, {
+  response_resolver,
+  expect_not_empty
+) => (variables) => {
+  const time_at_request = Date.now();
+
+  return get_client()
+    .query({
+      query: query,
       variables: {
         ...variables,
         _query_name: query_name,
       },
+    })
+    .then(response_resolver)
+    .then((resolved_response) => {
+      const resp_time = Date.now() - time_at_request;
+
+      if (!expect_not_empty || !_.isEmpty(resolved_response)) {
+        // Not a very good test, might report success with unexpected data... ah well, that's the API's job to test!
+        log_standard_event({
+          SUBAPP: window.location.hash.replace("#", ""),
+          MISC1: "API_QUERY_SUCCESS",
+          MISC2: `${query_name}, took ${resp_time} ms`,
+        });
+      } else {
+        log_standard_event({
+          SUBAPP: window.location.hash.replace("#", ""),
+          MISC1: "API_QUERY_UNEXPECTED",
+          MISC2: `${query_name}, took ${resp_time} ms`,
+        });
+      }
+
+      return resolved_response;
+    })
+    .catch((error) => {
+      const resp_time = Date.now() - time_at_request;
+
+      log_standard_event({
+        SUBAPP: window.location.hash.replace("#", ""),
+        MISC1: "API_QUERY_FAILURE",
+        MISC2: `${query_name}, took ${resp_time} ms - ${error.toString()}`,
+      });
+
+      throw error;
+    });
+};
+
+const make_query_hook = (
+  query_name,
+  query,
+  response_resolver,
+  expect_not_empty
+) => (variables) => {
+  // TODO does this actually make sense to use when calculating resp_time? What's the execution flow of this hook?
+  const time_at_request = Date.now();
+
+  const { loading, error, data } = useQuery(query, {
+    variables: {
+      ...variables,
+      _query_name: query_name,
+    },
+  });
+
+  if (error) {
+    const resp_time = Date.now() - time_at_request;
+
+    log_standard_event({
+      SUBAPP: window.location.hash.replace("#", ""),
+      MISC1: "API_QUERY_FAILURE",
+      MISC2: `${query_name}, took ${resp_time} ms - ${error.toString()}`,
     });
 
-    return { loading, error, data: loading ? data : response_resolver(data) };
-  },
+    throw new Error(error);
+  } else if (!loading) {
+    const resp_time = Date.now() - time_at_request;
+
+    const resolved_response = response_resolver(data);
+
+    if (!expect_not_empty || !_.isEmpty(resolved_response)) {
+      // Not a very good test, might report success with unexpected data... ah well, that's the API's job to test!
+      log_standard_event({
+        SUBAPP: window.location.hash.replace("#", ""),
+        MISC1: "API_QUERY_SUCCESS",
+        MISC2: `${query_name}, took ${resp_time} ms`,
+      });
+    } else {
+      log_standard_event({
+        SUBAPP: window.location.hash.replace("#", ""),
+        MISC1: "API_QUERY_UNEXPECTED",
+        MISC2: `${query_name}, took ${resp_time} ms`,
+      });
+    }
+
+    return { loading, error, data: resolved_response };
+  }
+
+  return { loading, error, data };
+};
+
+export const query_maker = ({
+  query_name,
+  query,
+  response_resolver = _.identity,
+  expect_not_empty = true,
+}) => ({
+  [`query_${query_name}`]: make_query_promise(
+    query_name,
+    query,
+    response_resolver,
+    expect_not_empty
+  ),
+  [`use${_.chain(query_name)
+    .camelCase()
+    .upperFirst()
+    .value()}`]: make_query_hook(
+    query_name,
+    query,
+    response_resolver,
+    expect_not_empty
+  ),
 });

--- a/client/src/graphql_utils/graphql_utils.js
+++ b/client/src/graphql_utils/graphql_utils.js
@@ -133,34 +133,3 @@ export const query_logging_wrapper = (
       throw error;
     });
 };
-
-const InnerLoadingHoc = ({ Component, data_to_props }) => (props) => {
-  if (props.data.loading) {
-    return <div> Loading ... </div>;
-  } else {
-    return (
-      <Component
-        data={data_to_props(props.data)}
-        gql_props={{
-          refetch: props.data.refetch,
-          variables: props.data.variables,
-        }}
-      />
-    );
-  }
-};
-
-//for use in development only
-export const LoadingHoc = ({
-  Component,
-  query,
-  data_to_props = _.identity,
-  variables,
-}) =>
-  apollo_connect(query, {
-    options: variables ? { variables } : {},
-  })(InnerLoadingHoc({ Component, data_to_props }));
-
-assign_to_dev_helper_namespace({
-  query_api: (query) => client.query({ query }),
-});

--- a/client/src/graphql_utils/graphql_utils.js
+++ b/client/src/graphql_utils/graphql_utils.js
@@ -1,18 +1,12 @@
-import {
-  InMemoryCache,
-  ApolloClient,
-  graphql as apollo_connect,
-} from "@apollo/client";
+import { InMemoryCache, ApolloClient, useQuery } from "@apollo/client";
 import { BatchHttpLink } from "@apollo/client/link/batch-http/index.js";
 
 import _ from "lodash";
-import React from "react";
 
 import string_hash from "string-hash";
 
 import { log_standard_event } from "src/core/analytics.js";
 
-import { assign_to_dev_helper_namespace } from "src/core/assign_to_dev_helper_namespace.ts";
 import {
   sha,
   local_ip,
@@ -97,7 +91,7 @@ export function get_client() {
   return client;
 }
 
-export const query_logging_wrapper = (
+const make_query_promise = (
   query_name,
   query,
   expect_resolved_response = true
@@ -132,4 +126,19 @@ export const query_logging_wrapper = (
       });
       throw error;
     });
+};
+
+export const query_maker = (
+  query_name,
+  query,
+  expect_resolved_response = true
+) => {
+  return {
+    [`query_${query_name}`]: make_query_promise(
+      query_name,
+      query,
+      expect_resolved_response
+    ),
+    [`use${_.chain(query_name).camelCase().upperFirst().value()}`]: "TODO",
+  };
 };

--- a/client/src/graphql_utils/graphql_utils.js
+++ b/client/src/graphql_utils/graphql_utils.js
@@ -106,7 +106,7 @@ export function get_client() {
   return client;
 }
 
-const make_query_promise = (query_name, query, resolver) => (variables) => {
+const query_promise_factory = (query_name, query, resolver) => (variables) => {
   const time_at_request = Date.now();
 
   return get_client()
@@ -140,7 +140,7 @@ const make_query_promise = (query_name, query, resolver) => (variables) => {
     });
 };
 
-const make_query_hook = (query_name, query, resolver) => (variables) => {
+const query_hook_factory = (query_name, query, resolver) => (variables) => {
   const [time_at_request, set_time_at_request] = useState(Date.now()); // eslint-disable-line no-unused-vars
 
   const { loading, error, data } = useQuery(query, {
@@ -181,7 +181,7 @@ const make_query_hook = (query_name, query, resolver) => (variables) => {
   }
 };
 
-export const query_maker = ({ query_name, query, resolver = _.identity }) => {
+export const query_factory = ({ query_name, query, resolver = _.identity }) => {
   if (!query_name) {
     throw new Error(
       "All queries must have (unique) names, for logging purposes."
@@ -197,7 +197,7 @@ export const query_maker = ({ query_name, query, resolver = _.identity }) => {
     .value();
 
   return {
-    [promise_key]: make_query_promise(query_name, query, resolver),
-    [hook_key]: make_query_hook(query_name, query, resolver),
+    [promise_key]: query_promise_factory(query_name, query, resolver),
+    [hook_key]: query_hook_factory(query_name, query, resolver),
   };
 };

--- a/client/src/models/covid/queries.js
+++ b/client/src/models/covid/queries.js
@@ -17,7 +17,7 @@ export const {
 } = query_maker({
   query_name: "gov_years_with_covid_data",
   query: gql`
-    query($lang: String!) {
+    query($lang: String! = "${lang}") {
       root(lang: $lang) {
         gov {
           id
@@ -35,7 +35,7 @@ export const {
 } = query_maker({
   query_name: "org_years_with_covid_data",
   query: gql`
-  query($lang: String!, $org_id: String!) {
+  query($lang: String! = "${lang}", $org_id: String!) {
     root(lang: $lang) {
       org(org_id: $org_id) {
         id
@@ -51,7 +51,7 @@ export const {
 export const { query_all_covid_measures, useAllCovidMeasures } = query_maker({
   query_name: "all_covid_measures",
   query: gql`
-    query($lang: String!) {
+    query($lang: String! = "${lang}") {
       root(lang: $lang) {
         covid_measures {
           id
@@ -74,7 +74,7 @@ export const {
 } = query_maker({
   query_name: "all_covid_estimates_by_measure_id",
   query: gql`
-  query($lang: String!, $fiscal_year: Int) {
+  query($lang: String! = "${lang}", $fiscal_year: Int) {
     root(lang: $lang) {
       covid_estimates_by_measure: covid_measures(fiscal_year: $fiscal_year) {
         id
@@ -111,7 +111,7 @@ export const {
 } = query_maker({
   query_name: "org_covid_estimates_by_measure_id",
   query: gql`
-  query($lang: String!, $org_id: String!, $fiscal_year: Int) {
+  query($lang: String! = "${lang}", $org_id: String!, $fiscal_year: Int) {
     root(lang: $lang) {
       org(org_id: $org_id) {
         id
@@ -156,7 +156,7 @@ export const {
 } = query_maker({
   query_name: "all_covid_expenditures_by_measure_id",
   query: gql`
-  query($lang: String!, $fiscal_year: Int) {
+  query($lang: String! = "${lang}", $fiscal_year: Int) {
     root(lang: $lang) {
       covid_expenditures_by_measure: covid_measures(fiscal_year: $fiscal_year) {
          id
@@ -193,7 +193,7 @@ export const {
 } = query_maker({
   query_name: "org_covid_expenditures_by_measure_id",
   query: gql`
-  query($lang: String!, $org_id: String!, $fiscal_year: Int) {
+  query($lang: String! = "${lang}", $org_id: String!, $fiscal_year: Int) {
     root(lang: $lang) {
       org(org_id: $org_id) {
         id
@@ -244,7 +244,7 @@ const common_covid_summary_fields = `
 export const { query_gov_covid_summaries, useGovCovidSummaries } = query_maker({
   query_name: "gov_covid_summaries",
   query: gql`
-  query($lang: String!) {
+  query($lang: String! = "${lang}") {
     root(lang: $lang) {
       gov {
         id
@@ -261,7 +261,7 @@ export const { query_gov_covid_summaries, useGovCovidSummaries } = query_maker({
 export const { query_org_covid_summaries, useOrgCovidSummaries } = query_maker({
   query_name: "org_covid_summaries",
   query: gql`
-  query($lang: String!, $org_id: String!) {
+  query($lang: String! = "${lang}", $org_id: String!) {
     root(lang: $lang) {
       org(org_id: $org_id) {
         id
@@ -278,7 +278,7 @@ export const { query_org_covid_summaries, useOrgCovidSummaries } = query_maker({
 export const { query_gov_covid_summary, useGovCovidSummary } = query_maker({
   query_name: "gov_covid_summary",
   query: gql`
-  query($lang: String!, $fiscal_year: Int!) {
+  query($lang: String! = "${lang}", $fiscal_year: Int!) {
     root(lang: $lang) {
       gov {
         id
@@ -295,7 +295,7 @@ export const { query_gov_covid_summary, useGovCovidSummary } = query_maker({
 export const { query_org_covid_summary, useOrgCovidSummary } = query_maker({
   query_name: "org_covid_summary",
   query: gql`
-  query($lang: String!, $org_id: String!, $fiscal_year: Int!) {
+  query($lang: String! = "${lang}", $org_id: String!, $fiscal_year: Int!) {
     root(lang: $lang) {
       org(org_id: $org_id) {
         id
@@ -313,7 +313,7 @@ export const { query_org_covid_summary, useOrgCovidSummary } = query_maker({
 export const { query_top_covid_spending, useTopCovidSpending } = query_maker({
   query_name: "top_covid_spending",
   query: gql`
-  query($lang: String!, $top_x: Int!, $fiscal_year: Int!) {
+  query($lang: String! = "${lang}", $top_x: Int!, $fiscal_year: Int!) {
     root(lang: $lang) {
       gov {
         id

--- a/client/src/models/covid/queries.js
+++ b/client/src/models/covid/queries.js
@@ -3,9 +3,7 @@ import _ from "lodash";
 
 import { lang } from "src/core/injected_build_constants.ts";
 
-import { get_client, query_maker } from "src/graphql_utils/graphql_utils.js";
-
-const client = get_client();
+import { query_maker } from "src/graphql_utils/graphql_utils.js";
 
 const years_with_covid_data = `
   years_with_covid_data {
@@ -16,77 +14,54 @@ const years_with_covid_data = `
 export const {
   query_gov_years_with_covid_data,
   useGovYearsWithCovidData,
-} = query_maker("gov_years_with_covid_data", ({ ...logging_variables }) =>
-  client
-    .query({
-      query: gql`
-          query($lang: String!) {
-            root(lang: $lang) {
-              gov {
-                id
-                ${years_with_covid_data}
-              }
-            }
-          }
-        `,
-      variables: {
-        lang,
-        ...logging_variables,
-      },
-    })
-    .then((response) => _.get(response, "data.root.gov.years_with_covid_data"))
-);
+} = query_maker({
+  query_name: "gov_years_with_covid_data",
+  query: gql`
+    query($lang: String!) {
+      root(lang: $lang) {
+        gov {
+          id
+          ${years_with_covid_data}
+        }
+      }
+    }
+  `,
+  response_resolver: (response) =>
+    _.get(response, "data.root.gov.years_with_covid_data"),
+});
 export const {
   query_org_years_with_covid_data,
   useOrgYearsWithCovidData,
-} = query_maker(
-  "org_years_with_covid_data",
-  ({ org_id, ...logging_variables }) =>
-    client
-      .query({
-        query: gql`
-          query($lang: String!, $org_id: String!) {
-            root(lang: $lang) {
-              org(org_id: $org_id) {
-                id
-                ${years_with_covid_data}
-              }
-            }
-          }
-        `,
-        variables: {
-          lang,
-          org_id,
-          ...logging_variables,
-        },
-      })
-      .then((response) =>
-        _.get(response, "data.root.org.years_with_covid_data")
-      )
-);
+} = query_maker({
+  query_name: "org_years_with_covid_data",
+  query: gql`
+  query($lang: String!, $org_id: String!) {
+    root(lang: $lang) {
+      org(org_id: $org_id) {
+        id
+        ${years_with_covid_data}
+      }
+    }
+  }
+`,
+  response_resolver: (response) =>
+    _.get(response, "data.root.org.years_with_covid_data"),
+});
 
-export const { query_all_covid_measures, useAllCovidMeasures } = query_maker(
-  "all_covid_measures",
-  ({ ...logging_variables }) =>
-    client
-      .query({
-        query: gql`
-          query($lang: String!) {
-            root(lang: $lang) {
-              covid_measures {
-                id
-                name
-              }
-            }
-          }
-        `,
-        variables: {
-          lang,
-          ...logging_variables,
-        },
-      })
-      .then((response) => _.get(response, "data.root.covid_measures"))
-);
+export const { query_all_covid_measures, useAllCovidMeasures } = query_maker({
+  query_name: "all_covid_measures",
+  query: gql`
+    query($lang: String!) {
+      root(lang: $lang) {
+        covid_measures {
+          id
+          name
+        }
+      }
+    }
+  `,
+  response_resolver: (response) => _.get(response, "data.root.covid_measures"),
+});
 
 const covid_estimates_fields = `
   est_doc
@@ -96,101 +71,80 @@ const covid_estimates_fields = `
 export const {
   query_all_covid_estimates_by_measure_id,
   useAllCovidEstimatesByMeasureId,
-} = query_maker(
-  "all_covid_estimates_by_measure_id",
-  ({ fiscal_year, ...logging_variables }) =>
-    client
-      .query({
-        query: gql`
-          query($lang: String!, $fiscal_year: Int) {
-            root(lang: $lang) {
-              covid_estimates_by_measure: covid_measures(fiscal_year: $fiscal_year) {
-                id
-  
-                covid_data(fiscal_year: $fiscal_year) {
-                  fiscal_year
+} = query_maker({
+  query_name: "all_covid_estimates_by_measure_id",
+  query: gql`
+  query($lang: String!, $fiscal_year: Int) {
+    root(lang: $lang) {
+      covid_estimates_by_measure: covid_measures(fiscal_year: $fiscal_year) {
+        id
 
-                  covid_estimates {
-                    org_id
-                    ${covid_estimates_fields}
-                  }
-                }
-              }
-            }
+        covid_data(fiscal_year: $fiscal_year) {
+          fiscal_year
+
+          covid_estimates {
+            org_id
+            ${covid_estimates_fields}
           }
-        `,
-        variables: {
-          lang,
-          fiscal_year,
-          ...logging_variables,
-        },
-      })
-      .then((response) =>
-        _.chain(response)
-          .get("data.root.covid_estimates_by_measure")
-          .flatMap(({ id: measure_id, covid_data }) =>
-            _.flatMap(covid_data, ({ fiscal_year, covid_estimates }) =>
-              _.map(covid_estimates, (row) => ({
-                measure_id,
-                fiscal_year,
-                ..._.omit(row, "__typename"),
-              }))
-            )
-          )
-          .value()
+        }
+      }
+    }
+  }
+`,
+  response_resolver: (response) =>
+    _.chain(response)
+      .get("data.root.covid_estimates_by_measure")
+      .flatMap(({ id: measure_id, covid_data }) =>
+        _.flatMap(covid_data, ({ fiscal_year, covid_estimates }) =>
+          _.map(covid_estimates, (row) => ({
+            measure_id,
+            fiscal_year,
+            ..._.omit(row, "__typename"),
+          }))
+        )
       )
-);
+      .value(),
+});
 export const {
   query_org_covid_estimates_by_measure_id,
   useOrgCovidEstimatesByMeasureId,
-} = query_maker(
-  "org_covid_estimates_by_measure_id",
-  ({ org_id, fiscal_year, ...logging_variables }) =>
-    client
-      .query({
-        query: gql`
-          query($lang: String!, $org_id: String!, $fiscal_year: Int) {
-            root(lang: $lang) {
-              org(org_id: $org_id) {
-                id
-                covid_estimates_by_measure: covid_measures(fiscal_year: $fiscal_year) {
-                  id
-  
-                  covid_data(fiscal_year: $fiscal_year, org_id: $org_id) {
-                    fiscal_year
+} = query_maker({
+  query_name: "org_covid_estimates_by_measure_id",
+  query: gql`
+  query($lang: String!, $org_id: String!, $fiscal_year: Int) {
+    root(lang: $lang) {
+      org(org_id: $org_id) {
+        id
+        covid_estimates_by_measure: covid_measures(fiscal_year: $fiscal_year) {
+          id
 
-                    covid_estimates {
-                      org_id
-                      ${covid_estimates_fields}
-                    }
-                  }
-                }
-              }
+          covid_data(fiscal_year: $fiscal_year, org_id: $org_id) {
+            fiscal_year
+
+            covid_estimates {
+              org_id
+              ${covid_estimates_fields}
             }
           }
-        `,
-        variables: {
-          lang,
-          org_id,
-          fiscal_year,
-          ...logging_variables,
-        },
-      })
-      .then((response) =>
-        _.chain(response)
-          .get("data.root.org.covid_estimates_by_measure")
-          .flatMap(({ id: measure_id, covid_data }) =>
-            _.flatMap(covid_data, ({ fiscal_year, covid_estimates }) =>
-              _.map(covid_estimates, (row) => ({
-                measure_id,
-                fiscal_year,
-                ..._.omit(row, "__typename"),
-              }))
-            )
-          )
-          .value()
+        }
+      }
+    }
+  }
+`,
+  response_resolver: (response) =>
+    _.chain(response)
+      .get("data.root.org.covid_estimates_by_measure")
+      .flatMap(({ id: measure_id, covid_data }) =>
+        _.flatMap(covid_data, ({ fiscal_year, covid_estimates }) =>
+          _.map(covid_estimates, (row) => ({
+            measure_id,
+            fiscal_year,
+            ..._.omit(row, "__typename"),
+          }))
+        )
       )
-);
+      .value(),
+});
 
 const covid_expenditures_fields = `
   vote
@@ -199,101 +153,80 @@ const covid_expenditures_fields = `
 export const {
   query_all_covid_expenditures_by_measure_id,
   useAllCovidExpendituresByMeasureId,
-} = query_maker(
-  "all_covid_expenditures_by_measure_id",
-  ({ fiscal_year, ...logging_variables }) =>
-    client
-      .query({
-        query: gql`
-         query($lang: String!, $fiscal_year: Int) {
-           root(lang: $lang) {
-             covid_expenditures_by_measure: covid_measures(fiscal_year: $fiscal_year) {
-                id
-  
-                covid_data(fiscal_year: $fiscal_year) {
-                  fiscal_year
+} = query_maker({
+  query_name: "all_covid_expenditures_by_measure_id",
+  query: gql`
+  query($lang: String!, $fiscal_year: Int) {
+    root(lang: $lang) {
+      covid_expenditures_by_measure: covid_measures(fiscal_year: $fiscal_year) {
+         id
 
-                  covid_expenditures {
-                    org_id
-                    ${covid_expenditures_fields}
-                  }
-                }
-             }
+         covid_data(fiscal_year: $fiscal_year) {
+           fiscal_year
+
+           covid_expenditures {
+             org_id
+             ${covid_expenditures_fields}
            }
          }
-       `,
-        variables: {
-          lang,
-          fiscal_year,
-          ...logging_variables,
-        },
-      })
-      .then((response) =>
-        _.chain(response)
-          .get("data.root.covid_expenditures_by_measure")
-          .flatMap(({ id: measure_id, covid_data }) =>
-            _.flatMap(covid_data, ({ fiscal_year, covid_expenditures }) =>
-              _.map(covid_expenditures, (row) => ({
-                measure_id,
-                fiscal_year,
-                ..._.omit(row, "__typename"),
-              }))
-            )
-          )
-          .value()
+      }
+    }
+  }
+`,
+  response_resolver: (response) =>
+    _.chain(response)
+      .get("data.root.covid_expenditures_by_measure")
+      .flatMap(({ id: measure_id, covid_data }) =>
+        _.flatMap(covid_data, ({ fiscal_year, covid_expenditures }) =>
+          _.map(covid_expenditures, (row) => ({
+            measure_id,
+            fiscal_year,
+            ..._.omit(row, "__typename"),
+          }))
+        )
       )
-);
+      .value(),
+});
 export const {
   query_org_covid_expenditures_by_measure_id,
   useOrgCovidExpendituresByMeasureId,
-} = query_maker(
-  "org_covid_expenditures_by_measure_id",
-  ({ org_id, fiscal_year, ...logging_variables }) =>
-    client
-      .query({
-        query: gql`
-          query($lang: String!, $org_id: String!, $fiscal_year: Int) {
-            root(lang: $lang) {
-              org(org_id: $org_id) {
-                id
-                covid_expenditures_by_measure: covid_measures(fiscal_year: $fiscal_year) {
-                  id
+} = query_maker({
+  query_name: "org_covid_expenditures_by_measure_id",
+  query: gql`
+  query($lang: String!, $org_id: String!, $fiscal_year: Int) {
+    root(lang: $lang) {
+      org(org_id: $org_id) {
+        id
+        covid_expenditures_by_measure: covid_measures(fiscal_year: $fiscal_year) {
+          id
 
-                  covid_data(fiscal_year: $fiscal_year, org_id: $org_id) {
-                    fiscal_year
+          covid_data(fiscal_year: $fiscal_year, org_id: $org_id) {
+            fiscal_year
 
-                    covid_expenditures {
-                      org_id
-                      ${covid_expenditures_fields}
-                    }
-                  }
-                }
-              }
+            covid_expenditures {
+              org_id
+              ${covid_expenditures_fields}
             }
           }
-        `,
-        variables: {
-          lang,
-          org_id,
-          fiscal_year,
-          ...logging_variables,
-        },
-      })
-      .then((response) =>
-        _.chain(response)
-          .get("data.root.org.covid_expenditures_by_measure")
-          .flatMap(({ id: measure_id, covid_data }) =>
-            _.flatMap(covid_data, ({ fiscal_year, covid_expenditures }) =>
-              _.map(covid_expenditures, (row) => ({
-                measure_id,
-                fiscal_year,
-                ..._.omit(row, "__typename"),
-              }))
-            )
-          )
-          .value()
+        }
+      }
+    }
+  }
+`,
+  response_resolver: (response) =>
+    _.chain(response)
+      .get("data.root.org.covid_expenditures_by_measure")
+      .flatMap(({ id: measure_id, covid_data }) =>
+        _.flatMap(covid_data, ({ fiscal_year, covid_expenditures }) =>
+          _.map(covid_expenditures, (row) => ({
+            measure_id,
+            fiscal_year,
+            ..._.omit(row, "__typename"),
+          }))
+        )
       )
-);
+      .value(),
+});
 
 const common_covid_summary_fields = `
   id
@@ -308,190 +241,143 @@ const common_covid_summary_fields = `
     ${covid_expenditures_fields}
   }
 `;
-export const { query_gov_covid_summaries, useGovCovidSummaries } = query_maker(
-  "gov_covid_summaries",
-  ({ ...logging_variables }) =>
-    client
-      .query({
-        query: gql`
-          query($lang: String!) {
-            root(lang: $lang) {
-              gov {
-                id
-                covid_summary {
-                  ${common_covid_summary_fields}
-                }
-              }
-            }
-          }
-        `,
-        variables: {
-          lang,
-          ...logging_variables,
-        },
-      })
-      .then((response) => _.get(response, "data.root.gov.covid_summary"))
-);
-export const { query_org_covid_summaries, useOrgCovidSummaries } = query_maker(
-  "org_covid_summaries",
-  ({ org_id, ...logging_variables }) =>
-    client
-      .query({
-        query: gql`
-          query($lang: String!, $org_id: String!) {
-            root(lang: $lang) {
-              org(org_id: $org_id) {
-                id
-                covid_summary {
-                  ${common_covid_summary_fields}
-                }
-              }
-            }
-          }
-        `,
-        variables: {
-          lang,
-          org_id,
-          ...logging_variables,
-        },
-      })
-      .then((response) => _.get(response, "data.root.org.covid_summary"))
-);
-export const { query_gov_covid_summary, useGovCovidSummary } = query_maker(
-  "gov_covid_summary",
-  ({ fiscal_year, ...logging_variables }) =>
-    client
-      .query({
-        query: gql`
-          query($lang: String!, $fiscal_year: Int!) {
-            root(lang: $lang) {
-              gov {
-                id
-                covid_summary(fiscal_year: $fiscal_year) {
-                  ${common_covid_summary_fields}
-                }
-              }
-            }
-          }
-        `,
-        variables: {
-          lang,
-          fiscal_year,
-          ...logging_variables,
-        },
-      })
-      .then((response) =>
-        _.chain(response).get("data.root.gov.covid_summary").first().value()
-      )
-);
-export const { query_org_covid_summary, useOrgCovidSummary } = query_maker(
-  "org_covid_summary",
-  ({ org_id, fiscal_year, ...logging_variables }) =>
-    client
-      .query({
-        query: gql`
-          query($lang: String!, $org_id: String!, $fiscal_year: Int!) {
-            root(lang: $lang) {
-              org(org_id: $org_id) {
-                id
-                covid_summary(fiscal_year: $fiscal_year) {
-                  ${common_covid_summary_fields}
-                }
-              }
-            }
-          }
-        `,
-        variables: {
-          lang,
-          org_id,
-          fiscal_year,
-          ...logging_variables,
-        },
-      })
-      .then((response) =>
-        _.chain(response).get("data.root.org.covid_summary").first().value()
-      )
-);
+export const { query_gov_covid_summaries, useGovCovidSummaries } = query_maker({
+  query_name: "gov_covid_summaries",
+  query: gql`
+  query($lang: String!) {
+    root(lang: $lang) {
+      gov {
+        id
+        covid_summary {
+          ${common_covid_summary_fields}
+        }
+      }
+    }
+  }
+`,
+  response_resolver: (response) =>
+    _.get(response, "data.root.gov.covid_summary"),
+});
+export const { query_org_covid_summaries, useOrgCovidSummaries } = query_maker({
+  query_name: "org_covid_summaries",
+  query: gql`
+  query($lang: String!, $org_id: String!) {
+    root(lang: $lang) {
+      org(org_id: $org_id) {
+        id
+        covid_summary {
+          ${common_covid_summary_fields}
+        }
+      }
+    }
+  }
+`,
+  response_resolver: (response) =>
+    _.get(response, "data.root.org.covid_summary"),
+});
+export const { query_gov_covid_summary, useGovCovidSummary } = query_maker({
+  query_name: "gov_covid_summary",
+  query: gql`
+  query($lang: String!, $fiscal_year: Int!) {
+    root(lang: $lang) {
+      gov {
+        id
+        covid_summary(fiscal_year: $fiscal_year) {
+          ${common_covid_summary_fields}
+        }
+      }
+    }
+  }
+`,
+  response_resolver: (response) =>
+    _.chain(response).get("data.root.gov.covid_summary").first().value(),
+});
+export const { query_org_covid_summary, useOrgCovidSummary } = query_maker({
+  query_name: "org_covid_summary",
+  query: gql`
+  query($lang: String!, $org_id: String!, $fiscal_year: Int!) {
+    root(lang: $lang) {
+      org(org_id: $org_id) {
+        id
+        covid_summary(fiscal_year: $fiscal_year) {
+          ${common_covid_summary_fields}
+        }
+      }
+    }
+  }
+`,
+  response_resolver: (response) =>
+    _.chain(response).get("data.root.org.covid_summary").first().value(),
+});
 
-export const { query_top_covid_spending, useTopCovidSpending } = query_maker(
-  "top_covid_spending",
-  ({ fiscal_year, top_x = 4, ...logging_variables }) =>
-    client
-      .query({
-        query: gql`
-          query($lang: String!, $top_x: Int!, $fiscal_year: Int!) {
-            root(lang: $lang) {
-              gov {
-                id
-                covid_summary(fiscal_year: $fiscal_year) {
-                  id
-                  fiscal_year
-        
-                  top_spending_orgs(top_x: $top_x) {
-                    id
-                    name
+export const { query_top_covid_spending, useTopCovidSpending } = query_maker({
+  query_name: "top_covid_spending",
+  query: gql`
+  query($lang: String!, $top_x: Int!, $fiscal_year: Int!) {
+    root(lang: $lang) {
+      gov {
+        id
+        covid_summary(fiscal_year: $fiscal_year) {
+          id
+          fiscal_year
 
-                    covid_summary(fiscal_year: $fiscal_year) {
-                      fiscal_year
-        
-                      covid_expenditures {
-                        ${covid_expenditures_fields}
-                      }
-                    }
-                  }
-                  top_spending_measures(top_x: $top_x) {
-                    id
-                    name
-        
-                    covid_data(fiscal_year: $fiscal_year) {
-                      fiscal_year
-                
-                      covid_expenditures {
-                        org_id
-                        ${covid_expenditures_fields}
-                      }
-                    }
-                  }
-                }
+          top_spending_orgs(top_x: $top_x) {
+            id
+            name
+
+            covid_summary(fiscal_year: $fiscal_year) {
+              fiscal_year
+
+              covid_expenditures {
+                ${covid_expenditures_fields}
               }
             }
           }
-        `,
-        variables: {
-          lang,
-          top_x,
-          fiscal_year,
-          ...logging_variables,
-        },
-      })
-      .then((response) =>
-        _.chain(response)
-          .get("data.root.gov.covid_summary")
-          .first()
-          .thru(({ top_spending_orgs, top_spending_measures }) => ({
-            top_spending_orgs: _.map(
-              top_spending_orgs,
-              ({ name, covid_summary }) => ({
-                name,
-                spending: _.chain(covid_summary)
-                  .first()
-                  .get("covid_expenditures")
-                  .thru(({ vote, stat }) => vote + stat)
-                  .value(),
-              })
-            ),
-            top_spending_measures: _.map(
-              top_spending_measures,
-              ({ name, covid_data }) => ({
-                name,
-                spending: _.chain(covid_data)
-                  .first()
-                  .get("covid_expenditures")
-                  .reduce((memo, { vote, stat }) => memo + vote + stat, 0)
-                  .value(),
-              })
-            ),
-          }))
-          .value()
-      )
-);
+          top_spending_measures(top_x: $top_x) {
+            id
+            name
+
+            covid_data(fiscal_year: $fiscal_year) {
+              fiscal_year
+        
+              covid_expenditures {
+                org_id
+                ${covid_expenditures_fields}
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+`,
+  response_resolver: (response) =>
+    _.chain(response)
+      .get("data.root.gov.covid_summary")
+      .first()
+      .thru(({ top_spending_orgs, top_spending_measures }) => ({
+        top_spending_orgs: _.map(
+          top_spending_orgs,
+          ({ name, covid_summary }) => ({
+            name,
+            spending: _.chain(covid_summary)
+              .first()
+              .get("covid_expenditures")
+              .thru(({ vote, stat }) => vote + stat)
+              .value(),
+          })
+        ),
+        top_spending_measures: _.map(
+          top_spending_measures,
+          ({ name, covid_data }) => ({
+            name,
+            spending: _.chain(covid_data)
+              .first()
+              .get("covid_expenditures")
+              .reduce((memo, { vote, stat }) => memo + vote + stat, 0)
+              .value(),
+          })
+        ),
+      }))
+      .value(),
+});

--- a/client/src/models/covid/queries.js
+++ b/client/src/models/covid/queries.js
@@ -35,15 +35,15 @@ export const {
 } = query_maker({
   query_name: "org_years_with_covid_data",
   query: gql`
-  query($lang: String! = "${lang}", $org_id: String!) {
-    root(lang: $lang) {
-      org(org_id: $org_id) {
-        id
-        ${years_with_covid_data}
+    query($lang: String! = "${lang}", $org_id: String!) {
+      root(lang: $lang) {
+        org(org_id: $org_id) {
+          id
+          ${years_with_covid_data}
+        }
       }
     }
-  }
-`,
+  `,
   response_resolver: (response) =>
     _.get(response, "data.root.org.years_with_covid_data"),
 });
@@ -74,23 +74,23 @@ export const {
 } = query_maker({
   query_name: "all_covid_estimates_by_measure_id",
   query: gql`
-  query($lang: String! = "${lang}", $fiscal_year: Int) {
-    root(lang: $lang) {
-      covid_estimates_by_measure: covid_measures(fiscal_year: $fiscal_year) {
-        id
-
-        covid_data(fiscal_year: $fiscal_year) {
-          fiscal_year
-
-          covid_estimates {
-            org_id
-            ${covid_estimates_fields}
+    query($lang: String! = "${lang}", $fiscal_year: Int) {
+      root(lang: $lang) {
+        covid_estimates_by_measure: covid_measures(fiscal_year: $fiscal_year) {
+          id
+  
+          covid_data(fiscal_year: $fiscal_year) {
+            fiscal_year
+  
+            covid_estimates {
+              org_id
+              ${covid_estimates_fields}
+            }
           }
         }
       }
     }
-  }
-`,
+  `,
   response_resolver: (response) =>
     _.chain(response)
       .get("data.root.covid_estimates_by_measure")
@@ -111,26 +111,26 @@ export const {
 } = query_maker({
   query_name: "org_covid_estimates_by_measure_id",
   query: gql`
-  query($lang: String! = "${lang}", $org_id: String!, $fiscal_year: Int) {
-    root(lang: $lang) {
-      org(org_id: $org_id) {
-        id
-        covid_estimates_by_measure: covid_measures(fiscal_year: $fiscal_year) {
+    query($lang: String! = "${lang}", $org_id: String!, $fiscal_year: Int) {
+      root(lang: $lang) {
+        org(org_id: $org_id) {
           id
-
-          covid_data(fiscal_year: $fiscal_year, org_id: $org_id) {
-            fiscal_year
-
-            covid_estimates {
-              org_id
-              ${covid_estimates_fields}
+          covid_estimates_by_measure: covid_measures(fiscal_year: $fiscal_year) {
+            id
+  
+            covid_data(fiscal_year: $fiscal_year, org_id: $org_id) {
+              fiscal_year
+  
+              covid_estimates {
+                org_id
+                ${covid_estimates_fields}
+              }
             }
           }
         }
       }
     }
-  }
-`,
+  `,
   response_resolver: (response) =>
     _.chain(response)
       .get("data.root.org.covid_estimates_by_measure")
@@ -156,23 +156,23 @@ export const {
 } = query_maker({
   query_name: "all_covid_expenditures_by_measure_id",
   query: gql`
-  query($lang: String! = "${lang}", $fiscal_year: Int) {
-    root(lang: $lang) {
-      covid_expenditures_by_measure: covid_measures(fiscal_year: $fiscal_year) {
-         id
-
-         covid_data(fiscal_year: $fiscal_year) {
-           fiscal_year
-
-           covid_expenditures {
-             org_id
-             ${covid_expenditures_fields}
+    query($lang: String! = "${lang}", $fiscal_year: Int) {
+      root(lang: $lang) {
+        covid_expenditures_by_measure: covid_measures(fiscal_year: $fiscal_year) {
+           id
+  
+           covid_data(fiscal_year: $fiscal_year) {
+             fiscal_year
+  
+             covid_expenditures {
+               org_id
+               ${covid_expenditures_fields}
+             }
            }
-         }
+        }
       }
     }
-  }
-`,
+  `,
   response_resolver: (response) =>
     _.chain(response)
       .get("data.root.covid_expenditures_by_measure")
@@ -193,26 +193,26 @@ export const {
 } = query_maker({
   query_name: "org_covid_expenditures_by_measure_id",
   query: gql`
-  query($lang: String! = "${lang}", $org_id: String!, $fiscal_year: Int) {
-    root(lang: $lang) {
-      org(org_id: $org_id) {
-        id
-        covid_expenditures_by_measure: covid_measures(fiscal_year: $fiscal_year) {
+    query($lang: String! = "${lang}", $org_id: String!, $fiscal_year: Int) {
+      root(lang: $lang) {
+        org(org_id: $org_id) {
           id
-
-          covid_data(fiscal_year: $fiscal_year, org_id: $org_id) {
-            fiscal_year
-
-            covid_expenditures {
-              org_id
-              ${covid_expenditures_fields}
+          covid_expenditures_by_measure: covid_measures(fiscal_year: $fiscal_year) {
+            id
+  
+            covid_data(fiscal_year: $fiscal_year, org_id: $org_id) {
+              fiscal_year
+  
+              covid_expenditures {
+                org_id
+                ${covid_expenditures_fields}
+              }
             }
           }
         }
       }
     }
-  }
-`,
+  `,
   response_resolver: (response) =>
     _.chain(response)
       .get("data.root.org.covid_expenditures_by_measure")
@@ -244,68 +244,68 @@ const common_covid_summary_fields = `
 export const { query_gov_covid_summaries, useGovCovidSummaries } = query_maker({
   query_name: "gov_covid_summaries",
   query: gql`
-  query($lang: String! = "${lang}") {
-    root(lang: $lang) {
-      gov {
-        id
-        covid_summary {
-          ${common_covid_summary_fields}
+    query($lang: String! = "${lang}") {
+      root(lang: $lang) {
+        gov {
+          id
+          covid_summary {
+            ${common_covid_summary_fields}
+          }
         }
       }
     }
-  }
-`,
+  `,
   response_resolver: (response) =>
     _.get(response, "data.root.gov.covid_summary"),
 });
 export const { query_org_covid_summaries, useOrgCovidSummaries } = query_maker({
   query_name: "org_covid_summaries",
   query: gql`
-  query($lang: String! = "${lang}", $org_id: String!) {
-    root(lang: $lang) {
-      org(org_id: $org_id) {
-        id
-        covid_summary {
-          ${common_covid_summary_fields}
+    query($lang: String! = "${lang}", $org_id: String!) {
+      root(lang: $lang) {
+        org(org_id: $org_id) {
+          id
+          covid_summary {
+            ${common_covid_summary_fields}
+          }
         }
       }
     }
-  }
-`,
+  `,
   response_resolver: (response) =>
     _.get(response, "data.root.org.covid_summary"),
 });
 export const { query_gov_covid_summary, useGovCovidSummary } = query_maker({
   query_name: "gov_covid_summary",
   query: gql`
-  query($lang: String! = "${lang}", $fiscal_year: Int!) {
-    root(lang: $lang) {
-      gov {
-        id
-        covid_summary(fiscal_year: $fiscal_year) {
-          ${common_covid_summary_fields}
+    query($lang: String! = "${lang}", $fiscal_year: Int!) {
+      root(lang: $lang) {
+        gov {
+          id
+          covid_summary(fiscal_year: $fiscal_year) {
+            ${common_covid_summary_fields}
+          }
         }
       }
     }
-  }
-`,
+  `,
   response_resolver: (response) =>
     _.chain(response).get("data.root.gov.covid_summary").first().value(),
 });
 export const { query_org_covid_summary, useOrgCovidSummary } = query_maker({
   query_name: "org_covid_summary",
   query: gql`
-  query($lang: String! = "${lang}", $org_id: String!, $fiscal_year: Int!) {
-    root(lang: $lang) {
-      org(org_id: $org_id) {
-        id
-        covid_summary(fiscal_year: $fiscal_year) {
-          ${common_covid_summary_fields}
+    query($lang: String! = "${lang}", $org_id: String!, $fiscal_year: Int!) {
+      root(lang: $lang) {
+        org(org_id: $org_id) {
+          id
+          covid_summary(fiscal_year: $fiscal_year) {
+            ${common_covid_summary_fields}
+          }
         }
       }
     }
-  }
-`,
+  `,
   response_resolver: (response) =>
     _.chain(response).get("data.root.org.covid_summary").first().value(),
 });
@@ -313,44 +313,44 @@ export const { query_org_covid_summary, useOrgCovidSummary } = query_maker({
 export const { query_top_covid_spending, useTopCovidSpending } = query_maker({
   query_name: "top_covid_spending",
   query: gql`
-  query($lang: String! = "${lang}", $top_x: Int!, $fiscal_year: Int!) {
-    root(lang: $lang) {
-      gov {
-        id
-        covid_summary(fiscal_year: $fiscal_year) {
+    query($lang: String! = "${lang}", $top_x: Int! = 4, $fiscal_year: Int!) {
+      root(lang: $lang) {
+        gov {
           id
-          fiscal_year
-
-          top_spending_orgs(top_x: $top_x) {
+          covid_summary(fiscal_year: $fiscal_year) {
             id
-            name
-
-            covid_summary(fiscal_year: $fiscal_year) {
-              fiscal_year
-
-              covid_expenditures {
-                ${covid_expenditures_fields}
+            fiscal_year
+  
+            top_spending_orgs(top_x: $top_x) {
+              id
+              name
+  
+              covid_summary(fiscal_year: $fiscal_year) {
+                fiscal_year
+  
+                covid_expenditures {
+                  ${covid_expenditures_fields}
+                }
               }
             }
-          }
-          top_spending_measures(top_x: $top_x) {
-            id
-            name
-
-            covid_data(fiscal_year: $fiscal_year) {
-              fiscal_year
-        
-              covid_expenditures {
-                org_id
-                ${covid_expenditures_fields}
+            top_spending_measures(top_x: $top_x) {
+              id
+              name
+  
+              covid_data(fiscal_year: $fiscal_year) {
+                fiscal_year
+          
+                covid_expenditures {
+                  org_id
+                  ${covid_expenditures_fields}
+                }
               }
             }
           }
         }
       }
     }
-  }
-`,
+  `,
   response_resolver: (response) =>
     _.chain(response)
       .get("data.root.gov.covid_summary")

--- a/client/src/models/covid/queries.js
+++ b/client/src/models/covid/queries.js
@@ -3,10 +3,7 @@ import _ from "lodash";
 
 import { lang } from "src/core/injected_build_constants.ts";
 
-import {
-  get_client,
-  query_logging_wrapper,
-} from "src/graphql_utils/graphql_utils.js";
+import { get_client, query_maker } from "src/graphql_utils/graphql_utils.js";
 
 const client = get_client();
 
@@ -16,12 +13,13 @@ const years_with_covid_data = `
     years_with_expenditures
   }
 `;
-export const query_gov_years_with_covid_data = query_logging_wrapper(
-  "gov_years_with_covid_data",
-  ({ ...logging_variables }) =>
-    client
-      .query({
-        query: gql`
+export const {
+  query_gov_years_with_covid_data,
+  useGovYearsWithCovidData,
+} = query_maker("gov_years_with_covid_data", ({ ...logging_variables }) =>
+  client
+    .query({
+      query: gql`
           query($lang: String!) {
             root(lang: $lang) {
               gov {
@@ -31,16 +29,17 @@ export const query_gov_years_with_covid_data = query_logging_wrapper(
             }
           }
         `,
-        variables: {
-          lang,
-          ...logging_variables,
-        },
-      })
-      .then((response) =>
-        _.get(response, "data.root.gov.years_with_covid_data")
-      )
+      variables: {
+        lang,
+        ...logging_variables,
+      },
+    })
+    .then((response) => _.get(response, "data.root.gov.years_with_covid_data"))
 );
-export const query_org_years_with_covid_data = query_logging_wrapper(
+export const {
+  query_org_years_with_covid_data,
+  useOrgYearsWithCovidData,
+} = query_maker(
   "org_years_with_covid_data",
   ({ org_id, ...logging_variables }) =>
     client
@@ -66,7 +65,7 @@ export const query_org_years_with_covid_data = query_logging_wrapper(
       )
 );
 
-export const query_all_covid_measures = query_logging_wrapper(
+export const { query_all_covid_measures, useAllCovidMeasures } = query_maker(
   "all_covid_measures",
   ({ ...logging_variables }) =>
     client
@@ -94,8 +93,11 @@ const covid_estimates_fields = `
   vote
   stat
 `;
-export const query_all_covid_estimates_by_measure_id = query_logging_wrapper(
-  "all_covid_estimates_by_measure",
+export const {
+  query_all_covid_estimates_by_measure_id,
+  useAllCovidEstimatesByMeasureId,
+} = query_maker(
+  "all_covid_estimates_by_measure_id",
   ({ fiscal_year, ...logging_variables }) =>
     client
       .query({
@@ -138,8 +140,11 @@ export const query_all_covid_estimates_by_measure_id = query_logging_wrapper(
           .value()
       )
 );
-export const query_org_covid_estimates_by_measure_id = query_logging_wrapper(
-  "org_covid_estimates_by_measure",
+export const {
+  query_org_covid_estimates_by_measure_id,
+  useOrgCovidEstimatesByMeasureId,
+} = query_maker(
+  "org_covid_estimates_by_measure_id",
   ({ org_id, fiscal_year, ...logging_variables }) =>
     client
       .query({
@@ -191,8 +196,11 @@ const covid_expenditures_fields = `
   vote
   stat
 `;
-export const query_all_covid_expenditures_by_measure_id = query_logging_wrapper(
-  "all_covid_expenditures_by_measure",
+export const {
+  query_all_covid_expenditures_by_measure_id,
+  useAllCovidExpendituresByMeasureId,
+} = query_maker(
+  "all_covid_expenditures_by_measure_id",
   ({ fiscal_year, ...logging_variables }) =>
     client
       .query({
@@ -235,8 +243,11 @@ export const query_all_covid_expenditures_by_measure_id = query_logging_wrapper(
           .value()
       )
 );
-export const query_org_covid_expenditures_by_measure_id = query_logging_wrapper(
-  "org_covid_expenditures_by_measure",
+export const {
+  query_org_covid_expenditures_by_measure_id,
+  useOrgCovidExpendituresByMeasureId,
+} = query_maker(
+  "org_covid_expenditures_by_measure_id",
   ({ org_id, fiscal_year, ...logging_variables }) =>
     client
       .query({
@@ -297,7 +308,7 @@ const common_covid_summary_fields = `
     ${covid_expenditures_fields}
   }
 `;
-export const query_gov_covid_summaries = query_logging_wrapper(
+export const { query_gov_covid_summaries, useGovCovidSummaries } = query_maker(
   "gov_covid_summaries",
   ({ ...logging_variables }) =>
     client
@@ -321,7 +332,7 @@ export const query_gov_covid_summaries = query_logging_wrapper(
       })
       .then((response) => _.get(response, "data.root.gov.covid_summary"))
 );
-export const query_org_covid_summaries = query_logging_wrapper(
+export const { query_org_covid_summaries, useOrgCovidSummaries } = query_maker(
   "org_covid_summaries",
   ({ org_id, ...logging_variables }) =>
     client
@@ -346,7 +357,7 @@ export const query_org_covid_summaries = query_logging_wrapper(
       })
       .then((response) => _.get(response, "data.root.org.covid_summary"))
 );
-export const query_gov_covid_summary = query_logging_wrapper(
+export const { query_gov_covid_summary, useGovCovidSummary } = query_maker(
   "gov_covid_summary",
   ({ fiscal_year, ...logging_variables }) =>
     client
@@ -373,7 +384,7 @@ export const query_gov_covid_summary = query_logging_wrapper(
         _.chain(response).get("data.root.gov.covid_summary").first().value()
       )
 );
-export const query_org_covid_summary = query_logging_wrapper(
+export const { query_org_covid_summary, useOrgCovidSummary } = query_maker(
   "org_covid_summary",
   ({ org_id, fiscal_year, ...logging_variables }) =>
     client
@@ -402,7 +413,7 @@ export const query_org_covid_summary = query_logging_wrapper(
       )
 );
 
-export const query_top_covid_spending = query_logging_wrapper(
+export const { query_top_covid_spending, useTopCovidSpending } = query_maker(
   "top_covid_spending",
   ({ fiscal_year, top_x = 4, ...logging_variables }) =>
     client

--- a/client/src/models/covid/queries.js
+++ b/client/src/models/covid/queries.js
@@ -26,7 +26,7 @@ export const {
       }
     }
   `,
-  response_resolver: (response) =>
+  resolver: (response) =>
     _.get(response, "data.root.gov.years_with_covid_data"),
 });
 export const {
@@ -44,7 +44,7 @@ export const {
       }
     }
   `,
-  response_resolver: (response) =>
+  resolver: (response) =>
     _.get(response, "data.root.org.years_with_covid_data"),
 });
 
@@ -60,7 +60,7 @@ export const { query_all_covid_measures, useAllCovidMeasures } = query_maker({
       }
     }
   `,
-  response_resolver: (response) => _.get(response, "data.root.covid_measures"),
+  resolver: (response) => _.get(response, "data.root.covid_measures"),
 });
 
 const covid_estimates_fields = `
@@ -91,7 +91,7 @@ export const {
       }
     }
   `,
-  response_resolver: (response) =>
+  resolver: (response) =>
     _.chain(response)
       .get("data.root.covid_estimates_by_measure")
       .flatMap(({ id: measure_id, covid_data }) =>
@@ -131,7 +131,7 @@ export const {
       }
     }
   `,
-  response_resolver: (response) =>
+  resolver: (response) =>
     _.chain(response)
       .get("data.root.org.covid_estimates_by_measure")
       .flatMap(({ id: measure_id, covid_data }) =>
@@ -173,7 +173,7 @@ export const {
       }
     }
   `,
-  response_resolver: (response) =>
+  resolver: (response) =>
     _.chain(response)
       .get("data.root.covid_expenditures_by_measure")
       .flatMap(({ id: measure_id, covid_data }) =>
@@ -213,7 +213,7 @@ export const {
       }
     }
   `,
-  response_resolver: (response) =>
+  resolver: (response) =>
     _.chain(response)
       .get("data.root.org.covid_expenditures_by_measure")
       .flatMap(({ id: measure_id, covid_data }) =>
@@ -255,8 +255,7 @@ export const { query_gov_covid_summaries, useGovCovidSummaries } = query_maker({
       }
     }
   `,
-  response_resolver: (response) =>
-    _.get(response, "data.root.gov.covid_summary"),
+  resolver: (response) => _.get(response, "data.root.gov.covid_summary"),
 });
 export const { query_org_covid_summaries, useOrgCovidSummaries } = query_maker({
   query_name: "org_covid_summaries",
@@ -272,8 +271,7 @@ export const { query_org_covid_summaries, useOrgCovidSummaries } = query_maker({
       }
     }
   `,
-  response_resolver: (response) =>
-    _.get(response, "data.root.org.covid_summary"),
+  resolver: (response) => _.get(response, "data.root.org.covid_summary"),
 });
 export const { query_gov_covid_summary, useGovCovidSummary } = query_maker({
   query_name: "gov_covid_summary",
@@ -289,7 +287,7 @@ export const { query_gov_covid_summary, useGovCovidSummary } = query_maker({
       }
     }
   `,
-  response_resolver: (response) =>
+  resolver: (response) =>
     _.chain(response).get("data.root.gov.covid_summary").first().value(),
 });
 export const { query_org_covid_summary, useOrgCovidSummary } = query_maker({
@@ -306,7 +304,7 @@ export const { query_org_covid_summary, useOrgCovidSummary } = query_maker({
       }
     }
   `,
-  response_resolver: (response) =>
+  resolver: (response) =>
     _.chain(response).get("data.root.org.covid_summary").first().value(),
 });
 
@@ -351,7 +349,7 @@ export const { query_top_covid_spending, useTopCovidSpending } = query_maker({
       }
     }
   `,
-  response_resolver: (response) =>
+  resolver: (response) =>
     _.chain(response)
       .get("data.root.gov.covid_summary")
       .first()

--- a/client/src/models/covid/queries.js
+++ b/client/src/models/covid/queries.js
@@ -3,7 +3,7 @@ import _ from "lodash";
 
 import { lang } from "src/core/injected_build_constants.ts";
 
-import { query_maker } from "src/graphql_utils/graphql_utils.js";
+import { query_factory } from "src/graphql_utils/graphql_utils.js";
 
 const years_with_covid_data = `
   years_with_covid_data {
@@ -14,7 +14,7 @@ const years_with_covid_data = `
 export const {
   query_gov_years_with_covid_data,
   useGovYearsWithCovidData,
-} = query_maker({
+} = query_factory({
   query_name: "gov_years_with_covid_data",
   query: gql`
     query($lang: String! = "${lang}") {
@@ -32,7 +32,7 @@ export const {
 export const {
   query_org_years_with_covid_data,
   useOrgYearsWithCovidData,
-} = query_maker({
+} = query_factory({
   query_name: "org_years_with_covid_data",
   query: gql`
     query($lang: String! = "${lang}", $org_id: String!) {
@@ -48,7 +48,7 @@ export const {
     _.get(response, "data.root.org.years_with_covid_data"),
 });
 
-export const { query_all_covid_measures, useAllCovidMeasures } = query_maker({
+export const { query_all_covid_measures, useAllCovidMeasures } = query_factory({
   query_name: "all_covid_measures",
   query: gql`
     query($lang: String! = "${lang}") {
@@ -71,7 +71,7 @@ const covid_estimates_fields = `
 export const {
   query_all_covid_estimates_by_measure_id,
   useAllCovidEstimatesByMeasureId,
-} = query_maker({
+} = query_factory({
   query_name: "all_covid_estimates_by_measure_id",
   query: gql`
     query($lang: String! = "${lang}", $fiscal_year: Int) {
@@ -108,7 +108,7 @@ export const {
 export const {
   query_org_covid_estimates_by_measure_id,
   useOrgCovidEstimatesByMeasureId,
-} = query_maker({
+} = query_factory({
   query_name: "org_covid_estimates_by_measure_id",
   query: gql`
     query($lang: String! = "${lang}", $org_id: String!, $fiscal_year: Int) {
@@ -153,7 +153,7 @@ const covid_expenditures_fields = `
 export const {
   query_all_covid_expenditures_by_measure_id,
   useAllCovidExpendituresByMeasureId,
-} = query_maker({
+} = query_factory({
   query_name: "all_covid_expenditures_by_measure_id",
   query: gql`
     query($lang: String! = "${lang}", $fiscal_year: Int) {
@@ -190,7 +190,7 @@ export const {
 export const {
   query_org_covid_expenditures_by_measure_id,
   useOrgCovidExpendituresByMeasureId,
-} = query_maker({
+} = query_factory({
   query_name: "org_covid_expenditures_by_measure_id",
   query: gql`
     query($lang: String! = "${lang}", $org_id: String!, $fiscal_year: Int) {
@@ -241,7 +241,10 @@ const common_covid_summary_fields = `
     ${covid_expenditures_fields}
   }
 `;
-export const { query_gov_covid_summaries, useGovCovidSummaries } = query_maker({
+export const {
+  query_gov_covid_summaries,
+  useGovCovidSummaries,
+} = query_factory({
   query_name: "gov_covid_summaries",
   query: gql`
     query($lang: String! = "${lang}") {
@@ -257,7 +260,10 @@ export const { query_gov_covid_summaries, useGovCovidSummaries } = query_maker({
   `,
   resolver: (response) => _.get(response, "data.root.gov.covid_summary"),
 });
-export const { query_org_covid_summaries, useOrgCovidSummaries } = query_maker({
+export const {
+  query_org_covid_summaries,
+  useOrgCovidSummaries,
+} = query_factory({
   query_name: "org_covid_summaries",
   query: gql`
     query($lang: String! = "${lang}", $org_id: String!) {
@@ -273,7 +279,7 @@ export const { query_org_covid_summaries, useOrgCovidSummaries } = query_maker({
   `,
   resolver: (response) => _.get(response, "data.root.org.covid_summary"),
 });
-export const { query_gov_covid_summary, useGovCovidSummary } = query_maker({
+export const { query_gov_covid_summary, useGovCovidSummary } = query_factory({
   query_name: "gov_covid_summary",
   query: gql`
     query($lang: String! = "${lang}", $fiscal_year: Int!) {
@@ -290,7 +296,7 @@ export const { query_gov_covid_summary, useGovCovidSummary } = query_maker({
   resolver: (response) =>
     _.chain(response).get("data.root.gov.covid_summary").first().value(),
 });
-export const { query_org_covid_summary, useOrgCovidSummary } = query_maker({
+export const { query_org_covid_summary, useOrgCovidSummary } = query_factory({
   query_name: "org_covid_summary",
   query: gql`
     query($lang: String! = "${lang}", $org_id: String!, $fiscal_year: Int!) {
@@ -308,7 +314,7 @@ export const { query_org_covid_summary, useOrgCovidSummary } = query_maker({
     _.chain(response).get("data.root.org.covid_summary").first().value(),
 });
 
-export const { query_top_covid_spending, useTopCovidSpending } = query_maker({
+export const { query_top_covid_spending, useTopCovidSpending } = query_factory({
   query_name: "top_covid_spending",
   query: gql`
     query($lang: String! = "${lang}", $top_x: Int! = 4, $fiscal_year: Int!) {


### PR DESCRIPTION
Refine pattern from `client/graphql_utils/graphql_utils.js`'s `query_logging_wrapper`. Introduce (tentatively named) `query_maker`, to return both promise and hook based query options, with standard logging built in, based on a common query configuration. Enforces naming of queries (for logging) and strongly suggest pairing each query with a response resolver (so that the query itself encapsulates as much knowledge of the actual query structure/server schema as it can).

Note, the hooks, being based on Apollo's `useQuery`, aren't actually usable until #1004 adds the necessary `ApolloProvider`. This was originally a branch off of `SI_apollo_hooks`, but I split it off when I decided it had reached a reviewable state without getting in to potentially touching a bunch of service inventory code.