### PR TITLE
Fixed bug with Details on Statutory Items in Estimates and Details on Voted Items in Estimates

### DIFF
--- a/client/src/panels/panel_declarations/finances/vote_stat/in_year_vote_stat_breakdown.js
+++ b/client/src/panels/panel_declarations/finances/vote_stat/in_year_vote_stat_breakdown.js
@@ -30,11 +30,15 @@ const { Dept } = Subject;
 const text_func = (vs, d, break_str) => {
   if (vs == "voted") {
     return d.dept
-      ? `${Dept.lookup(d.dept).name} ${break_str}  ${d.desc}`
+      ? _.includes(d.desc, `${Dept.lookup(d.dept).name} ${break_str}  `)
+        ? d.desc
+        : `${Dept.lookup(d.dept).name} ${break_str}  ${d.desc}`
       : d.desc;
   } else {
     return d.dept
-      ? `${d.desc} ${break_str} ${Dept.lookup(d.dept).name}`
+      ? _.includes(d.desc, ` ${break_str} ${Dept.lookup(d.dept).name}`)
+        ? d.desc
+        : `${d.desc} ${break_str} ${Dept.lookup(d.dept).name}`
       : d.desc;
   }
 };

--- a/client/src/panels/panel_declarations/finances/vote_stat/in_year_vote_stat_breakdown.js
+++ b/client/src/panels/panel_declarations/finances/vote_stat/in_year_vote_stat_breakdown.js
@@ -110,7 +110,7 @@ const planned_vote_or_stat_render = (vs) =>
       name: "root",
       color: "white",
       children: _.map(data, (d, i) =>
-        _.extend(d, {
+        _.extend(_.clone(d), {
           id: i,
           total: total_amt,
           total_of: text_maker(isVoted ? "all_voted_items" : "all_stat_items"),

--- a/client/src/panels/panel_declarations/finances/vote_stat/in_year_vote_stat_breakdown.js
+++ b/client/src/panels/panel_declarations/finances/vote_stat/in_year_vote_stat_breakdown.js
@@ -109,14 +109,13 @@ const planned_vote_or_stat_render = (vs) =>
     const packing_data = {
       name: "root",
       color: "white",
-      children: _.map(data, (d, i) =>
-        _.extend(_.clone(d), {
-          id: i,
-          total: total_amt,
-          total_of: text_maker(isVoted ? "all_voted_items" : "all_stat_items"),
-          desc: text_func(vs, d, "-"),
-        })
-      ),
+      children: _.map(data, (d, i) => ({
+        ...d,
+        id: i,
+        total: total_amt,
+        total_of: text_maker(isVoted ? "all_voted_items" : "all_stat_items"),
+        desc: text_func(vs, d, "-"),
+      })),
     };
 
     const show_pack = !is_a11y_mode;

--- a/client/src/panels/panel_declarations/finances/vote_stat/in_year_vote_stat_breakdown.js
+++ b/client/src/panels/panel_declarations/finances/vote_stat/in_year_vote_stat_breakdown.js
@@ -147,7 +147,6 @@ const planned_vote_or_stat_render = (vs) =>
                 value_string="{{est_in_year}}_estimates"
                 formatter={formats.compact1}
                 label_id="desc"
-                text_func={(d, break_str) => text_func(vs, d, break_str)}
               />
             </div>
           </Col>


### PR DESCRIPTION
Issue #1070

- adjusted text_func so department name only gets appended to desc once
- added _.clone to packing_data.children so _.extend won't change data
- deleted an unused WrappedNivoTreemap props