### PR TITLE
Drop react FC type

### DIFF
--- a/client/.eslintrc.json
+++ b/client/.eslintrc.json
@@ -48,7 +48,20 @@
         "@typescript-eslint/no-unused-vars": "off", // Lot of false positives on this rule. Better to use the exprimental
         "@typescript-eslint/no-unused-vars-experimental": "warn",
         "@typescript-eslint/no-redeclare": ["error"],
-        "@typescript-eslint/explicit-module-boundary-types": "off" // TODO might want to turn this on later, but it will take a while to fix all the warnings
+        "@typescript-eslint/explicit-module-boundary-types": "off", // TODO might want to turn this on later, but it will take a while to fix all the warnings
+        "@typescript-eslint/ban-types": [
+          "error",
+          {
+            "types": {
+              "React.FunctionalComponent": {
+                "message": "FunctionalComponent is discouraged, prefer a plain function. See https://github.com/facebook/create-react-app/pull/8177"
+              },
+              "React.FC": {
+                "message": "FC is discouraged, prefer a plain function. See https://github.com/facebook/create-react-app/pull/8177"
+              }
+            }
+          }
+        ]
       }
     }
   ],

--- a/client/src/components/AlertBanner/AlertBanner.tsx
+++ b/client/src/components/AlertBanner/AlertBanner.tsx
@@ -13,12 +13,12 @@ interface AlertBannerProps {
 
 export const banner_classes = ["info", "success", "warning", "danger"];
 
-export const AlertBanner: React.FC<AlertBannerProps> = ({
+export const AlertBanner = ({
   children,
   banner_class,
   additional_class_names,
   style,
-}) => {
+}: AlertBannerProps) => {
   if (banner_class && !_.includes(banner_classes, banner_class)) {
     throw new Error(
       `AlertBanner received invalid banner_class prop of ${banner_class}`

--- a/client/src/components/CardList/CardList.tsx
+++ b/client/src/components/CardList/CardList.tsx
@@ -16,44 +16,42 @@ interface CardListProps {
   elements: CardListElementProps[];
 }
 
-const CardList = (
-  {
-    elements
-  }: CardListProps
-) => <div>
-  <ul className="list-unstyled">
-    {_.chain(elements)
-      .map(({ display, href, children }, index) =>
-        _.isEmpty(children) ? null : (
-          <li key={index} style={{ padding: "0px 20px" }}>
-            <div className="card card-sm mrgn-bttm-0">
-              {href ? (
-                <a href={href} style={{ color: "white" }}>
-                  {display}
-                </a>
-              ) : (
-                <span style={{ color: "white" }}>{display}</span>
-              )}
-            </div>
-            <ul
-              className="list-group list-group--withheader"
-              style={{ marginBottom: "20px" }}
-            >
-              {_.map(children, ({ display, href }, ix) => (
-                <li key={ix} className="list-group-item">
-                  {href ? (
-                    <a href={href}>{display}</a>
-                  ) : (
-                    <span>{display}</span>
-                  )}
-                </li>
-              ))}
-            </ul>
-          </li>
+const CardList = ({ elements }: CardListProps) => (
+  <div>
+    <ul className="list-unstyled">
+      {_.chain(elements)
+        .map(({ display, href, children }, index) =>
+          _.isEmpty(children) ? null : (
+            <li key={index} style={{ padding: "0px 20px" }}>
+              <div className="card card-sm mrgn-bttm-0">
+                {href ? (
+                  <a href={href} style={{ color: "white" }}>
+                    {display}
+                  </a>
+                ) : (
+                  <span style={{ color: "white" }}>{display}</span>
+                )}
+              </div>
+              <ul
+                className="list-group list-group--withheader"
+                style={{ marginBottom: "20px" }}
+              >
+                {_.map(children, ({ display, href }, ix) => (
+                  <li key={ix} className="list-group-item">
+                    {href ? (
+                      <a href={href}>{display}</a>
+                    ) : (
+                      <span>{display}</span>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            </li>
+          )
         )
-      )
-      .value()}
-  </ul>
-</div>;
+        .value()}
+    </ul>
+  </div>
+);
 
 export { CardList };

--- a/client/src/components/CardList/CardList.tsx
+++ b/client/src/components/CardList/CardList.tsx
@@ -16,42 +16,44 @@ interface CardListProps {
   elements: CardListElementProps[];
 }
 
-const CardList: React.FC<CardListProps> = ({ elements }) => (
-  <div>
-    <ul className="list-unstyled">
-      {_.chain(elements)
-        .map(({ display, href, children }, index) =>
-          _.isEmpty(children) ? null : (
-            <li key={index} style={{ padding: "0px 20px" }}>
-              <div className="card card-sm mrgn-bttm-0">
-                {href ? (
-                  <a href={href} style={{ color: "white" }}>
-                    {display}
-                  </a>
-                ) : (
-                  <span style={{ color: "white" }}>{display}</span>
-                )}
-              </div>
-              <ul
-                className="list-group list-group--withheader"
-                style={{ marginBottom: "20px" }}
-              >
-                {_.map(children, ({ display, href }, ix) => (
-                  <li key={ix} className="list-group-item">
-                    {href ? (
-                      <a href={href}>{display}</a>
-                    ) : (
-                      <span>{display}</span>
-                    )}
-                  </li>
-                ))}
-              </ul>
-            </li>
-          )
+const CardList = (
+  {
+    elements
+  }: CardListProps
+) => <div>
+  <ul className="list-unstyled">
+    {_.chain(elements)
+      .map(({ display, href, children }, index) =>
+        _.isEmpty(children) ? null : (
+          <li key={index} style={{ padding: "0px 20px" }}>
+            <div className="card card-sm mrgn-bttm-0">
+              {href ? (
+                <a href={href} style={{ color: "white" }}>
+                  {display}
+                </a>
+              ) : (
+                <span style={{ color: "white" }}>{display}</span>
+              )}
+            </div>
+            <ul
+              className="list-group list-group--withheader"
+              style={{ marginBottom: "20px" }}
+            >
+              {_.map(children, ({ display, href }, ix) => (
+                <li key={ix} className="list-group-item">
+                  {href ? (
+                    <a href={href}>{display}</a>
+                  ) : (
+                    <span>{display}</span>
+                  )}
+                </li>
+              ))}
+            </ul>
+          </li>
         )
-        .value()}
-    </ul>
-  </div>
-);
+      )
+      .value()}
+  </ul>
+</div>;
 
 export { CardList };

--- a/client/src/components/Details/Details.tsx
+++ b/client/src/components/Details/Details.tsx
@@ -22,15 +22,13 @@ interface DetailsState {
   is_open: boolean;
 }
 
-export const StatelessDetails = (
-  {
-    summary_content,
-    content,
-    persist_content,
-    on_click,
-    is_open
-  }: StatelessDetailsProps
-) => {
+export const StatelessDetails = ({
+  summary_content,
+  content,
+  persist_content,
+  on_click,
+  is_open,
+}: StatelessDetailsProps) => {
   const aria_labels = {
     en: {
       open: "Content follows, activate to collapse content",

--- a/client/src/components/Details/Details.tsx
+++ b/client/src/components/Details/Details.tsx
@@ -22,13 +22,15 @@ interface DetailsState {
   is_open: boolean;
 }
 
-export const StatelessDetails: React.FC<StatelessDetailsProps> = ({
-  summary_content,
-  content,
-  persist_content,
-  on_click,
-  is_open,
-}) => {
+export const StatelessDetails = (
+  {
+    summary_content,
+    content,
+    persist_content,
+    on_click,
+    is_open
+  }: StatelessDetailsProps
+) => {
   const aria_labels = {
     en: {
       open: "Content follows, activate to collapse content",

--- a/client/src/components/FancyUL/FancyUL.tsx
+++ b/client/src/components/FancyUL/FancyUL.tsx
@@ -11,21 +11,21 @@ interface FancyULProps {
   children: React.ReactNode[];
 }
 
-export const FancyUL: React.FC<FancyULProps> = ({
-  className,
-  title,
-  TitleComponent,
-  children,
-}) => (
-  <ul className={classNames("fancy-ul", className)} aria-label={title}>
-    {title && (
-      <li className={"fancy-ul__title"} aria-hidden={true}>
-        {TitleComponent ? <TitleComponent>{title}</TitleComponent> : title}
-      </li>
-    )}
-    {_.chain(children)
-      .compact()
-      .map((item, i) => <li key={i}>{item}</li>)
-      .value()}
-  </ul>
-);
+export const FancyUL = (
+  {
+    className,
+    title,
+    TitleComponent,
+    children
+  }: FancyULProps
+) => <ul className={classNames("fancy-ul", className)} aria-label={title}>
+  {title && (
+    <li className={"fancy-ul__title"} aria-hidden={true}>
+      {TitleComponent ? <TitleComponent>{title}</TitleComponent> : title}
+    </li>
+  )}
+  {_.chain(children)
+    .compact()
+    .map((item, i) => <li key={i}>{item}</li>)
+    .value()}
+</ul>;

--- a/client/src/components/FancyUL/FancyUL.tsx
+++ b/client/src/components/FancyUL/FancyUL.tsx
@@ -11,21 +11,21 @@ interface FancyULProps {
   children: React.ReactNode[];
 }
 
-export const FancyUL = (
-  {
-    className,
-    title,
-    TitleComponent,
-    children
-  }: FancyULProps
-) => <ul className={classNames("fancy-ul", className)} aria-label={title}>
-  {title && (
-    <li className={"fancy-ul__title"} aria-hidden={true}>
-      {TitleComponent ? <TitleComponent>{title}</TitleComponent> : title}
-    </li>
-  )}
-  {_.chain(children)
-    .compact()
-    .map((item, i) => <li key={i}>{item}</li>)
-    .value()}
-</ul>;
+export const FancyUL = ({
+  className,
+  title,
+  TitleComponent,
+  children,
+}: FancyULProps) => (
+  <ul className={classNames("fancy-ul", className)} aria-label={title}>
+    {title && (
+      <li className={"fancy-ul__title"} aria-hidden={true}>
+        {TitleComponent ? <TitleComponent>{title}</TitleComponent> : title}
+      </li>
+    )}
+    {_.chain(children)
+      .compact()
+      .map((item, i) => <li key={i}>{item}</li>)
+      .value()}
+  </ul>
+);

--- a/client/src/components/LeafSpinner/LeafSpinner.tsx
+++ b/client/src/components/LeafSpinner/LeafSpinner.tsx
@@ -73,7 +73,11 @@ export const spinner_configs: {
 interface LeafSpinnerProps {
   config_name: spinner_config_names;
 }
-export const LeafSpinner: React.FC<LeafSpinnerProps> = ({ config_name }) => {
+export const LeafSpinner = (
+  {
+    config_name
+  }: LeafSpinnerProps
+) => {
   const default_config_name = _.chain(spinner_configs).keys().first().value();
 
   const { outer_positioning, spinner_container_style, svg_modifier } =

--- a/client/src/components/LeafSpinner/LeafSpinner.tsx
+++ b/client/src/components/LeafSpinner/LeafSpinner.tsx
@@ -73,11 +73,7 @@ export const spinner_configs: {
 interface LeafSpinnerProps {
   config_name: spinner_config_names;
 }
-export const LeafSpinner = (
-  {
-    config_name
-  }: LeafSpinnerProps
-) => {
+export const LeafSpinner = ({ config_name }: LeafSpinnerProps) => {
   const default_config_name = _.chain(spinner_configs).keys().first().value();
 
   const { outer_positioning, spinner_container_style, svg_modifier } =

--- a/client/src/components/LogInteractionEvents.tsx
+++ b/client/src/components/LogInteractionEvents.tsx
@@ -10,14 +10,12 @@ interface LogInterationEventsProps {
   children: React.ReactNode;
 }
 
-export const LogInteractionEvents = (
-  {
-    event_type,
-    event_details,
-    style,
-    children
-  }: LogInterationEventsProps
-) => {
+export const LogInteractionEvents = ({
+  event_type,
+  event_details,
+  style,
+  children,
+}: LogInterationEventsProps) => {
   const log_event = _.debounce(
     (event) =>
       log_standard_event({

--- a/client/src/components/LogInteractionEvents.tsx
+++ b/client/src/components/LogInteractionEvents.tsx
@@ -10,12 +10,14 @@ interface LogInterationEventsProps {
   children: React.ReactNode;
 }
 
-export const LogInteractionEvents: React.FC<LogInterationEventsProps> = ({
-  event_type,
-  event_details,
-  style,
-  children,
-}) => {
+export const LogInteractionEvents = (
+  {
+    event_type,
+    event_details,
+    style,
+    children
+  }: LogInterationEventsProps
+) => {
   const log_event = _.debounce(
     (event) =>
       log_standard_event({

--- a/client/src/components/RadioButtons/RadioButtons.tsx
+++ b/client/src/components/RadioButtons/RadioButtons.tsx
@@ -14,26 +14,23 @@ interface RadioButtonsProps {
   onChange: (id: string) => void;
 }
 
-export const RadioButtons = (
-  {
-    options,
-    onChange
-  }: RadioButtonsProps
-) => <div className="radio-buttons">
-  {options.map(({ display, id, active }) => (
-    <button
-      key={id}
-      aria-pressed={active}
-      className={classNames(
-        "btn",
-        "radio-buttons__option",
-        active && "radio-buttons__option--active"
-      )}
-      onClick={() => {
-        onChange(id);
-      }}
-    >
-      {display}
-    </button>
-  ))}
-</div>;
+export const RadioButtons = ({ options, onChange }: RadioButtonsProps) => (
+  <div className="radio-buttons">
+    {options.map(({ display, id, active }) => (
+      <button
+        key={id}
+        aria-pressed={active}
+        className={classNames(
+          "btn",
+          "radio-buttons__option",
+          active && "radio-buttons__option--active"
+        )}
+        onClick={() => {
+          onChange(id);
+        }}
+      >
+        {display}
+      </button>
+    ))}
+  </div>
+);

--- a/client/src/components/RadioButtons/RadioButtons.tsx
+++ b/client/src/components/RadioButtons/RadioButtons.tsx
@@ -14,26 +14,26 @@ interface RadioButtonsProps {
   onChange: (id: string) => void;
 }
 
-export const RadioButtons: React.FC<RadioButtonsProps> = ({
-  options,
-  onChange,
-}) => (
-  <div className="radio-buttons">
-    {options.map(({ display, id, active }) => (
-      <button
-        key={id}
-        aria-pressed={active}
-        className={classNames(
-          "btn",
-          "radio-buttons__option",
-          active && "radio-buttons__option--active"
-        )}
-        onClick={() => {
-          onChange(id);
-        }}
-      >
-        {display}
-      </button>
-    ))}
-  </div>
-);
+export const RadioButtons = (
+  {
+    options,
+    onChange
+  }: RadioButtonsProps
+) => <div className="radio-buttons">
+  {options.map(({ display, id, active }) => (
+    <button
+      key={id}
+      aria-pressed={active}
+      className={classNames(
+        "btn",
+        "radio-buttons__option",
+        active && "radio-buttons__option--active"
+      )}
+      onClick={() => {
+        onChange(id);
+      }}
+    >
+      {display}
+    </button>
+  ))}
+</div>;

--- a/client/src/components/Select/Select.tsx
+++ b/client/src/components/Select/Select.tsx
@@ -19,31 +19,31 @@ interface SelectProps {
 }
 
 //expects options to be of the form [ { id, display } ]
-const Select = (
-  {
-    id,
-    selected,
-    className,
-    options,
-    onSelect,
-    disabled,
-    style,
-    title
-  }: SelectProps
-) => <select
-  style={style}
-  id={id}
-  disabled={disabled}
-  className={className}
-  value={selected}
-  onChange={(event) => onSelect(event.target.value)}
-  title={title}
->
-  {_.map(options, (choice) => (
-    <option key={choice.id} value={choice.id}>
-      {choice.display}
-    </option>
-  ))}
-</select>;
+const Select = ({
+  id,
+  selected,
+  className,
+  options,
+  onSelect,
+  disabled,
+  style,
+  title,
+}: SelectProps) => (
+  <select
+    style={style}
+    id={id}
+    disabled={disabled}
+    className={className}
+    value={selected}
+    onChange={(event) => onSelect(event.target.value)}
+    title={title}
+  >
+    {_.map(options, (choice) => (
+      <option key={choice.id} value={choice.id}>
+        {choice.display}
+      </option>
+    ))}
+  </select>
+);
 
 export { Select };

--- a/client/src/components/Select/Select.tsx
+++ b/client/src/components/Select/Select.tsx
@@ -19,31 +19,31 @@ interface SelectProps {
 }
 
 //expects options to be of the form [ { id, display } ]
-const Select: React.FC<SelectProps> = ({
-  id,
-  selected,
-  className,
-  options,
-  onSelect,
-  disabled,
-  style,
-  title,
-}) => (
-  <select
-    style={style}
-    id={id}
-    disabled={disabled}
-    className={className}
-    value={selected}
-    onChange={(event) => onSelect(event.target.value)}
-    title={title}
-  >
-    {_.map(options, (choice) => (
-      <option key={choice.id} value={choice.id}>
-        {choice.display}
-      </option>
-    ))}
-  </select>
-);
+const Select = (
+  {
+    id,
+    selected,
+    className,
+    options,
+    onSelect,
+    disabled,
+    style,
+    title
+  }: SelectProps
+) => <select
+  style={style}
+  id={id}
+  disabled={disabled}
+  className={className}
+  value={selected}
+  onChange={(event) => onSelect(event.target.value)}
+  title={title}
+>
+  {_.map(options, (choice) => (
+    <option key={choice.id} value={choice.id}>
+      {choice.display}
+    </option>
+  ))}
+</select>;
 
 export { Select };

--- a/client/src/components/TagCloud.tsx
+++ b/client/src/components/TagCloud.tsx
@@ -23,31 +23,34 @@ interface TagCloudProps {
   onSelectTag: (parameter?: string) => void;
 }
 
-export const TagCloud: React.FC<TagCloudProps> = ({ tags, onSelectTag }) => (
-  <ul className="tag-cloud-main">
-    {_.map(tags, ({ id, active, label }) => (
-      <li
-        key={id}
-        className={classNames(active && "active")}
-        onClick={() => onSelectTag(id)}
-      >
-        <button role="checkbox" aria-checked={!!active}>
-          {active && (
-            <IconCheckmark
-              color={backgroundColor}
-              width={10}
-              height={10}
-              svg_style={{ verticalAlign: "0.1px" }}
-            />
-          )}
-          <span style={{ marginLeft: "5px" }}>{label}</span>
-        </button>
-        {GlossaryEntry.lookup(id) && (
-          <span className="tag-button-helper" tabIndex={0}>
-            <GlossaryIcon id={id} />
-          </span>
+export const TagCloud = (
+  {
+    tags,
+    onSelectTag
+  }: TagCloudProps
+) => <ul className="tag-cloud-main">
+  {_.map(tags, ({ id, active, label }) => (
+    <li
+      key={id}
+      className={classNames(active && "active")}
+      onClick={() => onSelectTag(id)}
+    >
+      <button role="checkbox" aria-checked={!!active}>
+        {active && (
+          <IconCheckmark
+            color={backgroundColor}
+            width={10}
+            height={10}
+            svg_style={{ verticalAlign: "0.1px" }}
+          />
         )}
-      </li>
-    ))}
-  </ul>
-);
+        <span style={{ marginLeft: "5px" }}>{label}</span>
+      </button>
+      {GlossaryEntry.lookup(id) && (
+        <span className="tag-button-helper" tabIndex={0}>
+          <GlossaryIcon id={id} />
+        </span>
+      )}
+    </li>
+  ))}
+</ul>;

--- a/client/src/components/TagCloud.tsx
+++ b/client/src/components/TagCloud.tsx
@@ -23,34 +23,31 @@ interface TagCloudProps {
   onSelectTag: (parameter?: string) => void;
 }
 
-export const TagCloud = (
-  {
-    tags,
-    onSelectTag
-  }: TagCloudProps
-) => <ul className="tag-cloud-main">
-  {_.map(tags, ({ id, active, label }) => (
-    <li
-      key={id}
-      className={classNames(active && "active")}
-      onClick={() => onSelectTag(id)}
-    >
-      <button role="checkbox" aria-checked={!!active}>
-        {active && (
-          <IconCheckmark
-            color={backgroundColor}
-            width={10}
-            height={10}
-            svg_style={{ verticalAlign: "0.1px" }}
-          />
+export const TagCloud = ({ tags, onSelectTag }: TagCloudProps) => (
+  <ul className="tag-cloud-main">
+    {_.map(tags, ({ id, active, label }) => (
+      <li
+        key={id}
+        className={classNames(active && "active")}
+        onClick={() => onSelectTag(id)}
+      >
+        <button role="checkbox" aria-checked={!!active}>
+          {active && (
+            <IconCheckmark
+              color={backgroundColor}
+              width={10}
+              height={10}
+              svg_style={{ verticalAlign: "0.1px" }}
+            />
+          )}
+          <span style={{ marginLeft: "5px" }}>{label}</span>
+        </button>
+        {GlossaryEntry.lookup(id) && (
+          <span className="tag-button-helper" tabIndex={0}>
+            <GlossaryIcon id={id} />
+          </span>
         )}
-        <span style={{ marginLeft: "5px" }}>{label}</span>
-      </button>
-      {GlossaryEntry.lookup(id) && (
-        <span className="tag-button-helper" tabIndex={0}>
-          <GlossaryIcon id={id} />
-        </span>
-      )}
-    </li>
-  ))}
-</ul>;
+      </li>
+    ))}
+  </ul>
+);

--- a/client/src/components/Tombstones/Tombstones.tsx
+++ b/client/src/components/Tombstones/Tombstones.tsx
@@ -7,17 +7,19 @@ interface UnlabeledTombstoneProps {
   items: (string | React.ReactNode)[];
 }
 
-const UnlabeledTombstone: React.FC<UnlabeledTombstoneProps> = ({ items }) => (
-  <table className="tombstone-table">
-    <tbody>
-      {_.map(items, (item, ix) => (
-        <tr key={ix}>
-          <td>{item}</td>
-        </tr>
-      ))}
-    </tbody>
-  </table>
-);
+const UnlabeledTombstone = (
+  {
+    items
+  }: UnlabeledTombstoneProps
+) => <table className="tombstone-table">
+  <tbody>
+    {_.map(items, (item, ix) => (
+      <tr key={ix}>
+        <td>{item}</td>
+      </tr>
+    ))}
+  </tbody>
+</table>;
 
 interface LabeledTombstoneProps {
   labels_and_items: [
@@ -26,20 +28,20 @@ interface LabeledTombstoneProps {
   ][];
 }
 
-const LabeledTombstone: React.FC<LabeledTombstoneProps> = ({
-  labels_and_items,
-}) => (
-  <dl className="row tombstone-data-list">
-    {_.map(labels_and_items, ([label, item], ix) => (
-      <Fragment key={ix}>
-        <dt className="col-12 col-lg-2">{label}</dt>
-        <dd className="col-12 col-lg-10">{item}</dd>
-        {ix !== _.size(labels_and_items) - 1 && (
-          <hr style={{ width: "100%" }} />
-        )}
-      </Fragment>
-    ))}
-  </dl>
-);
+const LabeledTombstone = (
+  {
+    labels_and_items
+  }: LabeledTombstoneProps
+) => <dl className="row tombstone-data-list">
+  {_.map(labels_and_items, ([label, item], ix) => (
+    <Fragment key={ix}>
+      <dt className="col-12 col-lg-2">{label}</dt>
+      <dd className="col-12 col-lg-10">{item}</dd>
+      {ix !== _.size(labels_and_items) - 1 && (
+        <hr style={{ width: "100%" }} />
+      )}
+    </Fragment>
+  ))}
+</dl>;
 
 export { UnlabeledTombstone, LabeledTombstone };

--- a/client/src/components/Tombstones/Tombstones.tsx
+++ b/client/src/components/Tombstones/Tombstones.tsx
@@ -7,19 +7,17 @@ interface UnlabeledTombstoneProps {
   items: (string | React.ReactNode)[];
 }
 
-const UnlabeledTombstone = (
-  {
-    items
-  }: UnlabeledTombstoneProps
-) => <table className="tombstone-table">
-  <tbody>
-    {_.map(items, (item, ix) => (
-      <tr key={ix}>
-        <td>{item}</td>
-      </tr>
-    ))}
-  </tbody>
-</table>;
+const UnlabeledTombstone = ({ items }: UnlabeledTombstoneProps) => (
+  <table className="tombstone-table">
+    <tbody>
+      {_.map(items, (item, ix) => (
+        <tr key={ix}>
+          <td>{item}</td>
+        </tr>
+      ))}
+    </tbody>
+  </table>
+);
 
 interface LabeledTombstoneProps {
   labels_and_items: [
@@ -28,20 +26,18 @@ interface LabeledTombstoneProps {
   ][];
 }
 
-const LabeledTombstone = (
-  {
-    labels_and_items
-  }: LabeledTombstoneProps
-) => <dl className="row tombstone-data-list">
-  {_.map(labels_and_items, ([label, item], ix) => (
-    <Fragment key={ix}>
-      <dt className="col-12 col-lg-2">{label}</dt>
-      <dd className="col-12 col-lg-10">{item}</dd>
-      {ix !== _.size(labels_and_items) - 1 && (
-        <hr style={{ width: "100%" }} />
-      )}
-    </Fragment>
-  ))}
-</dl>;
+const LabeledTombstone = ({ labels_and_items }: LabeledTombstoneProps) => (
+  <dl className="row tombstone-data-list">
+    {_.map(labels_and_items, ([label, item], ix) => (
+      <Fragment key={ix}>
+        <dt className="col-12 col-lg-2">{label}</dt>
+        <dd className="col-12 col-lg-10">{item}</dd>
+        {ix !== _.size(labels_and_items) - 1 && (
+          <hr style={{ width: "100%" }} />
+        )}
+      </Fragment>
+    ))}
+  </dl>
+);
 
 export { UnlabeledTombstone, LabeledTombstone };

--- a/client/src/components/TwoLevelSelect/TwoLevelSelect.tsx
+++ b/client/src/components/TwoLevelSelect/TwoLevelSelect.tsx
@@ -25,33 +25,33 @@ interface TwoSelectProps {
   style?: React.CSSProperties;
 }
 
-const TwoLevelSelect = (
-  {
-    style,
-    id,
-    selected,
-    className,
-    grouped_options,
-    onSelect,
-    disabled
-  }: TwoSelectProps
-) => <select
-  id={id}
-  style={style}
-  disabled={disabled}
-  className={className}
-  value={selected}
-  onChange={(event) => onSelect(event.target.value)}
->
-  {_.map(grouped_options, ({ children, display, id }) => (
-    <optgroup key={id} label={display}>
-      {_.map(children, (choice) => (
-        <option key={choice.id} value={choice.id}>
-          {choice.display}
-        </option>
-      ))}
-    </optgroup>
-  ))}
-</select>;
+const TwoLevelSelect = ({
+  style,
+  id,
+  selected,
+  className,
+  grouped_options,
+  onSelect,
+  disabled,
+}: TwoSelectProps) => (
+  <select
+    id={id}
+    style={style}
+    disabled={disabled}
+    className={className}
+    value={selected}
+    onChange={(event) => onSelect(event.target.value)}
+  >
+    {_.map(grouped_options, ({ children, display, id }) => (
+      <optgroup key={id} label={display}>
+        {_.map(children, (choice) => (
+          <option key={choice.id} value={choice.id}>
+            {choice.display}
+          </option>
+        ))}
+      </optgroup>
+    ))}
+  </select>
+);
 
 export { TwoLevelSelect };

--- a/client/src/components/TwoLevelSelect/TwoLevelSelect.tsx
+++ b/client/src/components/TwoLevelSelect/TwoLevelSelect.tsx
@@ -25,33 +25,33 @@ interface TwoSelectProps {
   style?: React.CSSProperties;
 }
 
-const TwoLevelSelect: React.FC<TwoSelectProps> = ({
-  style,
-  id,
-  selected,
-  className,
-  grouped_options,
-  onSelect,
-  disabled,
-}) => (
-  <select
-    id={id}
-    style={style}
-    disabled={disabled}
-    className={className}
-    value={selected}
-    onChange={(event) => onSelect(event.target.value)}
-  >
-    {_.map(grouped_options, ({ children, display, id }) => (
-      <optgroup key={id} label={display}>
-        {_.map(children, (choice) => (
-          <option key={choice.id} value={choice.id}>
-            {choice.display}
-          </option>
-        ))}
-      </optgroup>
-    ))}
-  </select>
-);
+const TwoLevelSelect = (
+  {
+    style,
+    id,
+    selected,
+    className,
+    grouped_options,
+    onSelect,
+    disabled
+  }: TwoSelectProps
+) => <select
+  id={id}
+  style={style}
+  disabled={disabled}
+  className={className}
+  value={selected}
+  onChange={(event) => onSelect(event.target.value)}
+>
+  {_.map(grouped_options, ({ children, display, id }) => (
+    <optgroup key={id} label={display}>
+      {_.map(children, (choice) => (
+        <option key={choice.id} value={choice.id}>
+          {choice.display}
+        </option>
+      ))}
+    </optgroup>
+  ))}
+</select>;
 
 export { TwoLevelSelect };

--- a/client/src/components/Typeahead/Typeahead.tsx
+++ b/client/src/components/Typeahead/Typeahead.tsx
@@ -54,7 +54,7 @@ interface TypeaheadProps {
   placeholder: string;
   on_query_debounce_time: number;
   additional_a11y_description?: string;
-  utility_buttons?: boolean | (React.FC | React.Component)[];
+  utility_buttons?: boolean | React.ReactNode | React.ReactNode[];
 }
 
 interface TypeaheadState {

--- a/client/src/components/Typeahead/Typeahead.tsx
+++ b/client/src/components/Typeahead/Typeahead.tsx
@@ -39,9 +39,9 @@ const virtualized_cell_measure_cache = new CellMeasurerCache({
 const default_selection_cursor = -1;
 
 export interface ResultProps {
-  header?: string | React.Component;
+  header?: React.ReactNode;
   on_select: () => void;
-  content: string | React.Component;
+  content: React.ReactNode;
   plain_text: string;
 }
 

--- a/client/src/components/Typeahead/TypeaheadA11yStatus.tsx
+++ b/client/src/components/Typeahead/TypeaheadA11yStatus.tsx
@@ -90,10 +90,12 @@ interface TypeaheadA11yStatusProps {
   results: ResultProps[];
 }
 
-export const TypeaheadA11yStatus: React.FC<TypeaheadA11yStatusProps> = ({
-  selection_cursor,
-  results,
-}) => {
+export const TypeaheadA11yStatus = (
+  {
+    selection_cursor,
+    results
+  }: TypeaheadA11yStatusProps
+) => {
   const status_content = (() => {
     if (selection_cursor >= 0) {
       const selected_name = results[selection_cursor].plain_text;

--- a/client/src/components/Typeahead/TypeaheadA11yStatus.tsx
+++ b/client/src/components/Typeahead/TypeaheadA11yStatus.tsx
@@ -90,12 +90,10 @@ interface TypeaheadA11yStatusProps {
   results: ResultProps[];
 }
 
-export const TypeaheadA11yStatus = (
-  {
-    selection_cursor,
-    results
-  }: TypeaheadA11yStatusProps
-) => {
+export const TypeaheadA11yStatus = ({
+  selection_cursor,
+  results,
+}: TypeaheadA11yStatusProps) => {
   const status_content = (() => {
     if (selection_cursor >= 0) {
       const selected_name = results[selection_cursor].plain_text;

--- a/client/src/components/glossary_components.tsx
+++ b/client/src/components/glossary_components.tsx
@@ -30,62 +30,63 @@ interface GlossaryItemProps {
   item_class: string;
 }
 
-const GlossaryTooltipWrapper: React.FC<GlossaryTooltipWrapperProps> = ({
-  id,
-  children,
-  no_bottom_border,
-}) =>
-  is_a11y_mode ? (
-    <a
-      href={glossary_href(id)}
-      title={trivial_text_maker("glossary_link_title")}
-    >
-      {children}
-    </a>
-  ) : (
-    <span
-      className="nowrap glossary-tippy-link"
-      style={no_bottom_border ? { borderBottom: "none" } : undefined}
-      tabIndex={0}
-      data-ibtt-glossary-key={id}
-      data-toggle="tooltip"
-    >
-      {children}
-    </span>
-  );
+const GlossaryTooltipWrapper = (
+  {
+    id,
+    children,
+    no_bottom_border
+  }: GlossaryTooltipWrapperProps
+) => is_a11y_mode ? (
+  <a
+    href={glossary_href(id)}
+    title={trivial_text_maker("glossary_link_title")}
+  >
+    {children}
+  </a>
+) : (
+  <span
+    className="nowrap glossary-tippy-link"
+    style={no_bottom_border ? { borderBottom: "none" } : undefined}
+    tabIndex={0}
+    data-ibtt-glossary-key={id}
+    data-toggle="tooltip"
+  >
+    {children}
+  </span>
+);
 
-export const GlossaryIcon: React.FC<GlossaryIconProps> = ({
-  id,
-  alternate_text,
-  icon_color,
-  icon_alt_color,
-}) => (
-  <GlossaryTooltipWrapper no_bottom_border={true} id={id}>
-    {is_a11y_mode ? (
-      alternate_text ? (
-        alternate_text
-      ) : (
-        GlossaryEntry.lookup(id).title
-      )
+export const GlossaryIcon = (
+  {
+    id,
+    alternate_text,
+    icon_color,
+    icon_alt_color
+  }: GlossaryIconProps
+) => <GlossaryTooltipWrapper no_bottom_border={true} id={id}>
+  {is_a11y_mode ? (
+    alternate_text ? (
+      alternate_text
     ) : (
-      <IconQuestion
-        color={icon_color ? icon_color : backgroundColor}
-        width={"1.2em"}
-        alternate_color={icon_alt_color ? icon_alt_color : primaryColor}
-        svg_style={{ verticalAlign: "-0.3em" }}
-      />
-    )}
-  </GlossaryTooltipWrapper>
-);
+      GlossaryEntry.lookup(id).title
+    )
+  ) : (
+    <IconQuestion
+      color={icon_color ? icon_color : backgroundColor}
+      width={"1.2em"}
+      alternate_color={icon_alt_color ? icon_alt_color : primaryColor}
+      svg_style={{ verticalAlign: "-0.3em" }}
+    />
+  )}
+</GlossaryTooltipWrapper>;
 
-export const GlossaryItem: React.FC<GlossaryItemProps> = ({
-  id,
-  alternate_text,
-  item_class,
-}) => (
-  <GlossaryTooltipWrapper id={id}>
-    <span className={item_class}>
-      {alternate_text ? alternate_text : GlossaryEntry.lookup(id).title}
-    </span>
-  </GlossaryTooltipWrapper>
-);
+export const GlossaryItem = (
+  {
+    id,
+    alternate_text,
+    item_class
+  }: GlossaryItemProps
+) => <GlossaryTooltipWrapper id={id}>
+  <span className={item_class}>
+    {alternate_text ? alternate_text : GlossaryEntry.lookup(id).title}
+  </span>
+</GlossaryTooltipWrapper>;

--- a/client/src/components/glossary_components.tsx
+++ b/client/src/components/glossary_components.tsx
@@ -30,63 +30,62 @@ interface GlossaryItemProps {
   item_class: string;
 }
 
-const GlossaryTooltipWrapper = (
-  {
-    id,
-    children,
-    no_bottom_border
-  }: GlossaryTooltipWrapperProps
-) => is_a11y_mode ? (
-  <a
-    href={glossary_href(id)}
-    title={trivial_text_maker("glossary_link_title")}
-  >
-    {children}
-  </a>
-) : (
-  <span
-    className="nowrap glossary-tippy-link"
-    style={no_bottom_border ? { borderBottom: "none" } : undefined}
-    tabIndex={0}
-    data-ibtt-glossary-key={id}
-    data-toggle="tooltip"
-  >
-    {children}
-  </span>
+const GlossaryTooltipWrapper = ({
+  id,
+  children,
+  no_bottom_border,
+}: GlossaryTooltipWrapperProps) =>
+  is_a11y_mode ? (
+    <a
+      href={glossary_href(id)}
+      title={trivial_text_maker("glossary_link_title")}
+    >
+      {children}
+    </a>
+  ) : (
+    <span
+      className="nowrap glossary-tippy-link"
+      style={no_bottom_border ? { borderBottom: "none" } : undefined}
+      tabIndex={0}
+      data-ibtt-glossary-key={id}
+      data-toggle="tooltip"
+    >
+      {children}
+    </span>
+  );
+
+export const GlossaryIcon = ({
+  id,
+  alternate_text,
+  icon_color,
+  icon_alt_color,
+}: GlossaryIconProps) => (
+  <GlossaryTooltipWrapper no_bottom_border={true} id={id}>
+    {is_a11y_mode ? (
+      alternate_text ? (
+        alternate_text
+      ) : (
+        GlossaryEntry.lookup(id).title
+      )
+    ) : (
+      <IconQuestion
+        color={icon_color ? icon_color : backgroundColor}
+        width={"1.2em"}
+        alternate_color={icon_alt_color ? icon_alt_color : primaryColor}
+        svg_style={{ verticalAlign: "-0.3em" }}
+      />
+    )}
+  </GlossaryTooltipWrapper>
 );
 
-export const GlossaryIcon = (
-  {
-    id,
-    alternate_text,
-    icon_color,
-    icon_alt_color
-  }: GlossaryIconProps
-) => <GlossaryTooltipWrapper no_bottom_border={true} id={id}>
-  {is_a11y_mode ? (
-    alternate_text ? (
-      alternate_text
-    ) : (
-      GlossaryEntry.lookup(id).title
-    )
-  ) : (
-    <IconQuestion
-      color={icon_color ? icon_color : backgroundColor}
-      width={"1.2em"}
-      alternate_color={icon_alt_color ? icon_alt_color : primaryColor}
-      svg_style={{ verticalAlign: "-0.3em" }}
-    />
-  )}
-</GlossaryTooltipWrapper>;
-
-export const GlossaryItem = (
-  {
-    id,
-    alternate_text,
-    item_class
-  }: GlossaryItemProps
-) => <GlossaryTooltipWrapper id={id}>
-  <span className={item_class}>
-    {alternate_text ? alternate_text : GlossaryEntry.lookup(id).title}
-  </span>
-</GlossaryTooltipWrapper>;
+export const GlossaryItem = ({
+  id,
+  alternate_text,
+  item_class,
+}: GlossaryItemProps) => (
+  <GlossaryTooltipWrapper id={id}>
+    <span className={item_class}>
+      {alternate_text ? alternate_text : GlossaryEntry.lookup(id).title}
+    </span>
+  </GlossaryTooltipWrapper>
+);

--- a/client/src/home/CardImage/CardImage.tsx
+++ b/client/src/home/CardImage/CardImage.tsx
@@ -14,33 +14,33 @@ interface CardImageProps {
   tmf: TMProps["tmf"];
 }
 
-const CardImage: React.FC<CardImageProps> = ({
-  svg,
-  title_key,
-  text_key,
-  link_href,
-  link_open_in_new_tab,
-  text_args,
-  tmf,
-}) => (
-  <a
-    className={"top-img-card-container link-unstyled"}
-    href={link_href}
-    target={link_open_in_new_tab ? "_blank" : "_self"}
-    rel={link_open_in_new_tab ? "noopener noreferrer" : ""}
-  >
-    <div className="top-img-card">
-      {svg && <div className="top-img-card__top">{svg}</div>}
-      <div className="top-img-card__bottom">
-        <div className="top-img-card__title">
-          <TM k={title_key} tmf={tmf} args={text_args} />
-        </div>
-        <div className="top-img-card__text">
-          <TM k={text_key} tmf={tmf} args={text_args} />
-        </div>
+const CardImage = (
+  {
+    svg,
+    title_key,
+    text_key,
+    link_href,
+    link_open_in_new_tab,
+    text_args,
+    tmf
+  }: CardImageProps
+) => <a
+  className={"top-img-card-container link-unstyled"}
+  href={link_href}
+  target={link_open_in_new_tab ? "_blank" : "_self"}
+  rel={link_open_in_new_tab ? "noopener noreferrer" : ""}
+>
+  <div className="top-img-card">
+    {svg && <div className="top-img-card__top">{svg}</div>}
+    <div className="top-img-card__bottom">
+      <div className="top-img-card__title">
+        <TM k={title_key} tmf={tmf} args={text_args} />
+      </div>
+      <div className="top-img-card__text">
+        <TM k={text_key} tmf={tmf} args={text_args} />
       </div>
     </div>
-  </a>
-);
+  </div>
+</a>;
 
 export { CardImage };

--- a/client/src/home/CardImage/CardImage.tsx
+++ b/client/src/home/CardImage/CardImage.tsx
@@ -14,33 +14,33 @@ interface CardImageProps {
   tmf: TMProps["tmf"];
 }
 
-const CardImage = (
-  {
-    svg,
-    title_key,
-    text_key,
-    link_href,
-    link_open_in_new_tab,
-    text_args,
-    tmf
-  }: CardImageProps
-) => <a
-  className={"top-img-card-container link-unstyled"}
-  href={link_href}
-  target={link_open_in_new_tab ? "_blank" : "_self"}
-  rel={link_open_in_new_tab ? "noopener noreferrer" : ""}
->
-  <div className="top-img-card">
-    {svg && <div className="top-img-card__top">{svg}</div>}
-    <div className="top-img-card__bottom">
-      <div className="top-img-card__title">
-        <TM k={title_key} tmf={tmf} args={text_args} />
-      </div>
-      <div className="top-img-card__text">
-        <TM k={text_key} tmf={tmf} args={text_args} />
+const CardImage = ({
+  svg,
+  title_key,
+  text_key,
+  link_href,
+  link_open_in_new_tab,
+  text_args,
+  tmf,
+}: CardImageProps) => (
+  <a
+    className={"top-img-card-container link-unstyled"}
+    href={link_href}
+    target={link_open_in_new_tab ? "_blank" : "_self"}
+    rel={link_open_in_new_tab ? "noopener noreferrer" : ""}
+  >
+    <div className="top-img-card">
+      {svg && <div className="top-img-card__top">{svg}</div>}
+      <div className="top-img-card__bottom">
+        <div className="top-img-card__title">
+          <TM k={title_key} tmf={tmf} args={text_args} />
+        </div>
+        <div className="top-img-card__text">
+          <TM k={text_key} tmf={tmf} args={text_args} />
+        </div>
       </div>
     </div>
-  </div>
-</a>;
+  </a>
+);
 
 export { CardImage };


### PR DESCRIPTION
Following from https://github.com/facebook/create-react-app/pull/8177

Lots of good reasons to not use the FC/FunctionComponent type turns out, seems better to just use normal functions.

Semi-related, cleaned up a couple props in Typeahead.tsx that were using `React.Component` where `React.ReactNode` was the appropriate type.

Possible TODO:
  - [x] maybe add `React.FC` etc to the linter's banned types, or look for an existing plugin with that rule