### PR TITLE
Add ssh to docker images, general image cleanup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,8 +31,8 @@ jobs:
           path: "~/InfoBase"
       - restore_cache:
           keys:
-            - email-backend-dependencies-{{ checksum "email_backend/package-lock.json" }}
-            - top-level-dependencies-{{ checksum "package-lock.json" }}
+            - email-backend-dependencies-{{ checksum "email_backend/package-lock.json" }}-v2
+            - top-level-dependencies-{{ checksum "package-lock.json" }}-v2
       - run: 
           command: |
             [ -e "email_backend/node_modules" ] || (cd email_backend && npm ci)
@@ -43,11 +43,11 @@ jobs:
           paths:
             - email_backend/node_modules
             - scripts/common_node_scripts/node_modules
-          key: email-backend-dependencies-{{ checksum "email_backend/package-lock.json" }}
+          key: email-backend-dependencies-{{ checksum "email_backend/package-lock.json" }}-v2
       - save_cache:
           paths:
             - node_modules
-          key: top-level-dependencies-{{ checksum "package-lock.json" }}
+          key: top-level-dependencies-{{ checksum "package-lock.json" }}-v2
 
       - run: (cd email_backend && npm run unit_tests)
 
@@ -84,7 +84,7 @@ jobs:
       # Use checksum of branch list to tell if the dev DBs need to be cleaned up
       - restore_cache:
           keys:
-            - dev-dbs-clean-for-these-branches--{{ checksum "./active-branches.txt" }}
+            - dev-dbs-clean-for-these-branches--{{ checksum "./active-branches.txt" }}-v2
       - run:
           command: |
             if [ ! -f "./dev-dbs-clean-for-these-branches.txt" ]; then
@@ -95,7 +95,7 @@ jobs:
       - save_cache:
           paths:
             - ./dev-dbs-clean-for-these-branches.txt
-          key: dev-dbs-clean-for-these-branches--{{ checksum "./active-branches.txt" }}
+          key: dev-dbs-clean-for-these-branches--{{ checksum "./active-branches.txt" }}-v2
 
 
   # Note: the image used for this job is built from a docker file found in ../dockerfiles/build
@@ -110,20 +110,20 @@ jobs:
 
       - restore_cache:
           keys:
-            - top-level-dependencies-{{ checksum "package-lock.json" }}
+            - top-level-dependencies-{{ checksum "package-lock.json" }}-v2
       - run: 
           command: |
             [ -e "node_modules" ] ||  npm ci
       - save_cache:
           paths:
             - node_modules
-          key: top-level-dependencies-{{ checksum "package-lock.json" }}
+          key: top-level-dependencies-{{ checksum "package-lock.json" }}-v2
 
       - run: ./scripts/ci_scripts/create_envs.sh
 
       - restore_cache:
           keys:
-            - client-dependencies-{{ checksum "client/package-lock.json" }}
+            - client-dependencies-{{ checksum "client/package-lock.json" }}-v2
       - run: 
           command: |
             [ -e "client/node_modules" ] || (cd client && npm ci)
@@ -131,7 +131,7 @@ jobs:
           paths:
             - client/node_modules
             - scripts/common_node_scripts/node_modules
-          key: client-dependencies-{{ checksum "client/package-lock.json" }}
+          key: client-dependencies-{{ checksum "client/package-lock.json" }}-v2
 
       - run: ./scripts/ci_scripts/get_bundle_stats_baseline.sh
 
@@ -153,20 +153,20 @@ jobs:
 
       - restore_cache:
           keys:
-            - prod-build-{{ .Branch }}-{{ .Revision }}
+            - prod-build-{{ .Branch }}-{{ .Revision }}-v2
       - run:
           command: |
             [ -f "client/$BUILD_DIR/InfoBase/app/app-a11y-en.min.js" ] || (cd client && ./deploy_scripts/build_all.sh -m 1536 -c "none")
       - save_cache:
           paths:
             - client/build
-          key: prod-build-{{ .Branch }}-{{ .Revision }}
+          key: prod-build-{{ .Branch }}-{{ .Revision }}-v2
       
       - run: cd client && npm run build-storybook -- -o $BUILD_DIR/InfoBase/storybook && npm run build-storybook-a11y -- -o $BUILD_DIR/InfoBase/storybook-a11y
 
       - restore_cache:
           keys:
