### PR TITLE
Consistent Order to data_sources' metadata

### DIFF
--- a/client/src/metadata/data_sources.js
+++ b/client/src/metadata/data_sources.js
@@ -62,7 +62,7 @@ const infobase_open_data_page = {
 
 const sources = _.chain([
   {
-    key: "1 IGOC",
+    key: "IGOC",
     title: text_maker("igoc_source_title"),
     frequency: text_maker("yearly"),
     open_data: infobase_open_data_page,
@@ -76,7 +76,7 @@ const sources = _.chain([
     ],
   },
   {
-    key: "2 PA",
+    key: "PA",
     title: text_maker("pa_title"),
     frequency: text_maker("yearly"),
     open_data: infobase_open_data_page,
@@ -92,7 +92,7 @@ const sources = _.chain([
     },
   },
   {
-    key: "3 ESTIMATES",
+    key: "ESTIMATES",
     title: text_maker("estimates_title"),
     frequency: text_maker("quarterly"),
     open_data: infobase_open_data_page,
@@ -108,7 +108,7 @@ const sources = _.chain([
     },
   },
   {
-    key: "4 CFMRS",
+    key: "CFMRS",
     title: text_maker("cfmrs_title"),
     open_data: {
       en: "http://open.canada.ca/data/en/dataset/5e6dcf6b-dbed-4b51-84e5-1f4926ad7fdf",
@@ -123,7 +123,7 @@ const sources = _.chain([
     },
   },
   {
-    key: "5 RTP",
+    key: "RTP",
     title: text_maker("transfer_payments_source_title"),
     frequency: text_maker("yearly"),
     open_data: {
@@ -143,7 +143,7 @@ const sources = _.chain([
     ],
   },
   {
-    key: "6 DP",
+    key: "DP",
     title: text_maker("dp_title"),
     frequency: text_maker("yearly"),
     open_data: infobase_open_data_page,
@@ -166,7 +166,7 @@ const sources = _.chain([
     },
   },
   {
-    key: "7 DRR",
+    key: "DRR",
     title: text_maker("drr_title"),
     frequency: text_maker("yearly"),
     open_data: infobase_open_data_page,
@@ -189,7 +189,7 @@ const sources = _.chain([
     },
   },
   {
-    key: "8 RPS",
+    key: "RPS",
     title: text_maker("rps_title"),
     frequency: text_maker("yearly"),
     get description() {
@@ -200,7 +200,7 @@ const sources = _.chain([
     },
   },
   {
-    key: "9 COVID",
+    key: "COVID",
     title: text_maker("covid_title"),
     frequency: text_maker("as_needed"),
     description: <TM k="covid_desc" />,
@@ -224,7 +224,7 @@ const sources = _.chain([
     ],
   },
   services_feature_flag && {
-    key: "10 SERVICES",
+    key: "SERVICES",
     title: text_maker("services_title"),
     frequency: text_maker("yearly"),
     description: text_maker("services_desc"),

--- a/client/src/metadata/data_sources.js
+++ b/client/src/metadata/data_sources.js
@@ -62,7 +62,21 @@ const infobase_open_data_page = {
 
 const sources = _.chain([
   {
-    key: "PA",
+    key: "1 IGOC",
+    title: text_maker("igoc_source_title"),
+    frequency: text_maker("yearly"),
+    open_data: infobase_open_data_page,
+    description: text_maker("igoc_source_desc"),
+    items: [
+      {
+        id: "igoc",
+        text: text_maker("igoc_item_name"),
+        inline_link: "#igoc",
+      },
+    ],
+  },
+  {
+    key: "2 PA",
     title: text_maker("pa_title"),
     frequency: text_maker("yearly"),
     open_data: infobase_open_data_page,
@@ -78,7 +92,7 @@ const sources = _.chain([
     },
   },
   {
-    key: "ESTIMATES",
+    key: "3 ESTIMATES",
     title: text_maker("estimates_title"),
     frequency: text_maker("quarterly"),
     open_data: infobase_open_data_page,
@@ -94,7 +108,7 @@ const sources = _.chain([
     },
   },
   {
-    key: "CFMRS",
+    key: "4 CFMRS",
     title: text_maker("cfmrs_title"),
     open_data: {
       en: "http://open.canada.ca/data/en/dataset/5e6dcf6b-dbed-4b51-84e5-1f4926ad7fdf",
@@ -109,18 +123,27 @@ const sources = _.chain([
     },
   },
   {
-    key: "RPS",
-    title: text_maker("rps_title"),
+    key: "5 RTP",
+    title: text_maker("transfer_payments_source_title"),
     frequency: text_maker("yearly"),
-    get description() {
-      return desc_from_glossary_keys("PEOPLE_DATA");
+    open_data: {
+      en: "https://open.canada.ca/data/en/dataset/69bdc3eb-e919-4854-bc52-a435a3e19092",
+      fr: "https://ouvert.canada.ca/data/fr/dataset/69bdc3eb-e919-4854-bc52-a435a3e19092",
     },
-    get items() {
-      return _.map(tables_from_source_key("RPS"), table_to_row_item);
-    },
+    description: text_maker("transfer_payments_source_desc"),
+    items: [
+      {
+        id: "rtp",
+        text: text_maker("transfer_payments_source_title"),
+        inline_link: rpb_link({
+          table: "orgTransferPaymentsRegion",
+          mode: "details",
+        }),
+      },
+    ],
   },
   {
-    key: "DP",
+    key: "6 DP",
     title: text_maker("dp_title"),
     frequency: text_maker("yearly"),
     open_data: infobase_open_data_page,
@@ -143,7 +166,7 @@ const sources = _.chain([
     },
   },
   {
-    key: "DRR",
+    key: "7 DRR",
     title: text_maker("drr_title"),
     frequency: text_maker("yearly"),
     open_data: infobase_open_data_page,
@@ -166,57 +189,18 @@ const sources = _.chain([
     },
   },
   {
-    key: "IGOC",
-    title: text_maker("igoc_source_title"),
+    key: "8 RPS",
+    title: text_maker("rps_title"),
     frequency: text_maker("yearly"),
-    open_data: infobase_open_data_page,
-    description: text_maker("igoc_source_desc"),
-    items: [
-      {
-        id: "igoc",
-        text: text_maker("igoc_item_name"),
-        inline_link: "#igoc",
-      },
-    ],
-  },
-  {
-    key: "RTP",
-    title: text_maker("transfer_payments_source_title"),
-    frequency: text_maker("yearly"),
-    open_data: {
-      en: "https://open.canada.ca/data/en/dataset/69bdc3eb-e919-4854-bc52-a435a3e19092",
-      fr: "https://ouvert.canada.ca/data/fr/dataset/69bdc3eb-e919-4854-bc52-a435a3e19092",
+    get description() {
+      return desc_from_glossary_keys("PEOPLE_DATA");
     },
-    description: text_maker("transfer_payments_source_desc"),
-    items: [
-      {
-        id: "rtp",
-        text: text_maker("transfer_payments_source_title"),
-        inline_link: rpb_link({
-          table: "orgTransferPaymentsRegion",
-          mode: "details",
-        }),
-      },
-    ],
-  },
-  services_feature_flag && {
-    key: "SERVICES",
-    title: text_maker("services_title"),
-    frequency: text_maker("yearly"),
-    description: text_maker("services_desc"),
-    items: [
-      {
-        id: "service",
-        text: text_maker("service_inventory"),
-        external_link:
-          lang === "en"
-            ? "https://open.canada.ca/data/en/dataset/3ac0d080-6149-499a-8b06-7ce5f00ec56c"
-            : "https://ouvert.canada.ca/data/fr/dataset/3ac0d080-6149-499a-8b06-7ce5f00ec56c",
-      },
-    ],
+    get items() {
+      return _.map(tables_from_source_key("RPS"), table_to_row_item);
+    },
   },
   {
-    key: "COVID",
+    key: "9 COVID",
     title: text_maker("covid_title"),
     frequency: text_maker("as_needed"),
     description: <TM k="covid_desc" />,
@@ -236,6 +220,22 @@ const sources = _.chain([
         text: text_maker("covid_expenditures_estimated_exp"),
         inline_link:
           "#orgs/gov/gov/infograph/covid/.-.-(panel_key.-.-'covid_expenditures_panel)",
+      },
+    ],
+  },
+  services_feature_flag && {
+    key: "10 SERVICES",
+    title: text_maker("services_title"),
+    frequency: text_maker("yearly"),
+    description: text_maker("services_desc"),
+    items: [
+      {
+        id: "service",
+        text: text_maker("service_inventory"),
+        external_link:
+          lang === "en"
+            ? "https://open.canada.ca/data/en/dataset/3ac0d080-6149-499a-8b06-7ce5f00ec56c"
+            : "https://ouvert.canada.ca/data/fr/dataset/3ac0d080-6149-499a-8b06-7ce5f00ec56c",
       },
     ],
   },

--- a/client/src/metadata/metadata.js
+++ b/client/src/metadata/metadata.js
@@ -28,8 +28,6 @@ export default class MetaData extends React.Component {
       },
     } = this.props;
 
-    const sorted_sources = _.sortBy(sources, (source) => source.title);
-
     return (
       <StandardRouteContainer
         title={text_maker("metadata")}
@@ -46,7 +44,7 @@ export default class MetaData extends React.Component {
           <TM k="metadata_t" />
         </p>
         <ScrollToTargetContainer target_id={data_source}>
-          {_.map(sorted_sources, (source) => (
+          {_.map(sources, (source) => (
             <div key={source.key} id={source.key}>
               <Panel title={source.title}>
                 <div>{source.description}</div>


### PR DESCRIPTION
The predetermined order for the metadata routes is:
(text_maker keys)
"IGOC"
"PA"
"ESTIMATES"
"CFMRS"
"RTP"
"DP"
"DRR"
"RPS"
"COVID"
"SERVICES"

Open to suggestions about how to sort the metadata!