### PR TITLE
TS Lint Errors: Typeahead.tsx and TypeaheadA11yStatus.tsx

### DIFF
--- a/client/src/components/Typeahead/Typeahead.tsx
+++ b/client/src/components/Typeahead/Typeahead.tsx
@@ -72,6 +72,7 @@ export class Typeahead extends React.Component<TypeaheadProps, TypeaheadState> {
 
   static defaultProps = {
     placeholder: text_maker("search"),
+    min_length: 3,
     on_query_debounce_time: 300,
   };
 

--- a/client/src/components/Typeahead/Typeahead.tsx
+++ b/client/src/components/Typeahead/Typeahead.tsx
@@ -123,7 +123,7 @@ export class Typeahead extends React.Component<TypeaheadProps, TypeaheadState> {
       return null;
     }
   }
-  componentDidUpdate(prevProps: TypeaheadProps, prevState: TypeaheadState) {
+  componentDidUpdate(_prevProps: TypeaheadProps, prevState: TypeaheadState) {
     const { selection_cursor } = this.state;
     const { selection_cursor: prev_selection_cursor } = prevState;
 

--- a/client/src/components/Typeahead/Typeahead.tsx
+++ b/client/src/components/Typeahead/Typeahead.tsx
@@ -1,9 +1,19 @@
 import classNames from "classnames";
 import _ from "lodash";
-import React, { ChangeEvent, KeyboardEvent, Fragment } from "react";
+import React, {
+  ChangeEvent,
+  KeyboardEvent,
+  Fragment,
+  ReactElement,
+} from "react";
 import ReactResizeDetector from "react-resize-detector/build/withPolyfill";
 
-import { AutoSizer, CellMeasurer, CellMeasurerCache } from "react-virtualized";
+import {
+  AutoSizer,
+  CellMeasurer,
+  CellMeasurerCache,
+  List,
+} from "react-virtualized";
 
 import { AutoHeightVirtualList } from "src/components/AutoHeightVirtualList";
 import { create_text_maker_component } from "src/components/misc_util_components";
@@ -54,19 +64,14 @@ interface TypeaheadState {
   results?: ResultProps[];
 }
 
-export class Typeahead extends React.Component<
-  TypeaheadProps,
-  TypeaheadState,
-  {}
-> {
+export class Typeahead extends React.Component<TypeaheadProps, TypeaheadState> {
   menu_id: string;
 
   private typeahead_ref = React.createRef<HTMLDivElement>();
-  private virtualized_list_ref = React.createRef<any>();
+  private virtualized_list_ref = React.createRef<List>();
 
   static defaultProps = {
     placeholder: text_maker("search"),
-    min_length: 3,
     on_query_debounce_time: 300,
   };
 
@@ -214,7 +219,7 @@ export class Typeahead extends React.Component<
                       key,
                       parent,
                       style,
-                    }: any) => (
+                    }): ReactElement => (
                       <CellMeasurer
                         cache={virtualized_cell_measure_cache}
                         columnIndex={0}

--- a/client/src/components/Typeahead/Typeahead.tsx
+++ b/client/src/components/Typeahead/Typeahead.tsx
@@ -184,7 +184,6 @@ export class Typeahead extends React.Component<
         </div>
         {this.show_menu && (
           <TypeaheadA11yStatus
-            min_length={min_length}
             selection_cursor={selection_cursor}
             results={results}
           />

--- a/client/src/components/Typeahead/TypeaheadA11yStatus.tsx
+++ b/client/src/components/Typeahead/TypeaheadA11yStatus.tsx
@@ -1,5 +1,5 @@
 import _ from "lodash";
-import React from "react";
+import React, { ReactNode } from "react";
 
 import { create_text_maker } from "src/models/text";
 
@@ -10,18 +10,17 @@ import text from "./Typeahead.yaml";
 const text_maker = create_text_maker(text);
 
 interface DelayedRenderProps {
-  children: any;
+  children: ReactNode;
 }
 
 interface DelayedRenderState {
-  children: any;
+  children: ReactNode;
   debounced: boolean;
 }
 
 class DelayedRender extends React.Component<
   DelayedRenderProps,
-  DelayedRenderState,
-  {}
+  DelayedRenderState
 > {
   constructor(props: DelayedRenderProps) {
     super(props);
@@ -60,10 +59,7 @@ class DelayedRender extends React.Component<
   componentDidMount() {
     this.debounceUpdate();
   }
-  componentDidUpdate(
-    prevProps: DelayedRenderProps,
-    prevState: DelayedRenderState
-  ) {
+  componentDidUpdate(prevState: DelayedRenderState) {
     const { children: prev_children } = prevState;
     const { children, debounced } = this.state;
 
@@ -88,13 +84,11 @@ class DelayedRender extends React.Component<
 
 interface TypeaheadA11yStatusProps {
   selection_cursor: number;
-  min_length: number;
   results: ResultProps[];
 }
 
 export const TypeaheadA11yStatus: React.FC<TypeaheadA11yStatusProps> = ({
   selection_cursor,
-  min_length,
   results,
 }) => {
   const status_content = (() => {

--- a/client/src/components/Typeahead/TypeaheadA11yStatus.tsx
+++ b/client/src/components/Typeahead/TypeaheadA11yStatus.tsx
@@ -59,7 +59,10 @@ class DelayedRender extends React.Component<
   componentDidMount() {
     this.debounceUpdate();
   }
-  componentDidUpdate(prevState: DelayedRenderState) {
+  componentDidUpdate(
+    _prevProps: DelayedRenderProps,
+    prevState: DelayedRenderState
+  ) {
     const { children: prev_children } = prevState;
     const { children, debounced } = this.state;
 


### PR DESCRIPTION
- deleted min_length props from TypeaheadA11yStatus because it was unused