-            - server-dependencies-{{ checksum "server/package-lock.json" }}
+            - server-dependencies-{{ checksum "server/package-lock.json" }}-v2
       - run: 
           command: |
             [ -e "server/node_modules" ] || (cd server && npm ci)
@@ -174,18 +174,18 @@ jobs:
           paths:
             - server/node_modules
             - scripts/common_node_scripts/node_modules
-          key: server-dependencies-{{ checksum "server/package-lock.json" }}
+          key: server-dependencies-{{ checksum "server/package-lock.json" }}-v2
 
       - restore_cache:
           keys:
-            - server-transpiled-build-{{ .Branch }}-{{ .Revision }}
+            - server-transpiled-build-{{ .Branch }}-{{ .Revision }}-v2
       - run:
           command: |
             [ -f "server/transpiled_build/app.js" ] || (cd server && ./deploy_scripts/build.sh)
       - save_cache:
           paths:
             - server/transpiled_build
-          key: server-transpiled-build-{{ .Branch }}-{{ .Revision }}
+          key: server-transpiled-build-{{ .Branch }}-{{ .Revision }}-v2
 
       - persist_to_workspace:
           root: ./
@@ -301,7 +301,7 @@ jobs:
       # Use this cached file to tell if the data needs to be loaded to mongodb (if on a new branch or if data has changed)
       - restore_cache:
           keys:
-            - data-is-deployed-{{ .Branch }}-{{ checksum "./data-checksums.txt" }}
+            - data-is-deployed-{{ .Branch }}-{{ checksum "./data-checksums.txt" }}-v2
       - run:
           command: |
             [ -f "./this-data-is-deployed.txt" ] || (cd server && npm run populate_db:remote)
@@ -309,7 +309,7 @@ jobs:
       - save_cache:
           paths:
             - ./this-data-is-deployed.txt
-          key: data-is-deployed--{{ .Branch }}-{{ checksum "./data-checksums.txt" }}
+          key: data-is-deployed--{{ .Branch }}-{{ checksum "./data-checksums.txt" }}-v2
 
 
   # Note: the image used for this job is provided by google
@@ -330,7 +330,7 @@ jobs:
       # Use this cached file to tell if the api needs to be redeployed (if on a new branch, if function code's changed, or if server node modules have changed)
       - restore_cache:
           keys:
-            - api-is-deployed-{{ .Branch }}-{{ checksum "./server-checksums.txt" }}-{{ checksum "./server/package-lock.json" }}
+            - api-is-deployed-{{ .Branch }}-{{ checksum "./server-checksums.txt" }}-{{ checksum "./server/package-lock.json" }}-v2
       - run:
           command: |
             [ -f "./this-api-is-deployed.txt" ] || (cd server && ./deploy_scripts/ci_deploy_function.sh)
@@ -338,7 +338,7 @@ jobs:
       - save_cache:
           paths:
             - ./this-api-is-deployed.txt
-          key: api-is-deployed--{{ .Branch }}-{{ checksum "./server-checksums.txt" }}-{{ checksum "./server/package-lock.json" }}
+          key: api-is-deployed--{{ .Branch }}-{{ checksum "./server-checksums.txt" }}-{{ checksum "./server/package-lock.json" }}-v2
 
 
   # Note: the image used for this job is provided by google

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
   # Note: the image used for this job is built from a docker file found in ../dockerfiles/build
   test_email_backend:
     docker:
-      - image: eaadtbs/ib-ci-build:1.5
+      - image: eaadtbs/ib-ci-build:1.6
         <<: *dockerhub_auth
     working_directory: "~/InfoBase"
     steps:
@@ -65,7 +65,7 @@ jobs:
   # Note: the image used for this job is built from a docker file found in ../dockerfiles/build
   cleanup_dev_links:
     docker:
-      - image: eaadtbs/ib-ci-test:1.5
+      - image: eaadtbs/ib-ci-test:1.6
         <<: *dockerhub_auth
     working_directory: "~/InfoBase"
     steps:
