### PR TITLE
More TypeScript lint rules

### DIFF
--- a/client/.eslintrc.json
+++ b/client/.eslintrc.json
@@ -2,7 +2,6 @@
   "plugins": ["react", "@typescript-eslint"],
   "extends": [
     "../.eslintrc.json",
-    "plugin:import/typescript",
     "plugin:react/recommended",
     "plugin:react-hooks/recommended"
   ],
@@ -40,13 +39,14 @@
     {
       "files": ["*.ts", "*.tsx"],
       "extends": [
+        "plugin:import/typescript",
         "plugin:@typescript-eslint/eslint-recommended",
         "plugin:@typescript-eslint/recommended"
       ],
       "rules": {
         "no-prototype-builtins": "off", //common TS pattern
         "@typescript-eslint/no-redeclare": ["error"],
-        "@typescript-eslint/explicit-module-boundary-types": "off" // TODO might want to turn this on later, but it will raise a LOT of warnings to manually lint
+        "@typescript-eslint/explicit-module-boundary-types": "off" // TODO might want to turn this on later, but it will take a while to fix all the warnings
       }
     }
   ],

--- a/client/.eslintrc.json
+++ b/client/.eslintrc.json
@@ -45,6 +45,8 @@
       ],
       "rules": {
         "no-prototype-builtins": "off", //common TS pattern
+        "@typescript-eslint/no-unused-vars": "off", // Lot of false positives on this rule. Better to use the exprimental
+        "@typescript-eslint/no-unused-vars-experimental": "warn",
         "@typescript-eslint/no-redeclare": ["error"],
         "@typescript-eslint/explicit-module-boundary-types": "off" // TODO might want to turn this on later, but it will take a while to fix all the warnings
       }

--- a/client/.eslintrc.json
+++ b/client/.eslintrc.json
@@ -4,7 +4,9 @@
     "../.eslintrc.json",
     "plugin:import/typescript",
     "plugin:react/recommended",
-    "plugin:react-hooks/recommended"
+    "plugin:react-hooks/recommended",
+    "plugin:@typescript-eslint/eslint-recommended",
+    "plugin:@typescript-eslint/recommended"
   ],
   "parser": "@typescript-eslint/parser",
   "env": {
@@ -36,8 +38,8 @@
   "rules": {
     "no-prototype-builtins": "off", //common TS pattern
     "no-use-before-define": "off",
-    "no-redeclare": "off", // Need to use @typescript-eslint/no-redeclare for ts overloading
     "no-restricted-imports": ["error", { "patterns": ["../*"] }],
+
     "react/jsx-uses-vars": 1,
     "react/jsx-no-target-blank": ["off"],
     "react/prop-types": ["off"],
@@ -45,6 +47,8 @@
     "react/display-name": ["off"],
     "react/no-find-dom-node": ["off"],
     "react/no-children-prop": ["off"],
+
+    "no-redeclare": "off", // Need to use @typescript-eslint/no-redeclare for ts overloading
     "@typescript-eslint/no-redeclare": ["error"]
   },
   "settings": {

--- a/client/.eslintrc.json
+++ b/client/.eslintrc.json
@@ -4,9 +4,7 @@
     "../.eslintrc.json",
     "plugin:import/typescript",
     "plugin:react/recommended",
-    "plugin:react-hooks/recommended",
-    "plugin:@typescript-eslint/eslint-recommended",
-    "plugin:@typescript-eslint/recommended"
+    "plugin:react-hooks/recommended"
   ],
   "parser": "@typescript-eslint/parser",
   "env": {
@@ -14,13 +12,18 @@
     "commonjs": true,
     "es6": true
   },
+  "rules": {
+    "no-use-before-define": "off",
+    "no-restricted-imports": ["error", { "patterns": ["../*"] }],
+    "react/jsx-uses-vars": 1,
+    "react/jsx-no-target-blank": ["off"],
+    "react/prop-types": ["off"],
+    "react/no-string-refs": ["off"],
+    "react/display-name": ["off"],
+    "react/no-find-dom-node": ["off"],
+    "react/no-children-prop": ["off"]
+  },
   "overrides": [
-    {
-      "files": ["*.ts", "*.tsx"],
-      "rules": {
-        "no-undef": "off"
-      }
-    },
     {
       "files": ["*.ts", "*.tsx", "*.js"],
       "rules": {
@@ -33,24 +36,21 @@
           }
         ]
       }
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "extends": [
+        "plugin:@typescript-eslint/eslint-recommended",
+        "plugin:@typescript-eslint/recommended"
+      ],
+      "rules": {
+        "no-redeclare": "off", // Need to use @typescript-eslint/no-redeclare for ts overloading
+        "@typescript-eslint/no-redeclare": ["error"],
+
+        "no-prototype-builtins": "off" //common TS pattern
+      }
     }
   ],
-  "rules": {
-    "no-prototype-builtins": "off", //common TS pattern
-    "no-use-before-define": "off",
-    "no-restricted-imports": ["error", { "patterns": ["../*"] }],
-
-    "react/jsx-uses-vars": 1,
-    "react/jsx-no-target-blank": ["off"],
-    "react/prop-types": ["off"],
-    "react/no-string-refs": ["off"],
-    "react/display-name": ["off"],
-    "react/no-find-dom-node": ["off"],
-    "react/no-children-prop": ["off"],
-
-    "no-redeclare": "off", // Need to use @typescript-eslint/no-redeclare for ts overloading
-    "@typescript-eslint/no-redeclare": ["error"]
-  },
   "settings": {
     "react": {
       "version": "17"

--- a/client/.eslintrc.json
+++ b/client/.eslintrc.json
@@ -44,10 +44,9 @@
         "plugin:@typescript-eslint/recommended"
       ],
       "rules": {
-        "no-redeclare": "off", // Need to use @typescript-eslint/no-redeclare for ts overloading
+        "no-prototype-builtins": "off", //common TS pattern
         "@typescript-eslint/no-redeclare": ["error"],
-
-        "no-prototype-builtins": "off" //common TS pattern
+        "@typescript-eslint/explicit-module-boundary-types": "off" // TODO might want to turn this on later, but it will raise a LOT of warnings to manually lint
       }
     }
   ],

--- a/client/build_code/webpack_common.js
+++ b/client/build_code/webpack_common.js
@@ -160,7 +160,7 @@ function get_plugins({
       IS_CI: JSON.stringify(is_ci),
       LOCAL_IP: JSON.stringify(local_ip),
     }),
