### PR TITLE
Better CI build memory usage logging

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,7 +140,7 @@ jobs:
             while true; do
               sleep 5
               echo "====="
-              ps -eo comm,vsz,rss | sort -k 3 -nr
+              ps -eo pgrp,comm,vsz,rss,cmd:1000 | sort -k 4 -nr
               echo "====="
             done 
           background: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
   # Note: the image used for this job is built from a docker file found in ../dockerfiles/build
   test_email_backend:
     docker:
-      - image: eaadtbs/ib-ci-build:1.4
+      - image: eaadtbs/ib-ci-build:1.5
         <<: *dockerhub_auth
     working_directory: "~/InfoBase"
     steps:
@@ -65,7 +65,7 @@ jobs:
   # Note: the image used for this job is built from a docker file found in ../dockerfiles/build
   cleanup_dev_links:
     docker:
-      - image: eaadtbs/ib-ci-test:1.4
+      - image: eaadtbs/ib-ci-test:1.5
         <<: *dockerhub_auth
     working_directory: "~/InfoBase"
     steps:
@@ -101,7 +101,7 @@ jobs:
   # Note: the image used for this job is built from a docker file found in ../dockerfiles/build
   build:
     docker:
-      - image: eaadtbs/ib-ci-build:1.4
+      - image: eaadtbs/ib-ci-build:1.5
         <<: *dockerhub_auth
     working_directory: "~/InfoBase"
     steps:
@@ -213,7 +213,7 @@ jobs:
   # Note: the image used for this job is built from a docker file found in ../dockerfiles/test
   test_server:
     docker:
-      - image: eaadtbs/ib-ci-test:1.4
+      - image: eaadtbs/ib-ci-test:1.5
         <<: *dockerhub_auth
     working_directory: "~/InfoBase"
     steps:
@@ -245,7 +245,7 @@ jobs:
   # Note: the image used for this job is built from a docker file found in ../dockerfiles/test
   test_end_to_end: # slower but more in-depth than the test job. Wait until these have passed before deploying the client
     docker:
-      - image: eaadtbs/ib-ci-test:1.4
+      - image: eaadtbs/ib-ci-test:1.5
         <<: *dockerhub_auth
     working_directory: "~/InfoBase"
     steps:
@@ -282,7 +282,7 @@ jobs:
   deploy_data:
     working_directory: "~/InfoBase"
     docker:
-      - image: eaadtbs/ib-ci-test:1.4
+      - image: eaadtbs/ib-ci-test:1.5
         <<: *dockerhub_auth
     steps:
       - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,7 +140,7 @@ jobs:
             while true; do
               sleep 5
               echo "====="
-              ps -eo pgrp,comm,vsz,rss,cmd:1000 | sort -k 4 -nr
+              ps -eo pgrp,comm,vsz,rss,%mem,cmd:1000 | sort -k 5 -nr
               echo "====="
             done 
           background: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,7 +140,11 @@ jobs:
             while true; do
               sleep 5
               echo "====="
-              ps -eo pgrp,comm,vsz,rss,%mem,cmd:1000 | sort -k 5 -nr
+              ps -eo pgrp,comm,vsz,rss,%mem,cmd:1000 |\
+                # skip header line, then sort by %mem
+                (read -r; printf "%s\n" "$REPLY"; sort -k 5 -nr) |\
+                # format vsz and rss, originally in kilobytes, as more friendly memory units 
+                numfmt --header --from-unit=1024 --to=iec --field 3,4
               echo "====="
             done 
           background: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,7 +140,13 @@ jobs:
             while true; do
               sleep 5
               echo "====="
-              ps -eo pgrp,comm,vsz,rss,%mem,cmd:1000 --sort %mem
+              ps -eo pgrp,comm,vsz,rss,%mem,cmd:1000 --sort %mem |\
+                awk '{
+                  if (NR==1) printf "%10s %20s %10s %10s %5s %s", $1, $2, $3, $4, $5, $6;
+                  else printf "%10s %20s %10s %10s %5s", $1, $2, $3/1024, $4/1024, $5;
+                  $1=$2=$3=$4=$5="";
+                  print $0;
+                }'
               echo "====="
             done 
           background: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,11 +140,7 @@ jobs:
             while true; do
               sleep 5
               echo "====="
-              ps -eo pgrp,comm,vsz,rss,%mem,cmd:1000 |\
-                # skip header line, then sort by %mem
-                (read -r; printf "%s\n" "$REPLY"; sort -k 5 -nr) |\
-                # format vsz and rss, originally in kilobytes, as more friendly memory units 
-                numfmt --header --from-unit=1024 --to=iec --field 3,4
+              ps -eo pgrp,comm,vsz,rss,%mem,cmd:1000 --sort %mem
               echo "====="
             done 
           background: true

--- a/dockerfiles/build/Dockerfile
+++ b/dockerfiles/build/Dockerfile
@@ -11,7 +11,8 @@ RUN apk update && apk upgrade && \
     bash \
     curl \
     ca-certificates \
-    python
+    python \
+    procps
 USER ${SERVICE_USER}
 RUN curl -sSL https://sdk.cloud.google.com | bash && \
   exec sh && \

--- a/dockerfiles/test/Dockerfile
+++ b/dockerfiles/test/Dockerfile
@@ -11,7 +11,8 @@ RUN apk update && apk upgrade && \
     bash \
     curl \
     ca-certificates \
-    python
+    python \
+    procps
 USER ${SERVICE_USER}
 RUN curl -sSL https://sdk.cloud.google.com | bash && \
   exec sh && \


### PR DESCRIPTION
Output looks like this, much more information than before:
![image](https://user-images.githubusercontent.com/11301919/118719433-7b18e900-b7f6-11eb-9a41-5119f70ccf78.png)

Note: `VSZ` (virtual memory size, includes swap) and `RSS` (resident set size, the non-swapped physical memory) are in megabytes (output in kb, coverted via some awk for easier reading). `%MEM` is the "ratio of the process's resident set size to the physical memory on the machine", but it's a bit confusing to interpret as a % because processes could be sharing memory etc.