### PR TITLE
show linting from ts/tsx files in webpack output

### DIFF
--- a/client/build_code/webpack_common.js
+++ b/client/build_code/webpack_common.js
@@ -163,7 +163,7 @@ function get_plugins({
       IS_CI: JSON.stringify(is_ci),
       LOCAL_IP: JSON.stringify(local_ip),
     }),
-    new ESLintPlugin(),
+    new ESLintPlugin({ extensions: ["js", "ts", "tsx"] }),
     new CircularDependencyPlugin({
       exclude: /node_modules/,
       onDetected({ module: webpackModuleRecord, paths, compilation }) {


### PR DESCRIPTION
Linting warnings/errors from wasn't showing up in the 