@@ -101,7 +101,7 @@ jobs:
   # Note: the image used for this job is built from a docker file found in ../dockerfiles/build
   build:
     docker:
-      - image: eaadtbs/ib-ci-build:1.5
+      - image: eaadtbs/ib-ci-build:1.6
         <<: *dockerhub_auth
     working_directory: "~/InfoBase"
     steps:
@@ -219,7 +219,7 @@ jobs:
   # Note: the image used for this job is built from a docker file found in ../dockerfiles/test
   test_server:
     docker:
-      - image: eaadtbs/ib-ci-test:1.5
+      - image: eaadtbs/ib-ci-test:1.6
         <<: *dockerhub_auth
     working_directory: "~/InfoBase"
     steps:
@@ -251,7 +251,7 @@ jobs:
   # Note: the image used for this job is built from a docker file found in ../dockerfiles/test
   test_end_to_end: # slower but more in-depth than the test job. Wait until these have passed before deploying the client
     docker:
-      - image: eaadtbs/ib-ci-test:1.5
+      - image: eaadtbs/ib-ci-test:1.6
         <<: *dockerhub_auth
     working_directory: "~/InfoBase"
     steps:
@@ -288,7 +288,7 @@ jobs:
   deploy_data:
     working_directory: "~/InfoBase"
     docker:
-      - image: eaadtbs/ib-ci-test:1.5
+      - image: eaadtbs/ib-ci-test:1.6
         <<: *dockerhub_auth
     steps:
       - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
   # Note: the image used for this job is built from a docker file found in ../dockerfiles/build
   test_email_backend:
     docker:
-      - image: eaadtbs/ib-ci-build:1.6
+      - image: eaadtbs/ib-ci-build:2.0
         <<: *dockerhub_auth
     working_directory: "~/InfoBase"
     steps:
@@ -65,7 +65,7 @@ jobs:
   # Note: the image used for this job is built from a docker file found in ../dockerfiles/build
   cleanup_dev_links:
     docker:
-      - image: eaadtbs/ib-ci-test:1.6
+      - image: eaadtbs/ib-ci-test:2.0
         <<: *dockerhub_auth
     working_directory: "~/InfoBase"
     steps:
@@ -101,7 +101,7 @@ jobs:
   # Note: the image used for this job is built from a docker file found in ../dockerfiles/build
   build:
     docker:
-      - image: eaadtbs/ib-ci-build:1.6
+      - image: eaadtbs/ib-ci-build:2.0
         <<: *dockerhub_auth
     working_directory: "~/InfoBase"
     steps:
@@ -219,7 +219,7 @@ jobs:
   # Note: the image used for this job is built from a docker file found in ../dockerfiles/test
   test_server:
     docker:
-      - image: eaadtbs/ib-ci-test:1.6
+      - image: eaadtbs/ib-ci-test:2.0
         <<: *dockerhub_auth
     working_directory: "~/InfoBase"
     steps:
@@ -251,7 +251,7 @@ jobs:
   # Note: the image used for this job is built from a docker file found in ../dockerfiles/test
   test_end_to_end: # slower but more in-depth than the test job. Wait until these have passed before deploying the client
     docker:
-      - image: eaadtbs/ib-ci-test:1.6
+      - image: eaadtbs/ib-ci-test:2.0
         <<: *dockerhub_auth
     working_directory: "~/InfoBase"
     steps:
@@ -288,7 +288,7 @@ jobs:
   deploy_data:
     working_directory: "~/InfoBase"
     docker:
-      - image: eaadtbs/ib-ci-test:1.6
+      - image: eaadtbs/ib-ci-test:2.0
         <<: *dockerhub_auth
     steps:
       - attach_workspace:

--- a/dockerfiles/build/Dockerfile
+++ b/dockerfiles/build/Dockerfile
@@ -1,10 +1,10 @@
 FROM mhart/alpine-node:14
 
-ENV SERVICE_USER build-image-user
+ENV SERVICE_USER service-user
 ENV SERVICE_HOME /home/${SERVICE_USER}
 
-# common
 RUN adduser -h ${SERVICE_HOME} -s /sbin/nologin -u 1000 -D ${SERVICE_USER}
