### PR TITLE
ts lint glossary_components

### DIFF
--- a/client/src/components/glossary_components.tsx
+++ b/client/src/components/glossary_components.tsx
@@ -20,8 +20,8 @@ interface GlossaryTooltipWrapperProps {
 interface GlossaryIconProps {
   id: string;
   alternate_text?: string;
-  arrow_selector?: any;
-  inner_selector?: any; // i don't know how to do the types for the selectors
+  arrow_selector?: string;
+  inner_selector?: string;
   icon_color?: string;
   icon_alt_color?: string;
 }
@@ -59,6 +59,8 @@ const GlossaryTooltipWrapper: React.FC<GlossaryTooltipWrapperProps> = ({
 export const GlossaryIcon: React.FC<GlossaryIconProps> = ({
   id,
   alternate_text,
+  arrow_selector,
+  inner_selector,
   icon_color,
   icon_alt_color,
 }) => (

--- a/client/src/components/glossary_components.tsx
+++ b/client/src/components/glossary_components.tsx
@@ -20,8 +20,6 @@ interface GlossaryTooltipWrapperProps {
 interface GlossaryIconProps {
   id: string;
   alternate_text?: string;
-  arrow_selector?: string;
-  inner_selector?: string;
   icon_color?: string;
   icon_alt_color?: string;
 }
@@ -59,8 +57,6 @@ const GlossaryTooltipWrapper: React.FC<GlossaryTooltipWrapperProps> = ({
 export const GlossaryIcon: React.FC<GlossaryIconProps> = ({
   id,
   alternate_text,
-  arrow_selector,
-  inner_selector,
   icon_color,
   icon_alt_color,
 }) => (


### PR DESCRIPTION
https://github.com/TBS-EACPD/infobase/blob/d2da7526629463ee3861c7ff90ff837a7eac79b7/client/src/components/glossary_components.tsx#L59-L66

`arrow_selector` and `inner_selector` never get used after being declared, should I remove them? 