### PR TITLE
fixed bug: added new config to leaf_spinner_configs

### DIFF
--- a/client/src/components/LeafSpinner.js
+++ b/client/src/components/LeafSpinner.js
@@ -6,7 +6,7 @@ import { primaryColor, secondaryColor } from "src/core/color_defs";
 import leaf_loading_spinner from "src/svg/leaf-loading-spinner.svg";
 import "./LeafSpinner.scss";
 
-export const LeafSpinner = ({ config_name }) => {
+export const LeafSpinner = ({ config_name, spinner_scale }) => {
   const default_spinner_config_form = (scale) => ({
     outer_positioning: "default",
     spinner_container_style: {
@@ -17,6 +17,7 @@ export const LeafSpinner = ({ config_name }) => {
   });
 
   const leaf_spinner_configs = {
+    no_config_name: default_spinner_config_form(spinner_scale),
     initial: default_spinner_config_form(2),
     route: default_spinner_config_form(2),
     sub_route: default_spinner_config_form(2),

--- a/client/src/components/SpinnerWrapper.js
+++ b/client/src/components/SpinnerWrapper.js
@@ -10,7 +10,10 @@ export class SpinnerWrapper extends React.Component {
     return !this.props.use_leaf_spinner ? (
       <div ref="main" />
     ) : (
-      <LeafSpinner config_name={this.props.config_name} />
+      <LeafSpinner
+        config_name={this.props.config_name}
+        spinner_scale={this.props.scale}
+      />
     );
   }
 


### PR DESCRIPTION
- Scale wasn't working because when there is no config_name the LeafSpinner used the first config (initial) in leaf_spinner_configs.
- Fixed bug by adding a new config before initial that uses default_spinner_config_form(spinner_scale)