### PR TITLE
TS lint components with {} state

### DIFF
--- a/client/src/about/about.tsx
+++ b/client/src/about/about.tsx
@@ -46,7 +46,7 @@ const tech_icon_list = _.chain([
 interface AboutProps {
   toggleSurvey: () => void;
 }
-export default class About extends React.Component<AboutProps, {}> {
+export default class About extends React.Component<AboutProps, never> {
   render() {
     const { toggleSurvey } = this.props;
 

--- a/client/src/components/LabeledBox/LabeledBox.tsx
+++ b/client/src/components/LabeledBox/LabeledBox.tsx
@@ -7,7 +7,7 @@ interface LabeledBoxProps {
   children: string | React.ReactNode;
 }
 
-export class LabeledBox extends React.Component<LabeledBoxProps, {}> {
+export class LabeledBox extends React.Component<LabeledBoxProps, never> {
   render() {
     const { label, children } = this.props;
 

--- a/client/src/contact/contact.tsx
+++ b/client/src/contact/contact.tsx
@@ -14,7 +14,7 @@ interface ContactProps {
   toggleSurvey: () => void;
 }
 
-export default class Contact extends React.Component<ContactProps, {}> {
+export default class Contact extends React.Component<ContactProps, never> {
   render() {
     const { toggleSurvey } = this.props;
 


### PR DESCRIPTION
Pretty trivial, opening a PR for further discussion though.

The `ban-types` rule doesn't using `{}` as a type (for good reasons it seems)... but `React.Component`'s default state and prop types are `{}` anyway.

Trivial fix for the lint rule is to just not explicitly set `{}` for stateless class components. Silences the lint error without actually changing this code. On the other hand, we could decide to explicitly provide `never` for the component state prop to make it explicit that the component is stateless. I prefer that, but wanted a conversation before we decide on it.