### PR TITLE
COVID expenditures July update

### DIFF
--- a/client/src/panels/panel_declarations/covid/covid_key_concepts.yaml
+++ b/client/src/panels/panel_declarations/covid/covid_key_concepts.yaml
@@ -20,7 +20,7 @@ covid_questions_missing_measures_a:
     The main purpose of the Estimates is to support Parliament’s consideration of the appropriation bills, which are the legal instruments
     for authorizing certain payments annually, and therefore not all COVID-19 related measures fall within its scope. For instance, excluded from the data are:
       * Measures legislated through the _Income Tax Act_ such as the Canada Emergency Wage Subsidy, the enhanced GST Credit, and the Canada Child Benefit;
-        * As of May 31, 2021, 2021-22 estimated expenditures for the Canada Emergency Wage Subsidy are $TODO billion.
+        * As of May 31, 2021, 2021-22 estimated expenditures for the Canada Emergency Wage Subsidy are $75.8 billion.
         * As of March 31, 2021, 2020-21 estimated expenditures for these programs are as follows:
           * Canada Emergency Wage Subsidy $73.5 billion
           * Enhanced GST Credit $5.2 billion
@@ -36,7 +36,7 @@ covid_questions_missing_measures_a:
     des projets de loi de crédits, qui sont toutes les instruments juridiques permettant d'autoriser certains paiements, si bien que les mesures
     liées à la COVID-19 ne sont pas inscrites aux budgets des dépenses. Par exemple, sont exclues de ces données :
       * les mesures prévues par la _Loi de l'impôt sur le revenu_, comme la Subvention salariale d’urgence du Canada, l’Augmentation du crédit pour TPS et l’Allocation canadienne pour enfants
-        * En date du 31 mai 2021, l'estimation des dépenses pour la Subvention salariale d’urgence du Canada pour 2021-2022 est TODO milliards de dollars.
+        * En date du 31 mai 2021, l'estimation des dépenses pour la Subvention salariale d’urgence du Canada pour 2021-2022 est 75,8 milliards de dollars.
         * En date du 31 mars 2021, l'estimation des dépenses pour 2020-2021 pour ces programmes est la suivante:
           * Subvention salariale d’urgence du Canada 73,5 milliards de dollars
           * Augmentation du crédit pour TPS 5,2 milliards de dollars

--- a/client/src/panels/panel_declarations/covid/covid_key_concepts.yaml
+++ b/client/src/panels/panel_declarations/covid/covid_key_concepts.yaml
@@ -5,9 +5,9 @@ covid_questions_up_to_date_q:
 covid_questions_up_to_date_a:
   transform: [handlebars,markdown]
   en: |
-    Yes. This data is the current most current available and reflects information available as of April 30, 2021.
+    Yes. This data is the current most current available and reflects information available as of May 31, 2021.
   fr: |
-    Oui. Ces données sont les plus récentes et correspondent aux renseignements à notre disposition le 30 avril 2021.
+    Oui. Ces données sont les plus récentes et correspondent aux renseignements à notre disposition le 31 mai 2021.
 
 covid_questions_missing_measures_q:
   en: Why are some measures of the Government’s COVID response plan missing from the data?
@@ -20,7 +20,7 @@ covid_questions_missing_measures_a:
     The main purpose of the Estimates is to support Parliament’s consideration of the appropriation bills, which are the legal instruments
     for authorizing certain payments annually, and therefore not all COVID-19 related measures fall within its scope. For instance, excluded from the data are:
       * Measures legislated through the _Income Tax Act_ such as the Canada Emergency Wage Subsidy, the enhanced GST Credit, and the Canada Child Benefit;
-        * As of April 30, 2021, 2021-22 estimated expenditures for the Canada Emergency Wage Subsidy are $3.8 billion.
+        * As of May 31, 2021, 2021-22 estimated expenditures for the Canada Emergency Wage Subsidy are $TODO billion.
         * As of March 31, 2021, 2020-21 estimated expenditures for these programs are as follows:
           * Canada Emergency Wage Subsidy $73.5 billion
           * Enhanced GST Credit $5.2 billion
@@ -36,7 +36,7 @@ covid_questions_missing_measures_a:
     des projets de loi de crédits, qui sont toutes les instruments juridiques permettant d'autoriser certains paiements, si bien que les mesures
     liées à la COVID-19 ne sont pas inscrites aux budgets des dépenses. Par exemple, sont exclues de ces données :
       * les mesures prévues par la _Loi de l'impôt sur le revenu_, comme la Subvention salariale d’urgence du Canada, l’Augmentation du crédit pour TPS et l’Allocation canadienne pour enfants
-        * En date du 30 avril 2021, l'estimation des dépenses pour la Subvention salariale d’urgence du Canada pour 2021-2022 est 3,8 milliards de dollars.
+        * En date du 31 mai 2021, l'estimation des dépenses pour la Subvention salariale d’urgence du Canada pour 2021-2022 est TODO milliards de dollars.
         * En date du 31 mars 2021, l'estimation des dépenses pour 2020-2021 pour ces programmes est la suivante:
           * Subvention salariale d’urgence du Canada 73,5 milliards de dollars
           * Augmentation du crédit pour TPS 5,2 milliards de dollars

--- a/server/src/models/covid/populate.js
+++ b/server/src/models/covid/populate.js
@@ -14,8 +14,19 @@ export default async function ({ models }) {
       stat: +row.stat,
     })
   );
-  const covid_expenditures_rows = _.chain(
+
+  const temporarily_filtered_covid_expenditures_data = _.chain(
     get_standard_csv_file_rows("covid_expenditures.csv")
+  )
+    .filter(
+      ({ fiscal_year, is_in_estimates }) =>
+        fiscal_year !== "2019" && is_in_estimates === "1"
+    )
+    .map((row) => _.omit(row, "is_in_estimates"))
+    .value();
+
+  const covid_expenditures_rows = _.chain(
+    temporarily_filtered_covid_expenditures_data
   )
     .map((row) => ({
       // covid_expenditures.csv contains the bud/non-bud split, but the client doesn't use it yet and supporting it creates lots of room for error,
@@ -43,7 +54,7 @@ export default async function ({ models }) {
     .value();
 
   const covid_expenditures_month_last_updated_by_fiscal_year = _.chain(
-    get_standard_csv_file_rows("covid_expenditures.csv")
+    temporarily_filtered_covid_expenditures_data
   )
     .groupBy("fiscal_year")
     .mapValues((rows, fiscal_year) =>


### PR DESCRIPTION
TODO:
  - [x] update to "Why are some measures of the Government’s COVID response plan missing from the data?" FAQ numbers
  - [ ] Confirm the 75.8 CEWS figure