### PR TITLE
Util types for special Omit cases

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,8 @@
 node_modules
 
+# TEMPORARY... prettier 2.0 doesn't understand TypeScript's `as` keyword AND had a // prettier-ignore bug, ha
+client/src/types/util_types.d.ts
+
 # generated stuff
 client/app/
 client/build/

--- a/client/src/types/util_types.d.ts
+++ b/client/src/types/util_types.d.ts
@@ -18,6 +18,4 @@ export type WithoutIndexTypes<T> = Pick<T, KnownKeys<T>>;
 // e.g. if a type has [key: string]: any then Omit will swallow ALL OTHER string-keyed properties...
 // SafeOmit does not, only omits what you tell it to
 // TODO revisit the need for this once we have negated types https://github.com/Microsoft/TypeScript/pull/29317
-// TODO drop prettier-ignore after prettier is updated past 2.0 (it doesn't understand TypeScript's "as" keyword in 2.0, does by 2.3 at least)
-// prettier-ignore
 export type SafeOmit<T, K extends PropertyKey> = { [P in keyof T as Exclude<P, K>]: T[P] };

--- a/client/src/types/util_types.d.ts
+++ b/client/src/types/util_types.d.ts
@@ -13,9 +13,11 @@ export type KnownKeys<T> = {
 export type WithoutIndexTypes<T> = Pick<T, KnownKeys<T>>;
 
 // from https://stackoverflow.com/a/54827898
-// TODO revisit the need for this once we have negated types https://github.com/Microsoft/TypeScript/pull/29317
 // See for motivation: https://github.com/TBS-EACPD/infobase/pull/1121
 // TLDR: the built in Omit will lose a lot of type information when used on something with an index type
 // e.g. if a type has [key: string]: any then Omit will swallow ALL OTHER string-keyed properties...
 // SafeOmit does not, only omits what you tell it to
+// TODO revisit the need for this once we have negated types https://github.com/Microsoft/TypeScript/pull/29317
+// TODO drop prettier-ignore after prettier is updated past 2.0 (it doesn't understand TypeScript's "as" keyword in 2.0, does by 2.3 at least)
+// prettier-ignore
 export type SafeOmit<T, K extends PropertyKey> = { [P in keyof T as Exclude<P, K>]: T[P] };

--- a/client/src/types/util_types.d.ts
+++ b/client/src/types/util_types.d.ts
@@ -4,7 +4,7 @@
 // https://github.com/microsoft/TypeScript/issues/25987#issuecomment-441224690
 export type KnownKeys<T> = {
   [K in keyof T]: string extends K ? never : number extends K ? never : K;
-} extends { [_ in keyof T]: infer U }
+} extends { [_ in keyof T]: infer U } // eslint-disable-line no-unused-vars
   ? {} extends U
     ? never
     : U

--- a/client/src/types/util_types.d.ts
+++ b/client/src/types/util_types.d.ts
@@ -19,7 +19,7 @@ export type WithoutIndexTypes<T> = KnownKeys<T> extends infer U
 
 // based on https://github.com/microsoft/TypeScript/issues/31153#issuecomment-487894895
 // TODO revisit the need for this once we have negated types https://github.com/Microsoft/TypeScript/pull/29317
-// See for motivation: TODO link to PR here
+// See for motivation: https://github.com/TBS-EACPD/infobase/pull/1121
 export type IndexTypeSafeOmit<T, K extends keyof T> = Omit<
   WithoutIndexTypes<T>,
   K

--- a/client/src/types/util_types.d.ts
+++ b/client/src/types/util_types.d.ts
@@ -1,0 +1,36 @@
+// by Klaus Meinhardt @ajafff
+// known from Gerrit Birkeland @Gerrit0
+// https://github.com/Microsoft/TypeScript/issues/25987#issuecomment-408339599
+// https://github.com/microsoft/TypeScript/issues/25987#issuecomment-441224690
+export type KnownKeys<T> = {
+  [K in keyof T]: string extends K ? never : number extends K ? never : K;
+} extends { [_ in keyof T]: infer U }
+  ? {} extends U
+    ? never
+    : U
+  : never;
+
+// based on https://github.com/microsoft/TypeScript/issues/31153#issuecomment-487894895
+export type WithoutIndexTypes<T> = KnownKeys<T> extends infer U
+  ? [U] extends [keyof T]
+    ? Pick<T, U>
+    : never
+  : never;
+
+// based on https://github.com/microsoft/TypeScript/issues/31153#issuecomment-487894895
+// TODO revisit the need for this once we have negated types https://github.com/Microsoft/TypeScript/pull/29317
+// See for motivation: TODO link to PR here
+export type IndexTypeSafeOmit<T, K extends keyof T> = Omit<
+  WithoutIndexTypes<T>,
+  K
+> &
+  (string extends K // preserve wildcard string index type
+    ? {}
+    : string extends keyof T
+    ? { [n: string]: T[Exclude<keyof T, number>] }
+    : {}) &
+  (number extends K // preserve wildcard number index type
+    ? {}
+    : number extends keyof T
+    ? { [n: number]: T[Exclude<keyof T, string>] }
+    : {});

--- a/client/src/types/util_types.d.ts
+++ b/client/src/types/util_types.d.ts
@@ -10,27 +10,12 @@ export type KnownKeys<T> = {
     : U
   : never;
 
-// based on https://github.com/microsoft/TypeScript/issues/31153#issuecomment-487894895
-export type WithoutIndexTypes<T> = KnownKeys<T> extends infer U
-  ? [U] extends [keyof T]
-    ? Pick<T, U>
-    : never
-  : never;
+export type WithoutIndexTypes<T> = Pick<T, KnownKeys<T>>;
 
-// based on https://github.com/microsoft/TypeScript/issues/31153#issuecomment-487894895
+// from https://stackoverflow.com/a/54827898
 // TODO revisit the need for this once we have negated types https://github.com/Microsoft/TypeScript/pull/29317
 // See for motivation: https://github.com/TBS-EACPD/infobase/pull/1121
-export type IndexTypeSafeOmit<T, K extends keyof T> = Omit<
-  WithoutIndexTypes<T>,
-  K
-> &
-  (string extends K // preserve wildcard string index type
-    ? {}
-    : string extends keyof T
-    ? { [n: string]: T[Exclude<keyof T, number>] }
-    : {}) &
-  (number extends K // preserve wildcard number index type
-    ? {}
-    : number extends keyof T
-    ? { [n: number]: T[Exclude<keyof T, string>] }
-    : {});
+// TLDR: the built in Omit will lose a lot of type information when used on something with an index type
+// e.g. if a type has [key: string]: any then Omit will swallow ALL OTHER string-keyed properties...
+// SafeOmit does not, only omits what you tell it to
+export type SafeOmit<T, K extends PropertyKey> = { [P in keyof T as Exclude<P, K>]: T[P] };


### PR DESCRIPTION
As encountered [here](https://github.com/TBS-EACPD/infobase/pull/1071#pullrequestreview-676613323), using the built in [Omit util](https://www.typescriptlang.org/docs/handbook/utility-types.html#omittype-keys) on a something that has any index types on it will give an unexpected result... Although they say it's [the expected behaviour](https://github.com/microsoft/TypeScript/issues/31153#issuecomment-487679270) regardless :shrug: .

Scrounged up a handful of useful util types from the various discussions of this issue. We'll probably want to use `IndexTypeSafeOmit`\* pretty much anywhere we need to omit keys, since it doesn't have the fiddly gotcha of the built-in.

\* names in this branch feel kinda awkward, would welcome any better suggestions!