+
 RUN apk update && apk upgrade && \
   apk add --no-cache \
     git \
@@ -14,13 +14,12 @@ RUN apk update && apk upgrade && \
     python \
     procps \
     openssh
+
 USER ${SERVICE_USER}
+
 RUN curl -sSL https://sdk.cloud.google.com | bash && \
   exec sh && \
   gcloud init
 ENV PATH $SERVICE_HOME/google-cloud-sdk/bin:$PATH
-USER root
 
-USER    ${SERVICE_USER}
-WORKDIR ${SERVICE_HOME}
 VOLUME  ${SERVICE_HOME}

--- a/dockerfiles/build/Dockerfile
+++ b/dockerfiles/build/Dockerfile
@@ -12,20 +12,14 @@ RUN apk update && apk upgrade && \
     curl \
     ca-certificates \
     python \
-    procps
+    procps \
+    openssh
 USER ${SERVICE_USER}
 RUN curl -sSL https://sdk.cloud.google.com | bash && \
   exec sh && \
   gcloud init
 ENV PATH $SERVICE_HOME/google-cloud-sdk/bin:$PATH
 USER root
-
-# image specific
-RUN apk add --no-cache --virtual .gyp \
-  make \
-  openssh \
-  g++ \
-  && apk del .gyp
 
 USER    ${SERVICE_USER}
 WORKDIR ${SERVICE_HOME}

--- a/dockerfiles/test/Dockerfile
+++ b/dockerfiles/test/Dockerfile
@@ -12,7 +12,8 @@ RUN apk update && apk upgrade && \
     curl \
     ca-certificates \
     python \
-    procps
+    procps \
+    openssh
 USER ${SERVICE_USER}
 RUN curl -sSL https://sdk.cloud.google.com | bash && \
   exec sh && \

--- a/dockerfiles/test/Dockerfile
+++ b/dockerfiles/test/Dockerfile
@@ -1,31 +1,13 @@
-FROM mhart/alpine-node:14
+FROM eaadtbs/ib-ci-build:2.0
 
-ENV SERVICE_USER test-image-user
-ENV SERVICE_HOME /home/${SERVICE_USER}
-
-# common
-RUN adduser -h ${SERVICE_HOME} -s /sbin/nologin -u 1000 -D ${SERVICE_USER}
-RUN apk update && apk upgrade && \
-  apk add --no-cache \
-    git \
-    bash \
-    curl \
-    ca-certificates \
-    python \
-    procps \
-    openssh
-USER ${SERVICE_USER}
-RUN curl -sSL https://sdk.cloud.google.com | bash && \
-  exec sh && \
-  gcloud init
-ENV PATH $SERVICE_HOME/google-cloud-sdk/bin:$PATH
 USER root
 
-# image specific
+# for test-cafe
 RUN apk add --no-cache \
   udev \
   xvfb \
   chromium
+
 # mongodb not not available in alpine apk repositories post 3.9, switch back to old repo and install from there
 # TODO check if this is still necessary in the future 
 RUN echo 'http://dl-cdn.alpinelinux.org/alpine/v3.9/main' >> /etc/apk/repositories && \
@@ -33,9 +15,7 @@ RUN echo 'http://dl-cdn.alpinelinux.org/alpine/v3.9/main' >> /etc/apk/repositori
   apk update && \
   apk add mongodb yaml-cpp=0.6.2-r2
 
-# create default mongodb data directory and give the $USER access
+# create default mongodb data directory and give the $SERVICE_USER access
 RUN mkdir -p /data/db && chown -R ${SERVICE_USER} /data/db
 
-USER    ${SERVICE_USER}
-WORKDIR ${SERVICE_HOME}
-VOLUME  ${SERVICE_HOME}
+USER ${SERVICE_USER}


### PR DESCRIPTION
RE: 
![image](https://user-images.githubusercontent.com/11301919/120340201-c84f8d00-c2c3-11eb-8e2a-290a616aaffe.png)

Finally found a case where the CircleCI native git client's non-standard behaviour was a problem. Added ssh to build and test images (we already had git), checkout now uses standard git. Resolved the issue.

While I was at it, I cleaned up some legacy lines in the build docker image and updated the test image to use the build image as its base. 