-    new ESLintPlugin({ extensions: ["js", "ts", "tsx"] }),
+    //new ESLintPlugin({ extensions: ["js", "ts", "tsx"] }),
     new ForkTsCheckerWebpackPlugin({
       async: true,
       typescript: { configFile: "tsconfig.json" },

--- a/client/build_code/webpack_common.js
+++ b/client/build_code/webpack_common.js
@@ -160,7 +160,7 @@ function get_plugins({
       IS_CI: JSON.stringify(is_ci),
       LOCAL_IP: JSON.stringify(local_ip),
     }),
-    //new ESLintPlugin({ extensions: ["js", "ts", "tsx"] }),
+    new ESLintPlugin({ extensions: ["js", "ts", "tsx"] }),
     new ForkTsCheckerWebpackPlugin({
       async: true,
       typescript: { configFile: "tsconfig.json" },

--- a/client/src/FAQ/faq_data.ts
+++ b/client/src/FAQ/faq_data.ts
@@ -15,7 +15,7 @@ export const faq_data = _.chain(faq_csv_string)
     qa_row.id,
     {
       q: qa_row[`q_${lang}`],
-      a: marked(qa_row[`a_${lang}`]!, { sanitize: false, gfm: true }),
+      a: marked(qa_row[`a_${lang}`] as string, { sanitize: false, gfm: true }),
     },
   ])
   .fromPairs()

--- a/client/src/InfoBase/AppState.ts
+++ b/client/src/InfoBase/AppState.ts
@@ -2,7 +2,7 @@ import { lang } from "src/core/injected_build_constants";
 
 export const app_reducer = (
   state = { lang: lang, is_showing_graph_overlay: true },
-  { type, payload }: { [key: string]: string }
+  { type }: { [key: string]: string }
 ) => {
   switch (type) {
     case "graph_overlay":

--- a/client/src/InfoBase/AppState.ts
+++ b/client/src/InfoBase/AppState.ts
@@ -2,7 +2,7 @@ import { lang } from "src/core/injected_build_constants";
 
 export const app_reducer = (
   state = { lang: lang, is_showing_graph_overlay: true },
-  { type }: { [key: string]: string }
+  { type, _payload }: { [key: string]: string }
 ) => {
   switch (type) {
     case "graph_overlay":

--- a/client/src/about/about.tsx
+++ b/client/src/about/about.tsx
@@ -46,7 +46,7 @@ const tech_icon_list = _.chain([
 interface AboutProps {
   toggleSurvey: () => void;
 }
-export default class About extends React.Component<AboutProps, {}> {
+export default class About extends React.Component<AboutProps, never> {
   render() {
     const { toggleSurvey } = this.props;
 

--- a/client/src/charts/graphRegistry.ts
+++ b/client/src/charts/graphRegistry.ts
@@ -7,21 +7,21 @@ import { Dispatch, dispatch } from "d3-dispatch";
 import { Selection } from "d3-selection";
 import _ from "lodash";
 
-interface GraphRegistryOptions {
+interface GraphRegistryOptions<T extends Record<string, unknown>> {
   height?: number;
   alternative_svg?: string;
-  dispatch?: Dispatch<any>;
+  dispatch?: Dispatch<T>;
   events?: string[];
 }
 
-class GraphRegistry {
-  registry: GraphRegistry[];
+class GraphRegistry<T extends Record<string, unknown>> {
+  registry: GraphRegistry<T>[];
   window_width_last_updated_at: number;
-  options: GraphRegistryOptions;
+  options: GraphRegistryOptions<T>;
   outside_width: number | undefined;
   outside_height: number | undefined;
-  dispatch: Dispatch<any> | undefined;
-  render: Function | undefined;
+  dispatch: Dispatch<T> | undefined;
+  render: (options: GraphRegistryOptions<T>) => void | undefined;
   svg: Selection<SVGElement, {}, HTMLElement, any> | undefined;
   html: Selection<SVGElement, {}, HTMLElement, any> | undefined;
 
@@ -30,20 +30,19 @@ class GraphRegistry {
     this.window_width_last_updated_at = window.innerWidth;
     this.options = {};
 
-    const that = this;
     window.addEventListener(
       "hashchange",
       _.debounce(function () {
-        that.update_registry();
+        this.update_registry();
       }, 250)
     );
 
     window.addEventListener(
       "resize",
       _.debounce(function () {
-        if (that.should_graphs_update()) {
-          that.update_registry();
-          that.update_graphs();
+        if (this.should_graphs_update()) {
+          this.update_registry();
+          this.update_graphs();
         }
       }, 250)
     );

--- a/client/src/charts/graphRegistry.ts
+++ b/client/src/charts/graphRegistry.ts
@@ -57,11 +57,10 @@ class GraphRegistry<T extends Record<string, unknown>> {
   }
 
   update_registry() {
-    const new_registry = this.registry.filter((panel_obj) => {
-      if (panel_obj.html) {
-        document.body.contains(panel_obj.html.node());
-      }
-    });
+    const new_registry = this.registry.filter(
+      (panel_obj) =>
+        panel_obj.html && document.body.contains(panel_obj.html.node())
+    );
     this.registry = new_registry;
   }
 

--- a/client/src/components/Accordion/Accordions.tsx
+++ b/client/src/components/Accordion/Accordions.tsx
@@ -24,22 +24,23 @@ function FirstChild(props: { children: React.ReactElement }) {
   return childrenArray[0] || null;
 }
 
-interface AccordionEnterExitProps {
+type AccordionEnterExitProps = typeof AccordionEnterExit.defaultProps & {
   opening_opacity?: number;
   closing_opacity?: number;
   expandDuration: number;
   collapseDuration: number;
-  max_height: number | string;
+  max_height: string;
   onExited?: (node: HTMLElement) => void;
   enter?: boolean;
   exit?: boolean;
   in?: boolean;
   className: string;
   style: { [key: string]: string };
-  children: React.ReactElement;
-}
+  children: React.ReactNode;
+};
+
 class AccordionEnterExit extends React.Component<AccordionEnterExitProps> {
-  defaultProps = {
+  static defaultProps = {
     max_height: "80vh",
     opening_opacity: 1e-6,
     closing_opacity: 1,
@@ -48,19 +49,19 @@ class AccordionEnterExit extends React.Component<AccordionEnterExitProps> {
     const node = ReactDOM.findDOMNode(component) as HTMLElement;
     const initialHeight = node.offsetHeight;
     select(node)
-      .style("opacity", this.props.closing_opacity!)
+      .style("opacity", this.props.closing_opacity)
       .style("max-height", initialHeight + "px")
       .transition()
       .ease(easeLinear)
       .duration(this.props.collapseDuration)
-      .style("opacity", this.props.opening_opacity!)
+      .style("opacity", this.props.opening_opacity)
       .style("max-height", "1px");
   };
   onEntering = (component: HTMLElement) => {
     const node = ReactDOM.findDOMNode(component) as HTMLElement;
     select(node)
       .style("max-height", "0px")
-      .style("opacity", this.props.opening_opacity!)
+      .style("opacity", this.props.opening_opacity)
       .transition()
       .ease(easeLinear)
       .duration(this.props.expandDuration)
@@ -104,7 +105,7 @@ class AccordionEnterExit extends React.Component<AccordionEnterExitProps> {
 }
 
 interface CommonStatelessPullDownAccordionProps {
-  max_height: number | string;
+  max_height: string;
   title: string;
   children: React.ReactElement;
   onToggle: React.ReactEventHandler<HTMLElement>;

--- a/client/src/components/AlertBanner/AlertBanner.tsx
+++ b/client/src/components/AlertBanner/AlertBanner.tsx
@@ -8,7 +8,7 @@ interface AlertBannerProps {
   children: React.ReactNode;
   banner_class: string;
   additional_class_names: string;
-  style: Record<string, unknown>;
+  style: React.CSSProperties;
 }
 
 export const banner_classes = ["info", "success", "warning", "danger"];

--- a/client/src/components/AlertBanner/AlertBanner.tsx
+++ b/client/src/components/AlertBanner/AlertBanner.tsx
@@ -8,7 +8,7 @@ interface AlertBannerProps {
   children: React.ReactNode;
   banner_class: string;
   additional_class_names: string;
-  style: Object;
+  style: Record<string, unknown>;
 }
 
 export const banner_classes = ["info", "success", "warning", "danger"];

--- a/client/src/components/AutoHeightVirtualList.tsx
+++ b/client/src/components/AutoHeightVirtualList.tsx
@@ -4,9 +4,10 @@ import type { ListProps } from "react-virtualized";
 
 import { SafeOmit } from "src/types/util_types.d";
 
+/* eslint-disable @typescript-eslint/no-explicit-any */
 interface AutoHeightVirtualListProps extends SafeOmit<ListProps, "height"> {
-  list_ref: React.RefObject<any>; //cannot use List from react-virtualized because it doesn't have "getTotalRowsHeight"
-  max_height?: number;
+  list_ref: React.RefObject<any>; //cannot use List from react-virtualized because it doesn't have "getTotalRowsHeight". Possible workaround: (this.list_ref.current.Grid as any).getTotalRowsHeight();
+  max_height: number;
 }
 
 interface AutoHeightVirtualListState {
@@ -18,9 +19,6 @@ export class AutoHeightVirtualList extends React.Component<
   AutoHeightVirtualListState
 > {
   list_ref: React.RefObject<any>;
-  static defaultProps = {
-    max_height: 400,
-  };
 
   constructor(props: AutoHeightVirtualListProps) {
     super(props);
@@ -28,24 +26,21 @@ export class AutoHeightVirtualList extends React.Component<
     this.list_ref = props.list_ref || React.createRef();
 
     this.state = {
-      list_height: props.max_height!,
+      list_height: props.max_height,
     };
   }
 
-  componentDidUpdate(
-    prev_props: AutoHeightVirtualListProps,
-    prev_state: AutoHeightVirtualListState
-  ) {
+  componentDidUpdate() {
     const { max_height } = this.props;
 
     if (this.list_ref && this.list_ref.current) {
       this.list_ref.current.Grid.measureAllCells();
       const list_height = this.list_ref.current.Grid.getTotalRowsHeight();
       if (list_height !== this.state.list_height) {
-        if (list_height < max_height!) {
+        if (list_height < max_height) {
           this.setState({ list_height: list_height });
-        } else if (this.state.list_height < max_height!) {
-          this.setState({ list_height: max_height! });
+        } else if (this.state.list_height < max_height) {
+          this.setState({ list_height: max_height });
         }
       }
     }

--- a/client/src/components/AutoHeightVirtualList.tsx
+++ b/client/src/components/AutoHeightVirtualList.tsx
@@ -4,8 +4,8 @@ import type { ListProps } from "react-virtualized";
 
 import { SafeOmit } from "src/types/util_types.d";
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
 interface AutoHeightVirtualListProps extends SafeOmit<ListProps, "height"> {
+  /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
   list_ref: React.RefObject<any>; //cannot use List from react-virtualized because it doesn't have "getTotalRowsHeight". Possible workaround: (this.list_ref.current.Grid as any).getTotalRowsHeight();
   max_height: number;
 }
@@ -18,6 +18,7 @@ export class AutoHeightVirtualList extends React.Component<
   AutoHeightVirtualListProps,
   AutoHeightVirtualListState
 > {
+  /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
   list_ref: React.RefObject<any>;
 
   constructor(props: AutoHeightVirtualListProps) {

--- a/client/src/components/BackToTop/BackToTop.tsx
+++ b/client/src/components/BackToTop/BackToTop.tsx
@@ -35,24 +35,35 @@ export class BackToTop extends React.Component<BackToTopProps, BackToTopState> {
   }
 
   componentDidMount() {
-    this.page_header = document.getElementById("ib-site-header-area")!;
-    this.page_footer = document.getElementById("wb-info")!;
+    this.page_header = document.getElementById("ib-site-header-area");
+    this.page_footer = document.getElementById("wb-info");
 
-    this.header_observer = new IntersectionObserver((entries, observer) => {
+    this.header_observer = new IntersectionObserver((entries) => {
       this.setState({ show_back_to_top: entries[0].intersectionRatio <= 0 });
     });
-    this.header_observer.observe(this.page_header);
+    if (this.page_header && this.header_observer) {
+      this.header_observer.observe(this.page_header);
+    }
 
-    this.footer_observer = new IntersectionObserver((entries, observer) => {
+    this.footer_observer = new IntersectionObserver((entries) => {
       this.setState({
         caught_by_footer: entries[0].isIntersecting,
       });
     });
-    this.footer_observer.observe(this.page_footer);
+    if (this.page_footer && this.footer_observer) {
+      this.footer_observer.observe(this.page_footer);
+    }
   }
   componentWillUnmount() {
-    this.header_observer!.unobserve(this.page_header!);
-    this.footer_observer!.unobserve(this.page_footer!);
+    if (
+      this.page_header &&
+      this.header_observer &&
+      this.page_footer &&
+      this.footer_observer
+    ) {
+      this.header_observer.unobserve(this.page_header);
+      this.footer_observer.unobserve(this.page_footer);
+    }
   }
 
   handleClick() {
@@ -74,9 +85,10 @@ export class BackToTop extends React.Component<BackToTopProps, BackToTopState> {
           caught_by_footer && "back-to-top--caught"
         )}
         style={{
-          top: caught_by_footer
-            ? `${this.page_footer!.offsetTop - 50}px`
-            : "auto",
+          top:
+            caught_by_footer && this.page_footer
+              ? `${this.page_footer.offsetTop - 50}px`
+              : "auto",
           opacity:
             caught_by_footer && is_mobile() && window.innerWidth <= 600
               ? 0

--- a/client/src/components/BackToTop/BackToTop.tsx
+++ b/client/src/components/BackToTop/BackToTop.tsx
@@ -38,14 +38,14 @@ export class BackToTop extends React.Component<BackToTopProps, BackToTopState> {
     this.page_header = document.getElementById("ib-site-header-area");
     this.page_footer = document.getElementById("wb-info");
 
-    this.header_observer = new IntersectionObserver((entries) => {
+    this.header_observer = new IntersectionObserver((entries, _observer) => {
       this.setState({ show_back_to_top: entries[0].intersectionRatio <= 0 });
     });
     if (this.page_header && this.header_observer) {
       this.header_observer.observe(this.page_header);
     }
 
-    this.footer_observer = new IntersectionObserver((entries) => {
+    this.footer_observer = new IntersectionObserver((entries, _observer) => {
       this.setState({
         caught_by_footer: entries[0].isIntersecting,
       });

--- a/client/src/components/BackToTop/BackToTop.tsx
+++ b/client/src/components/BackToTop/BackToTop.tsx
@@ -55,13 +55,10 @@ export class BackToTop extends React.Component<BackToTopProps, BackToTopState> {
     }
   }
   componentWillUnmount() {
-    if (
-      this.page_header &&
-      this.header_observer &&
-      this.page_footer &&
-      this.footer_observer
-    ) {
+    if (this.page_header && this.header_observer) {
       this.header_observer.unobserve(this.page_header);
+    }
+    if (this.page_footer && this.footer_observer) {
       this.footer_observer.unobserve(this.page_footer);
     }
   }

--- a/client/src/components/CheckBox/CheckBox.tsx
+++ b/client/src/components/CheckBox/CheckBox.tsx
@@ -107,7 +107,7 @@ export class CheckBox extends React.Component<CheckBoxProps> {
               onKeyDown={(e) =>
                 (e.keyCode === 13 || e.keyCode === 32) &&
                 !disabled &&
-                onClick(id!)
+                onClick(id)
               }
             >
               {label}

--- a/client/src/components/DisplayTable/DisplayTable.tsx
+++ b/client/src/components/DisplayTable/DisplayTable.tsx
@@ -331,7 +331,7 @@ export class _DisplayTable extends React.Component<
         ),
       _.chain(col_configs_with_defaults)
         .toPairs()
-        .filter(([key, col]) => col.is_summable)
+        .filter(([_key, col]) => col.is_summable)
         .map(([key, col]) => [key, col.sum_initial_value])
         .fromPairs() //had to do this to/from pair hack because over type overriding to object key:boolean pairs
         .value()

--- a/client/src/components/DisplayTable/DisplayTable.tsx
+++ b/client/src/components/DisplayTable/DisplayTable.tsx
@@ -37,7 +37,7 @@ interface ColumnKeyProps {
   initial_visible: boolean; // Default to trues
   formatter: string | Function; // If string, supply format key (e.g.: "big_int") found in format.js. If function, column value is passed in (e.g.: (value) => <span<{value}</span>)
   raw_formatter: (val: any) => string; // Actual raw value for data. Value from this is used for sorting/searching/csv string. Default to _.identity. (e.g.: (value) => Dept.lookup(value).name)
-  sum_func: Function; // e.g.: (sum, value) => ... Default to sum + value
+  sum_func: (sum: number, value: number) => number; // e.g.: (sum, value) => ... Default to sum + value
   sort_func: Function; // e.g.: (a,b) => ... Default to _.sortBy
   sum_initial_value: number; // Default to 0
   visibility_toggleable?: boolean; // Default to false for index 0, true for all other indexes

--- a/client/src/components/DropdownMenu/DropdownMenu.tsx
+++ b/client/src/components/DropdownMenu/DropdownMenu.tsx
@@ -48,7 +48,7 @@ export class DropdownMenu extends React.Component<
   }
 
   componentDidUpdate(
-    prev_props: DropdownMenuProps,
+    _prev_props: DropdownMenuProps,
     prev_state: DropdownMenuState
   ) {
     const { is_open } = this.state;

--- a/client/src/components/HeightClipper/HeightClipper.tsx
+++ b/client/src/components/HeightClipper/HeightClipper.tsx
@@ -85,9 +85,11 @@ export class HeightClipper extends React.Component<
         height_clipper_node.querySelectorAll("[prev-tabindex]"),
         _.identity
       ).forEach((node: HTMLElement) => {
-        const previous_tabindex = node.getAttribute("prev-tabindex")!;
-        node.setAttribute("tabindex", previous_tabindex);
-        node.removeAttribute("prev-tabindex");
+        const previous_tabindex = node.getAttribute("prev-tabindex");
+        if (previous_tabindex) {
+          node.setAttribute("tabindex", previous_tabindex);
+          node.removeAttribute("prev-tabindex");
+        }
       });
 
       _.map<Element, HTMLElement>(
@@ -159,7 +161,9 @@ export class HeightClipper extends React.Component<
               }}
               onClick={() => {
                 this.setState({ shouldClip: false }, () => {
-                  this.content.current!.focus();
+                  if (this.content.current) {
+                    this.content.current.focus();
+                  }
                 });
               }}
             >

--- a/client/src/components/LabeledBox/LabeledBox.tsx
+++ b/client/src/components/LabeledBox/LabeledBox.tsx
@@ -7,7 +7,7 @@ interface LabeledBoxProps {
   children: string | React.ReactNode;
 }
 
-export class LabeledBox extends React.Component<LabeledBoxProps, {}> {
+export class LabeledBox extends React.Component<LabeledBoxProps, never> {
   render() {
     const { label, children } = this.props;
 

--- a/client/src/components/LabeledTable/LabeledTable.tsx
+++ b/client/src/components/LabeledTable/LabeledTable.tsx
@@ -11,7 +11,7 @@ interface ContentItem {
 interface LabeledTableProps {
   title: string;
   contents: Array<ContentItem>;
-  TitleComponent?: any;
+  TitleComponent?: React.ComponentType;
 }
 
 export const LabeledTable = (props: LabeledTableProps) => (

--- a/client/src/components/Select/Select.tsx
+++ b/client/src/components/Select/Select.tsx
@@ -14,7 +14,7 @@ interface SelectProps {
 
   className?: string;
   disabled?: boolean;
-  style?: Object;
+  style?: React.CSSProperties;
   title?: string;
 }
 

--- a/client/src/components/TextMaker.tsx
+++ b/client/src/components/TextMaker.tsx
@@ -4,17 +4,14 @@ import React from "react";
 import { trivial_text_maker } from "src/models/text";
 
 interface TextMakerProps {
-  text_maker_func?: (key: string, args?: any) => string;
+  text_maker_func?: (key: string, args?: Record<string, unknown>) => string;
   text_key: string;
   el?: string;
-  args?: Object;
-  style?: Object;
+  args?: Record<string, unknown>;
+  style?: Record<string, unknown>;
   className?: string;
-  template_str?: string;
 }
 
-// I think eslint is wrong here
-/* disable-eslint react/jsx-no-danger-children */
 const TextMaker = ({
   text_maker_func,
   text_key,
@@ -22,7 +19,6 @@ const TextMaker = ({
   args,
   style,
   className,
-  template_str,
 }: TextMakerProps) => {
   const tm_func = _.isFunction(text_maker_func)
     ? text_maker_func
@@ -35,13 +31,12 @@ const TextMaker = ({
   });
 };
 export interface TMProps {
-  tmf?: (key: string, args?: any) => string;
+  tmf?: (key: string, args?: Record<string, unknown>) => string;
   k: string;
   el?: string;
-  args?: Object;
-  style?: Object;
+  args?: Record<string, unknown>;
+  style?: Record<string, unknown>;
   className?: string;
-  template_str?: string;
 }
 //shorthand for the above
 const TM = (props: TMProps) => (
@@ -52,7 +47,6 @@ const TM = (props: TMProps) => (
     text_maker_func={props.tmf}
     style={props.style}
     className={props.className}
-    template_str={props.template_str}
   />
 );
 

--- a/client/src/components/TextMaker.tsx
+++ b/client/src/components/TextMaker.tsx
@@ -8,7 +8,7 @@ interface TextMakerProps {
   text_key: string;
   el?: string;
   args?: Record<string, unknown>;
-  style?: Record<string, unknown>;
+  style?: React.CSSProperties;
   className?: string;
 }
 
@@ -35,7 +35,7 @@ export interface TMProps {
   k: string;
   el?: string;
   args?: Record<string, unknown>;
-  style?: Record<string, unknown>;
+  style?: React.CSSProperties;
   className?: string;
 }
 //shorthand for the above

--- a/client/src/components/TwoLevelSelect/TwoLevelSelect.tsx
+++ b/client/src/components/TwoLevelSelect/TwoLevelSelect.tsx
@@ -22,7 +22,7 @@ interface TwoSelectProps {
 
   className?: string;
   disabled?: boolean;
-  style?: Object;
+  style?: React.CSSProperties;
 }
 
 const TwoLevelSelect: React.FC<TwoSelectProps> = ({

--- a/client/src/components/Typeahead/Typeahead.tsx
+++ b/client/src/components/Typeahead/Typeahead.tsx
@@ -72,6 +72,7 @@ export class Typeahead extends React.Component<TypeaheadProps, TypeaheadState> {
 
   static defaultProps = {
     placeholder: text_maker("search"),
+    min_length: 3,
     on_query_debounce_time: 300,
   };
 

--- a/client/src/components/Typeahead/Typeahead.tsx
+++ b/client/src/components/Typeahead/Typeahead.tsx
@@ -123,7 +123,7 @@ export class Typeahead extends React.Component<TypeaheadProps, TypeaheadState> {
       return null;
     }
   }
-  componentDidUpdate(prevProps: TypeaheadProps, prevState: TypeaheadState) {
+  componentDidUpdate(_prevProps: TypeaheadProps, prevState: TypeaheadState) {
     const { selection_cursor } = this.state;
     const { selection_cursor: prev_selection_cursor } = prevState;
 

--- a/client/src/components/Typeahead/Typeahead.tsx
+++ b/client/src/components/Typeahead/Typeahead.tsx
@@ -1,9 +1,19 @@
 import classNames from "classnames";
 import _ from "lodash";
-import React, { ChangeEvent, KeyboardEvent, Fragment } from "react";
+import React, {
+  ChangeEvent,
+  KeyboardEvent,
+  Fragment,
+  ReactElement,
+} from "react";
 import ReactResizeDetector from "react-resize-detector/build/withPolyfill";
 
-import { AutoSizer, CellMeasurer, CellMeasurerCache } from "react-virtualized";
+import {
+  AutoSizer,
+  CellMeasurer,
+  CellMeasurerCache,
+  List,
+} from "react-virtualized";
 
 import { AutoHeightVirtualList } from "src/components/AutoHeightVirtualList";
 import { create_text_maker_component } from "src/components/misc_util_components";
@@ -54,19 +64,14 @@ interface TypeaheadState {
   results?: ResultProps[];
 }
 
-export class Typeahead extends React.Component<
-  TypeaheadProps,
-  TypeaheadState,
-  {}
-> {
+export class Typeahead extends React.Component<TypeaheadProps, TypeaheadState> {
   menu_id: string;
 
   private typeahead_ref = React.createRef<HTMLDivElement>();
-  private virtualized_list_ref = React.createRef<any>();
+  private virtualized_list_ref = React.createRef<List>();
 
   static defaultProps = {
     placeholder: text_maker("search"),
-    min_length: 3,
     on_query_debounce_time: 300,
   };
 
@@ -214,7 +219,7 @@ export class Typeahead extends React.Component<
                       key,
                       parent,
                       style,
-                    }: any) => (
+                    }): ReactElement => (
                       <CellMeasurer
                         cache={virtualized_cell_measure_cache}
                         columnIndex={0}

--- a/client/src/components/Typeahead/Typeahead.tsx
+++ b/client/src/components/Typeahead/Typeahead.tsx
@@ -184,7 +184,6 @@ export class Typeahead extends React.Component<
         </div>
         {this.show_menu && (
           <TypeaheadA11yStatus
-            min_length={min_length}
             selection_cursor={selection_cursor}
             results={results}
           />

--- a/client/src/components/Typeahead/Typeahead.tsx
+++ b/client/src/components/Typeahead/Typeahead.tsx
@@ -206,6 +206,7 @@ export class Typeahead extends React.Component<TypeaheadProps, TypeaheadState> {
                 {() => (
                   <AutoHeightVirtualList
                     className="typeahead__dropdown"
+                    max_height={400}
                     role="listbox"
                     id={this.menu_id}
                     ariaExpanded={this.show_menu}

--- a/client/src/components/Typeahead/TypeaheadA11yStatus.tsx
+++ b/client/src/components/Typeahead/TypeaheadA11yStatus.tsx
@@ -1,5 +1,5 @@
 import _ from "lodash";
-import React from "react";
+import React, { ReactNode } from "react";
 
 import { create_text_maker } from "src/models/text";
 
@@ -10,18 +10,17 @@ import text from "./Typeahead.yaml";
 const text_maker = create_text_maker(text);
 
 interface DelayedRenderProps {
-  children: any;
+  children: ReactNode;
 }
 
 interface DelayedRenderState {
-  children: any;
+  children: ReactNode;
   debounced: boolean;
 }
 
 class DelayedRender extends React.Component<
   DelayedRenderProps,
-  DelayedRenderState,
-  {}
+  DelayedRenderState
 > {
   constructor(props: DelayedRenderProps) {
     super(props);
@@ -60,10 +59,7 @@ class DelayedRender extends React.Component<
   componentDidMount() {
     this.debounceUpdate();
   }
-  componentDidUpdate(
-    prevProps: DelayedRenderProps,
-    prevState: DelayedRenderState
-  ) {
+  componentDidUpdate(prevState: DelayedRenderState) {
     const { children: prev_children } = prevState;
     const { children, debounced } = this.state;
 
@@ -88,13 +84,11 @@ class DelayedRender extends React.Component<
 
 interface TypeaheadA11yStatusProps {
   selection_cursor: number;
-  min_length: number;
   results: ResultProps[];
 }
 
 export const TypeaheadA11yStatus: React.FC<TypeaheadA11yStatusProps> = ({
   selection_cursor,
-  min_length,
   results,
 }) => {
   const status_content = (() => {

--- a/client/src/components/Typeahead/TypeaheadA11yStatus.tsx
+++ b/client/src/components/Typeahead/TypeaheadA11yStatus.tsx
@@ -59,7 +59,10 @@ class DelayedRender extends React.Component<
   componentDidMount() {
     this.debounceUpdate();
   }
-  componentDidUpdate(prevState: DelayedRenderState) {
+  componentDidUpdate(
+    _prevProps: DelayedRenderProps,
+    prevState: DelayedRenderState
+  ) {
     const { children: prev_children } = prevState;
     const { children, debounced } = this.state;
 

--- a/client/src/components/glossary_components.tsx
+++ b/client/src/components/glossary_components.tsx
@@ -20,8 +20,8 @@ interface GlossaryTooltipWrapperProps {
 interface GlossaryIconProps {
   id: string;
   alternate_text?: string;
-  arrow_selector?: any;
-  inner_selector?: any; // i don't know how to do the types for the selectors
+  arrow_selector?: string;
+  inner_selector?: string;
   icon_color?: string;
   icon_alt_color?: string;
 }
@@ -59,6 +59,8 @@ const GlossaryTooltipWrapper: React.FC<GlossaryTooltipWrapperProps> = ({
 export const GlossaryIcon: React.FC<GlossaryIconProps> = ({
   id,
   alternate_text,
+  arrow_selector,
+  inner_selector,
   icon_color,
   icon_alt_color,
 }) => (

--- a/client/src/components/glossary_components.tsx
+++ b/client/src/components/glossary_components.tsx
@@ -20,8 +20,6 @@ interface GlossaryTooltipWrapperProps {
 interface GlossaryIconProps {
   id: string;
   alternate_text?: string;
-  arrow_selector?: string;
-  inner_selector?: string;
   icon_color?: string;
   icon_alt_color?: string;
 }
@@ -59,8 +57,6 @@ const GlossaryTooltipWrapper: React.FC<GlossaryTooltipWrapperProps> = ({
 export const GlossaryIcon: React.FC<GlossaryIconProps> = ({
   id,
   alternate_text,
-  arrow_selector,
-  inner_selector,
   icon_color,
   icon_alt_color,
 }) => (

--- a/client/src/components/modals_and_popovers/FocusLockedModal.tsx
+++ b/client/src/components/modals_and_popovers/FocusLockedModal.tsx
@@ -9,14 +9,14 @@ import "./bootstrap_modal_exstension.scss";
 interface FocusLockedModalProps {
   mounted: boolean;
   children: React.ReactNode;
-  additional_dialog_class: string | Object;
+  additional_dialog_class: string | string[];
   on_exit: () => void;
   aria_label: string;
 }
 
 export class FocusLockedModal extends React.Component<
   FocusLockedModalProps,
-  {}
+  never
 > {
   constructor(props: FocusLockedModalProps) {
     super(props);

--- a/client/src/contact/contact.tsx
+++ b/client/src/contact/contact.tsx
@@ -14,7 +14,7 @@ interface ContactProps {
   toggleSurvey: () => void;
 }
 
-export default class Contact extends React.Component<ContactProps, {}> {
+export default class Contact extends React.Component<ContactProps, never> {
   render() {
     const { toggleSurvey } = this.props;
 

--- a/client/src/core/assign_to_dev_helper_namespace.ts
+++ b/client/src/core/assign_to_dev_helper_namespace.ts
@@ -1,12 +1,14 @@
 import { is_dev, is_dev_link } from "./injected_build_constants";
 
-const assign_to_dev_helper_namespace = (dev_helpers: Object) => {
+const assign_to_dev_helper_namespace = (
+  dev_helpers: Record<string, unknown>
+) => {
   if (!(is_dev || is_dev_link)) {
     return null;
   }
 
   if (!window.__DEV) {
-    window.__DEV = {};
+    window.__DEV = {} as Record<string, unknown>;
   }
 
   Object.assign(window.__DEV, dev_helpers);

--- a/client/src/core/assign_to_dev_helper_namespace.ts
+++ b/client/src/core/assign_to_dev_helper_namespace.ts
@@ -8,7 +8,7 @@ const assign_to_dev_helper_namespace = (
   }
 
   if (!window.__DEV) {
-    window.__DEV = {} as Record<string, unknown>;
+    window.__DEV = {};
   }
 
   Object.assign(window.__DEV, dev_helpers);

--- a/client/src/core/breakpoint_defs.ts
+++ b/client/src/core/breakpoint_defs.ts
@@ -15,11 +15,11 @@ const base_breakpoints = {
 // Note max breakpoints are base breakpoints -0.02
 const breakpoints = {
   ..._.chain(base_breakpoints)
-    .mapKeys((value, key) => `min${_.upperFirst(key)}`)
+    .mapKeys((_value, key) => `min${_.upperFirst(key)}`)
     .value(),
 
   ..._.chain(base_breakpoints)
-    .mapKeys((value, key) => `max${_.upperFirst(key)}`)
+    .mapKeys((_value, key) => `max${_.upperFirst(key)}`)
     .mapValues((value) => value - 0.02)
     .value(),
 };

--- a/client/src/core/format.ts
+++ b/client/src/core/format.ts
@@ -342,11 +342,16 @@ type Formatted<T> = T extends number | string
   ? { [key: string]: string }
   : never;
 
-const formatter_wrapper = (
+function formatter_wrapper<T extends Formattable>(
+  format: FormatKey,
+  val: T,
+  options: formatterOptions
+): Formatted<T>;
+function formatter_wrapper(
   format: FormatKey,
   val: Formattable,
   options: formatterOptions
-): Formatted<Formattable> => {
+): Formatted<Formattable> {
   const formatter = (actual_val: number | string) =>
     types_to_format[format](+actual_val as number, lang, options);
 
@@ -359,7 +364,7 @@ const formatter_wrapper = (
   } else {
     return formatter(val);
   }
-};
+}
 
 // legacy-ish hack here, two keys for every format, one with the suffix _raw that always has the option raw: true,
 // one with no suffix that defaults to raw: false but can have that overwritten. Primarily because, at least historically
@@ -381,9 +386,7 @@ export const formats = _.chain(types_to_format)
   ])
   .fromPairs()
   .value() as {
-  // Important note, this is what the rest of src will see formats as. The other typing is just for internal consistency.
-  // Little trick here too, unlike formatter_wrapper, we can actually lean on the generic nature of Formatted here, couldn't
-  // in the actual formatter_wrapper type signature as it requires extending a type, which causes type uncertainty within the function body
+  // note, this is what the rest of src will see formats as. The other typing is just for internal consistency
   [key in FormatKey | `${FormatKey}_raw`]: <T extends Formattable>(
     val: T,
     options?: Partial<formatterOptions>

--- a/client/src/core/format.ts
+++ b/client/src/core/format.ts
@@ -361,11 +361,11 @@ const formatter_wrapper = (
   }
 };
 
-// legacyish hack here, two keys for every format, one with the suffix _raw that always has the option raw: true,
+// legacy-ish hack here, two keys for every format, one with the suffix _raw that always has the option raw: true,
 // one with no suffix that defaults to raw: false but can have that overwritten. Primarily because, at least historically
 // the generated handlebar helper versions of formats don't take options (so needed an alternate way to set raw value).
 // I think types in the legacy table definition API also use the _raw versions a lot
-const formats = _.chain(types_to_format)
+export const formats = _.chain(types_to_format)
   .keys()
   .flatMap((key: FormatKey) => [
     [
@@ -381,13 +381,16 @@ const formats = _.chain(types_to_format)
   ])
   .fromPairs()
   .value() as {
-  [key in FormatKey | `${FormatKey}_raw`]: <T>(
+  // Important note, this is what the rest of src will see formats as. The other typing is just for internal consistency.
+  // Little trick here too, unlike formatter_wrapper, we can actually lean on the generic nature of Formatted here, couldn't
+  // in the actual formatter_wrapper type signature as it requires extending a type, which causes type uncertainty within the function body
+  [key in FormatKey | `${FormatKey}_raw`]: <T extends Formattable>(
     val: T,
     options?: Partial<formatterOptions>
   ) => Formatted<T>;
 };
 
-const array_to_grammatical_list = (items: string[]) => {
+export const array_to_grammatical_list = (items: string[]) => {
   const and_et = {
     en: "and",
     fr: "et",
@@ -405,5 +408,3 @@ const array_to_grammatical_list = (items: string[]) => {
       .value();
   }
 };
-
-export { formats, array_to_grammatical_list };

--- a/client/src/core/format.ts
+++ b/client/src/core/format.ts
@@ -122,13 +122,16 @@ const compact = (
         }
       });
 
-      const defined_compacted = _.filter(compacted, (pair) => {
-        return !_.isUndefined(pair);
-      });
+      const defined_compacted = _.filter(
+        compacted,
+        (pair) => !_.isUndefined(pair)
+      );
 
-      return defined_compacted.length! > 0 //have to use the ! because TS thinks filter can return null/
-        ? defined_compacted[0]!
-        : [abbrev[999][lang], val];
+      if (typeof defined_compacted[0] !== "undefined") {
+        return defined_compacted[0];
+      } else {
+        return [abbrev[999][lang], val];
+      }
     }
   })();
 
@@ -184,7 +187,10 @@ const compact_written = (
         return !_.isUndefined(pair);
       });
 
-      return defined_compacted[0]!;
+      // ... this code is a real pile of crap. Refactor a TODO, in the meantime just wanted to note that the pre-TS code assumed
+      // this would never return undefined, so encoding that assumption in the types here
+      // ...not that I trust this code further than I can throw an error
+      return defined_compacted[0] as [string, string];
     } else {
       precision = precision < 2 ? 0 : precision;
       return [

--- a/client/src/core/format.ts
+++ b/client/src/core/format.ts
@@ -7,8 +7,8 @@ import { lang } from "src/core/injected_build_constants";
 
 const number_formatter = {
   en: _.map(
-    Array(4),
-    (_sval, ix) =>
+    _.range(4),
+    (ix) =>
       new Intl.NumberFormat("en-CA", {
         style: "decimal",
         minimumFractionDigits: ix,
@@ -16,8 +16,8 @@ const number_formatter = {
       })
   ),
   fr: _.map(
-    Array(4),
-    (_val, ix) =>
+    _.range(4),
+    (ix) =>
       new Intl.NumberFormat("fr-CA", {
         style: "decimal",
         minimumFractionDigits: ix,
@@ -27,8 +27,8 @@ const number_formatter = {
 };
 const money_formatter = {
   en: _.map(
-    Array(3),
-    (_val, ix) =>
+    _.range(3),
+    (ix) =>
       new Intl.NumberFormat("en-CA", {
         style: "currency",
         currency: "CAD",
@@ -38,8 +38,8 @@ const money_formatter = {
       })
   ),
   fr: _.map(
-    Array(3),
-    (_val, ix) =>
+    _.range(3),
+    (ix) =>
       new Intl.NumberFormat("fr-CA", {
         style: "currency",
         currency: "CAD",
@@ -51,8 +51,8 @@ const money_formatter = {
 };
 const percent_formatter = {
   en: _.map(
-    Array(4),
-    (_val, ix) =>
+    _.range(4),
+    (ix) =>
       new Intl.NumberFormat("en-CA", {
         style: "percent",
         minimumFractionDigits: ix,
@@ -60,8 +60,8 @@ const percent_formatter = {
       })
   ),
   fr: _.map(
-    Array(4),
-    (_val, ix) =>
+    _.range(4),
+    (ix) =>
       new Intl.NumberFormat("fr-CA", {
         style: "percent",
         minimumFractionDigits: ix,

--- a/client/src/core/format.ts
+++ b/client/src/core/format.ts
@@ -8,7 +8,7 @@ import { lang } from "src/core/injected_build_constants";
 const number_formatter = {
   en: _.map(
     Array(4),
-    (val, ix) =>
+    (_sval, ix) =>
       new Intl.NumberFormat("en-CA", {
         style: "decimal",
         minimumFractionDigits: ix,
@@ -17,7 +17,7 @@ const number_formatter = {
   ),
   fr: _.map(
     Array(4),
-    (val, ix) =>
+    (_val, ix) =>
       new Intl.NumberFormat("fr-CA", {
         style: "decimal",
         minimumFractionDigits: ix,
@@ -28,7 +28,7 @@ const number_formatter = {
 const money_formatter = {
   en: _.map(
     Array(3),
-    (val, ix) =>
+    (_val, ix) =>
       new Intl.NumberFormat("en-CA", {
         style: "currency",
         currency: "CAD",
@@ -39,7 +39,7 @@ const money_formatter = {
   ),
   fr: _.map(
     Array(3),
-    (val, ix) =>
+    (_val, ix) =>
       new Intl.NumberFormat("fr-CA", {
         style: "currency",
         currency: "CAD",
@@ -52,7 +52,7 @@ const money_formatter = {
 const percent_formatter = {
   en: _.map(
     Array(4),
-    (val, ix) =>
+    (_val, ix) =>
       new Intl.NumberFormat("en-CA", {
         style: "percent",
         minimumFractionDigits: ix,
@@ -61,7 +61,7 @@ const percent_formatter = {
   ),
   fr: _.map(
     Array(4),
-    (val, ix) =>
+    (_val, ix) =>
       new Intl.NumberFormat("fr-CA", {
         style: "percent",
         minimumFractionDigits: ix,
@@ -126,9 +126,10 @@ const compact = (
         compacted,
         (pair) => !_.isUndefined(pair)
       );
+      const defined_compact_val = defined_compacted[0];
 
-      if (typeof defined_compacted[0] !== "undefined") {
-        return defined_compacted[0];
+      if (!_.isUndefined(defined_compact_val)) {
+        return defined_compact_val;
       } else {
         return [abbrev[999][lang], val];
       }
@@ -352,12 +353,11 @@ function format_wrapper(
   options: FormatterOptions
 ): Formatted<Formattable> {
   const formatter = (actual_val: number | string) =>
-    typeof actual_val === "number" ||
-    (typeof actual_val === "string" && !_.isNaN(+actual_val))
+    _.isNumber(actual_val) || (_.isString(actual_val) && !_.isNaN(+actual_val))
       ? types_to_format[format](+actual_val as number, lang, options)
       : _.toString(actual_val); // TODO would prefer to throw in this case, but some legacy code likely depends on this. Check
 
-  if (typeof val === "object") {
+  if (_.isObject(val)) {
     if (Array.isArray(val)) {
       return _.map(val, (v) => formatter(v));
     } else {

--- a/client/src/core/format.ts
+++ b/client/src/core/format.ts
@@ -3,9 +3,6 @@
 //  site.scss also establishes the widths for displaying each of the data types
 import _ from "lodash";
 
-import { identity } from "react-virtualized/dist/es/Masonry";
-import { string } from "yargs";
-
 import { lang } from "src/core/injected_build_constants";
 
 const number_formatter = {
@@ -410,7 +407,7 @@ const legacy_string_formats = _.chain(legacy_string_format_keys)
   .value() as {
   [key in
     | LegacyStringNumberFormatKeys
-    | `${LegacyStringNumberFormatKeys}_raw`]: identity;
+    | `${LegacyStringNumberFormatKeys}_raw`]: <T>(value: T) => T;
 };
 
 export const formats = { ...number_formats, ...legacy_string_formats };

--- a/client/src/core/format.ts
+++ b/client/src/core/format.ts
@@ -397,7 +397,7 @@ const number_formats = _.chain(types_to_format)
 // legacy, exist primarily for the Table API/RPB, where columns may have these types and expec a corresponding format to exist (but do nothing)
 // TODO either before or after the Table API is dropped/the RPB is refactored, remove these
 const legacy_string_format_keys = ["str", "short-str", "wide-str"] as const;
-type LegacyStringNumberFormatKeys = typeof legacy_string_format_keys[number]; // "str" | "short-str" | "wide-str"
+type LegacyStringNumberFormatKeys = typeof legacy_string_format_keys[number];
 const legacy_string_formats = _.chain(legacy_string_format_keys)
   .flatMap((key) => [
     [key, _.identity],

--- a/client/src/core/tables/queries.js
+++ b/client/src/core/tables/queries.js
@@ -2,7 +2,7 @@ import _ from "lodash";
 
 import { Subject } from "src/models/subject";
 
-import * as FORMAT from "src/core/format";
+import { formats } from "src/core/format";
 import { lang } from "src/core/injected_build_constants";
 
 // #Queries
@@ -101,7 +101,7 @@ class Queries {
       _.each(cols, (col) => {
         // jump to [col_from_nick](base_tables.html#col_from_nick)
         var type = this.table.col_from_nick(col).type;
-        vals[col] = FORMAT.formatter(type, vals[col]);
+        vals[col] = _.get(formats, type, _.identity)(vals[col]);
       });
     }
     if (!as_object) {
@@ -184,10 +184,10 @@ class Queries {
     if (format) {
       _.each(cols, (col) => {
         var type = this.table.col_from_nick(col).type;
-        vals[col] = FORMAT.formatter(type, vals[col]);
+        vals[col] = _.get(formats, type, _.identity)(vals[col]);
       });
       if (gross_percentage) {
-        vals[gp_colname] = FORMAT.formatter("percentage", vals[gp_colname]);
+        vals[gp_colname] = formats["percentage"](vals[gp_colname]);
       }
     }
     if (options.pop_single && cols.length === 1) {

--- a/client/src/general_utils.ts
+++ b/client/src/general_utils.ts
@@ -39,7 +39,7 @@ export const text_abbrev = function (text: string, length: number) {
 };
 
 export const make_unique_func = function () {
-  var val = 0;
+  let val = 0;
   return function () {
     return ++val;
   };
@@ -83,14 +83,10 @@ export const escapeRegExp = function (str: string) {
   return str.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, "\\$&");
 };
 
-type ObjectAny = {
-  [key: string]: any;
-};
-
-export const shallowEqualObjectsOverKeys = (
-  obj1: ObjectAny,
-  obj2: ObjectAny,
-  keys_to_compare: string[]
+export const shallowEqualObjectsOverKeys = <Type, Key extends keyof Type>(
+  obj1: Type,
+  obj2: Type,
+  keys_to_compare: Key[]
 ) =>
   _.reduce(
     keys_to_compare,
@@ -98,10 +94,10 @@ export const shallowEqualObjectsOverKeys = (
     true
   );
 
-export const shallowEqualObjectsExceptKeys = (
-  obj1: ObjectAny,
-  obj2: ObjectAny,
-  keys_to_ignore: string[]
+export const shallowEqualObjectsExceptKeys = <Type, Key extends keyof Type>(
+  obj1: Type,
+  obj2: Type,
+  keys_to_ignore: Key[]
 ) => {
   return _.isEqualWith(
     obj1,
@@ -110,11 +106,11 @@ export const shallowEqualObjectsExceptKeys = (
   );
 };
 
-export const retry_promise = (
-  promise_to_try: Function,
+export const retry_promise = <T>(
+  promise_to_try: () => Promise<T>,
   retries = 2,
   interval = 500
-) => {
+): Promise<T> => {
   return new Promise((resolve, reject) => {
     promise_to_try()
       .then(resolve)
@@ -163,9 +159,10 @@ export function completeAssign<TObject, TSource1, TSource2, TSource3, TSource4>(
   source4: TSource4
 ): TObject & TSource1 & TSource2 & TSource3 & TSource4;
 export function completeAssign<TObject>(object: TObject): TObject;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function completeAssign(target: any, ...sources: any[]): any {
   sources.forEach((source) => {
-    let descriptors = Object.keys(source).reduce(
+    const descriptors = Object.keys(source).reduce(
       (descriptors: { [key: string]: PropertyDescriptor }, key) => {
         descriptors[key] = Object.getOwnPropertyDescriptor(source, key)!;
         return descriptors;
@@ -174,7 +171,7 @@ export function completeAssign(target: any, ...sources: any[]): any {
     );
     // by default, Object.assign copies enumerable Symbols too
     Object.getOwnPropertySymbols(source).forEach((sym) => {
-      let descriptor = Object.getOwnPropertyDescriptor(source, sym);
+      const descriptor = Object.getOwnPropertyDescriptor(source, sym);
       if (descriptor && descriptor.enumerable) {
         // Typescript bug that symbol cannot be used as index: https://github.com/microsoft/TypeScript/issues/1863
         descriptors[sym as unknown as string] = descriptor;
@@ -188,12 +185,12 @@ export function completeAssign(target: any, ...sources: any[]): any {
 //copied from https://stackoverflow.com/questions/5623838/rgb-to-hex-and-hex-to-rgb
 export const hex_to_rgb = (hex: string) => {
   // Expand shorthand form (e.g. "03F") to full form (e.g. "0033FF")
-  var shorthandRegex = /^#?([a-f\d])([a-f\d])([a-f\d])$/i;
+  const shorthandRegex = /^#?([a-f\d])([a-f\d])([a-f\d])$/i;
   hex = hex.replace(shorthandRegex, function (m, r, g, b) {
     return r + r + g + g + b + b;
   });
 
-  var result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
+  const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
   return result
     ? {
         r: parseInt(result[1], 16),

--- a/client/src/general_utils.ts
+++ b/client/src/general_utils.ts
@@ -3,6 +3,8 @@ import JSURL from "jsurl";
 import _ from "lodash";
 import marked from "marked";
 
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
 export const sanitize_html = (markup: string | Node) => {
   // a little tedious, but this is the safe way to enforce safe usage of target="_blank" with DOMPurify
   // note: add and then pop the hook, don't want the side effect of leaving hooks on DOMPurify (ugh)
@@ -159,7 +161,6 @@ export function completeAssign<TObject, TSource1, TSource2, TSource3, TSource4>(
   source4: TSource4
 ): TObject & TSource1 & TSource2 & TSource3 & TSource4;
 export function completeAssign<TObject>(object: TObject): TObject;
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function completeAssign(target: any, ...sources: any[]): any {
   sources.forEach((source) => {
     const descriptors = Object.keys(source).reduce(

--- a/client/src/general_utils.ts
+++ b/client/src/general_utils.ts
@@ -3,8 +3,6 @@ import JSURL from "jsurl";
 import _ from "lodash";
 import marked from "marked";
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
 export const sanitize_html = (markup: string | Node) => {
   // a little tedious, but this is the safe way to enforce safe usage of target="_blank" with DOMPurify
   // note: add and then pop the hook, don't want the side effect of leaving hooks on DOMPurify (ugh)
@@ -161,6 +159,7 @@ export function completeAssign<TObject, TSource1, TSource2, TSource3, TSource4>(
   source4: TSource4
 ): TObject & TSource1 & TSource2 & TSource3 & TSource4;
 export function completeAssign<TObject>(object: TObject): TObject;
+/* eslint-disable-next-line @typescript-eslint/no-explicit-any */
 export function completeAssign(target: any, ...sources: any[]): any {
   sources.forEach((source) => {
     const descriptors = Object.keys(source).reduce(
@@ -190,7 +189,7 @@ export function completeAssign(target: any, ...sources: any[]): any {
 export const hex_to_rgb = (hex: string) => {
   // Expand shorthand form (e.g. "03F") to full form (e.g. "0033FF")
   const shorthandRegex = /^#?([a-f\d])([a-f\d])([a-f\d])$/i;
-  hex = hex.replace(shorthandRegex, function (m, r, g, b) {
+  hex = hex.replace(shorthandRegex, function (_m, r, g, b) {
     return r + r + g + g + b + b;
   });
 
@@ -235,6 +234,7 @@ interface ElementDescriptor {
 }
 interface ElementDescriptorExtra extends ElementDescriptor {
   placement: string;
+  /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
   initializer: (this: any) => any;
 }
 
@@ -245,6 +245,7 @@ export function cached_property(elementDescriptor: ElementDescriptor) {
   }
   const og_method = descriptor.value;
   const cache_name = `_${key}_cached_val`;
+  /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
   function new_method(this: any) {
     if (!this[cache_name]) {
       this[cache_name] = og_method.call(this);
@@ -265,11 +266,13 @@ export function bound(elementDescriptor: ElementDescriptor) {
   const initializer =
     // check for private method
     typeof key === "object"
-      ? function (this: any) {
+      ? /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+        function (this: any) {
           return method.bind(this);
         }
       : // For public and symbol-keyed methods (which are technically public),
         // we defer method lookup until construction to respect the prototype chain.
+        /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
         function (this: any) {
           return this[key].bind(this);
         };

--- a/client/src/general_utils.ts
+++ b/client/src/general_utils.ts
@@ -164,7 +164,10 @@ export function completeAssign(target: any, ...sources: any[]): any {
   sources.forEach((source) => {
     const descriptors = Object.keys(source).reduce(
       (descriptors: { [key: string]: PropertyDescriptor }, key) => {
-        descriptors[key] = Object.getOwnPropertyDescriptor(source, key)!;
+        const descriptor = Object.getOwnPropertyDescriptor(source, key);
+        if (descriptor) {
+          descriptors[key] = descriptor;
+        }
         return descriptors;
       },
       {}
@@ -215,7 +218,7 @@ const pre_parse_safe_jsurl = (safe_jsurl_string: string) =>
 export const SafeJSURL = {
   parse: (safe_jsurl_string: string) =>
     JSURL.parse(pre_parse_safe_jsurl(safe_jsurl_string)),
-  stringify: (json: { [key: string]: any }) =>
+  stringify: (json: { [key: string]: string }) =>
     make_jsurl_safe(JSURL.stringify(json)),
   tryParse: (safe_jsurl_string: string) =>
     JSURL.tryParse(pre_parse_safe_jsurl(safe_jsurl_string)),
@@ -223,12 +226,15 @@ export const SafeJSURL = {
 
 export const generate_href = (url: string) =>
   url.startsWith("http") ? url : `https://${url}`;
-
 interface ElementDescriptor {
   kind: string;
   key: string;
   descriptor: PropertyDescriptor;
-  extras?: [{ [key: string]: any }];
+  extras?: [ElementDescriptorExtra];
+}
+interface ElementDescriptorExtra extends ElementDescriptor {
+  placement: string;
+  initializer: (this: any) => any;
 }
 
 export function cached_property(elementDescriptor: ElementDescriptor) {

--- a/client/src/home/CardImage/CardImage.tsx
+++ b/client/src/home/CardImage/CardImage.tsx
@@ -10,7 +10,7 @@ interface CardImageProps {
   text_key: string;
   link_href: string;
   link_open_in_new_tab?: boolean;
-  text_args: Object;
+  text_args?: Record<string, unknown>;
   tmf: TMProps["tmf"];
 }
 

--- a/client/src/icons/icons.tsx
+++ b/client/src/icons/icons.tsx
@@ -24,7 +24,7 @@ interface IconProps {
   title?: string;
   width?: number | string;
   height?: number | string;
-  svg_style?: Object;
+  svg_style?: React.CSSProperties;
   inline?: boolean;
   aria_hide?: boolean;
 

--- a/client/src/panels/panel_declarations/services/single_service_panels/service_overview.js
+++ b/client/src/panels/panel_declarations/services/single_service_panels/service_overview.js
@@ -18,7 +18,7 @@ import {
 import { Subject } from "src/models/subject";
 
 import { backgroundColor } from "src/core/color_defs";
-import { formatter } from "src/core/format";
+import { formats } from "src/core/format";
 import { is_a11y_mode } from "src/core/injected_build_constants";
 
 import Gauge from "src/charts/gauge";
@@ -193,14 +193,13 @@ export class ServiceOverview extends React.Component {
           </dd>
           <dt>{text_maker("applications_and_calls")}</dt>
           <dd>
-            {formatter("big_int", applications_and_calls, {
+            {formats["big_int"](applications_and_calls, {
               raw: true,
             })}
           </dd>
           <dt>{text_maker("online_inquiry")}</dt>
           <dd>
-            {formatter(
-              "big_int",
+            {formats["big_int"](
               _.sumBy(service.service_report, "online_inquiry_count"),
               {
                 raw: true,

--- a/client/src/panels/panel_declarations/services/top10_services_application_volume.js
+++ b/client/src/panels/panel_declarations/services/top10_services_application_volume.js
@@ -16,7 +16,7 @@ import {
 import { useSummaryServices } from "src/models/populate_services";
 
 import { newIBLightCategoryColors } from "src/core/color_schemes";
-import { formatter } from "src/core/format";
+import { formats } from "src/core/format";
 import { is_a11y_mode } from "src/core/injected_build_constants";
 
 import { WrappedNivoHBar } from "src/charts/wrapped_nivo/index";
@@ -28,7 +28,7 @@ const { text_maker, TM } = create_text_maker_component(text);
 const colors = scaleOrdinal().range(_.at(newIBLightCategoryColors, [0]));
 const total_volume = text_maker("applications_and_calls");
 const volume_formatter = (val) =>
-  formatter("compact", val, { raw: true, noMoney: true });
+  formats.compact(val, { raw: true }).replace("$", "");
 
 const Top10ServicesApplicationVolumePanel = ({ subject }) => {
   const { loading, data } = useSummaryServices({

--- a/client/src/panels/panel_declarations/services/top10_services_website_visits.js
+++ b/client/src/panels/panel_declarations/services/top10_services_website_visits.js
@@ -17,7 +17,7 @@ import { useSummaryServices } from "src/models/populate_services";
 import { Subject } from "src/models/subject";
 
 import { newIBLightCategoryColors } from "src/core/color_schemes";
-import { formatter } from "src/core/format";
+import { formats } from "src/core/format";
 import { is_a11y_mode } from "src/core/injected_build_constants";
 
 import { WrappedNivoHBar } from "src/charts/wrapped_nivo/index";
@@ -34,7 +34,7 @@ const colors = scaleOrdinal().range(_.at(newIBLightCategoryColors, [0]));
 const website_visits_key = "online_inquiry";
 const total_volume = text_maker(website_visits_key);
 const volume_formatter = (val) =>
-  formatter("compact", val, { raw: true, noMoney: true });
+  formats.compact(val, { raw: true }).replace("$", "");
 
 const Top10WebsiteVisitsPanel = ({ panel_args }) => {
   const { subject } = panel_args;

--- a/client/src/tables/orgVoteStatEstimates.js
+++ b/client/src/tables/orgVoteStatEstimates.js
@@ -1,7 +1,7 @@
 import { sum } from "d3-array";
 import _ from "lodash";
 
-import * as FORMAT from "src/core/format";
+import { formats } from "src/core/format";
 import { lang } from "src/core/injected_build_constants";
 
 import {
@@ -183,11 +183,15 @@ export default {
         })
         .map(function (row) {
           if (format) {
-            if (add_percentage) {
-              return FORMAT.list_formatter(["", "big-int", "percentage"], row);
-            } else {
-              return FORMAT.list_formatter(["", "big-int"], row);
-            }
+            return _.chain([
+              _.identity,
+              formats["big-int"],
+              add_percentage && formats["percentage"],
+            ])
+              .compact()
+              .zip(row)
+              .map(([formatter, value]) => formatter(value))
+              .value();
           }
           return row;
         })

--- a/client/src/types/global.d.ts
+++ b/client/src/types/global.d.ts
@@ -7,7 +7,7 @@ interface LangDict<T> {
   fr: T;
 }
 interface Window {
-  __DEV: Object;
+  __DEV: Record<string, unknown>;
 }
 
 // Global variables injected by webpack

--- a/client/src/types/types.d.ts
+++ b/client/src/types/types.d.ts
@@ -1,5 +1,12 @@
 interface TextBundle {
-  [key: string]: Object;
+  [key: string]: {
+    transform?:
+      | ["handlebars"]
+      | ["markdown"]
+      | ["handlebars", "markdown"]
+      | ["handlebars", "embeded-markdown", "markdown"]; // TODO embeded-markdown transform is legacy, hacky. Remove at some point
+  };
+  [(key in "en") | "fr" | "text"]: string;
 }
 declare module "*.yaml" {
   let val: TextBundle;

--- a/client/src/types/types.d.ts
+++ b/client/src/types/types.d.ts
@@ -5,8 +5,8 @@ interface TextBundle {
       | ["markdown"]
       | ["handlebars", "markdown"]
       | ["handlebars", "embeded-markdown", "markdown"]; // TODO embeded-markdown transform is legacy, hacky. Remove at some point
+    [key in ("en" | "fr" | "text")]: string;
   };
-  [(key in "en") | "fr" | "text"]: string;
 }
 declare module "*.yaml" {
   let val: TextBundle;

--- a/client/src/types/util_types.d.ts
+++ b/client/src/types/util_types.d.ts
@@ -1,14 +1,29 @@
 // by Klaus Meinhardt @ajafff
 // known from Gerrit Birkeland @Gerrit0
+// comments by @stephen-oneil, so blame me if I've interpeted it wrong
 // https://github.com/Microsoft/TypeScript/issues/25987#issuecomment-408339599
 // https://github.com/microsoft/TypeScript/issues/25987#issuecomment-441224690
+
 export type KnownKeys<T> = {
-  [K in keyof T]: string extends K ? never : number extends K ? never : K;
-} extends { [_ in keyof T]: infer U } // eslint-disable-line no-unused-vars
-  ? {} extends U
+  // map key: value to key: key OR key: never in the case where key is an index signature (e.g. [key: string], [key: number])
+  // future proofed against symbol index types, not released but on master as of https://github.com/microsoft/TypeScript/pull/44512
+  [key in keyof T]: string extends key
     ? never
-    : U
-  : never;
+    : number extends key
+    ? never
+    : symbol extends key
+    ? never
+    : key;
+} extends {
+  // conditional used to infer union  the value types from the left hand side of this extends
+  // (where the value types are either the keys or never, and never is excluded from the infered union)
+  [_ in keyof T]: infer KnowableKeys;
+}
+  ? // above line will infer a type of {} if T has no keys, not what we want. Return never instead
+    {} extends KnowableKeys // eslint-disable-line @typescript-eslint/ban-types
+    ? never
+    : KnowableKeys
+  : never; // not reachable, but conditional expression necessary for construction with desired inference of KnowableKeys
 
 export type WithoutIndexTypes<T> = Pick<T, KnownKeys<T>>;
 


### PR DESCRIPTION
Closes #1146

This is a big one, lots of our TS practices so far have been anti-patterns.

I'll try and keep track of some of the big ones here:
  -  [non-null assertions aren't recommended](https://github.com/typescript-eslint/typescript-eslint/blob/v4.22.0/packages/eslint-plugin/docs/rules/no-non-null-assertion.md), using them supposedly cancels outs the benefit of the `strictNullChecks` we set to true in the tsconfig?
    - right, duh, the point is that if your type says it could be null, then you really should be handling the null case explicitly (type narrowing the null out of the other branches). Using the non-null assertion freely leads to losing the safety in cases where there could be nulls. That's not the intent of the non-null assertion, it's only supposed to be used if you're really sure null values aren't possible, but it's always better to handle them explicitly (maybe with a comment saying, _at this point_ nulls should be impossible... but assuming they'll never be possible and not handling them is just setting up future run-time bugs)
  - I've left the warning against using explicit `any` types on for now, finding in most cases so far that things can be rewritten with generics rather than disabling the lint rule locally
  - I've disabled the [explicit-module-boundary-types](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/explicit-module-boundary-types.md) rule to make this fix PR more manageable, but we might want to enable it later. Will bite us in a lot of places, so try to manually apply the rule when possible to make it easier if we eventually turn it on

To lint:
  - [x] FAQ/faq_data.ts (@ktw1016, #1160)
  - [x] InfoBase/AppState.ts (@ktw1016, #1160)
  - [x] about/about.tsx  (@Stephen-ONeil, #1152)
  - [x] charts/graphRegistry.ts (@ktw1016, #1160)
  - [x] components/Accordion/Accordions.tsx (@ktw1016, #1160)
  - [x] components/AlertBanner/AlertBanner.tsx (@csong202, #1156) 
  - [x] components/AutoHeightVirtualList.tsx (@ktw1016, #1160)
  - [x] components/BackToTop/BackToTop.tsx (@ktw1016, #1160)
  - [x] components/CheckBox/CheckBox.tsx (@ktw1016, #1160)
  - [x] components/DisplayTable/DisplayTable.tsx (@ktw1016, #1160)
  - [x] components/HeightClipper/HeightClipper.tsx (@ktw1016, #1160)
  - [x] components/LabeledBox/LabeledBox.tsx  (@Stephen-ONeil, #1152)
  - [x] components/LabeledTable/LabeledTable.tsx (@IvanFeng1 #1155)
  - [x] components/Select/Select.tsx (@IvanFeng1, #1154)
  - [x] components/TextMaker.tsx (@csong202, #1159) 
  - [x] components/TwoLevelSelect/TwoLevelSelect.tsx (@IvanFeng1 #1158)
  - [x] components/Typeahead/Typeahead.tsx (@csong202, #1163) 
  - [x] components/Typeahead/TypeaheadA11yStatus.tsx (@csong202, #1163)
  - [x] components/glossary_components.tsx (@IvanFeng1, #1153)
  - [x] components/modals_and_popovers/FocusLockedModal.tsx (~@sranc046, PR: TODO~ @Stephen-ONeil, trivial 12817a2)
  - [x] contact/contact.tsx (@Stephen-ONeil, #1152)
  - [x] core/assign_to_dev_helper_namespace.ts  (@Stephen-ONeil, trivial)
  - [x] core/format.ts (@Stephen-ONeil, PR: #1149)
  - [x] general_utils.ts (@ktw1016, #1160)
  - [x] types/global.d.ts  (@Stephen-ONeil, PR: #1164)
  - [x] types/types.d.ts  (@Stephen-ONeil, PR: #1164)
  - [x] types/util_types.d.ts  (@Stephen-ONeil, PR: #1164)

Note: I generated that list based on running eslint directly on `client/src`, _not_ based on the webpack output. Files like `types/global.d.ts` aren't directly part of our webpack'ed tree, so the build-time linter doesn't catch them. TODO: add a separate lint for them in CI or something? Hmm.