### PR TITLE
Updating h1 font within extended_bootstrap_css

### DIFF
--- a/client/src/EstimatesComparison/EstimatesComparison.scss
+++ b/client/src/EstimatesComparison/EstimatesComparison.scss
@@ -30,5 +30,5 @@
 h1 {
   margin-top: 20px;
   margin-bottom: 20px;
-  border-bottom: 3px solid $highlightColor;
+  border-bottom: 3px solid #da3a38;
 }

--- a/client/src/EstimatesComparison/EstimatesComparison.scss
+++ b/client/src/EstimatesComparison/EstimatesComparison.scss
@@ -26,3 +26,9 @@
   }
   justify-content: space-evenly;
 }
+
+h1 {
+  margin-top: 20px;
+  margin-bottom: 20px;
+  border-bottom: 3px solid $highlightColor;
+}

--- a/client/src/IgocExplorer/IgocExplorer.scss
+++ b/client/src/IgocExplorer/IgocExplorer.scss
@@ -15,5 +15,5 @@
 h1 {
   margin-top: 20px;
   margin-bottom: 20px;
-  border-bottom: 3px solid $highlightColor;
+  border-bottom: 3px solid #da3a38;
 }

--- a/client/src/IgocExplorer/IgocExplorer.scss
+++ b/client/src/IgocExplorer/IgocExplorer.scss
@@ -11,3 +11,9 @@
     flex-grow: 1;
   }
 }
+
+h1 {
+  margin-top: 20px;
+  margin-bottom: 20px;
+  border-bottom: 3px solid $highlightColor;
+}

--- a/client/src/Survey/Survey.scss
+++ b/client/src/Survey/Survey.scss
@@ -1,0 +1,5 @@
+h1 {
+  margin-top: 20px;
+  margin-bottom: 20px;
+  border-bottom: 3px solid #da3a38;
+}

--- a/client/src/TagExplorer/TagExplorer.js
+++ b/client/src/TagExplorer/TagExplorer.js
@@ -14,6 +14,8 @@ import { ResourceScheme } from "./resource_scheme";
 
 import { text_maker, TM, route_arg_to_year_map, planning_year } from "./utils";
 
+import "./TagExplorer.scss";
+
 import "src/explorer_common/explorer-styles.scss";
 
 class ExplorerContainer extends React.Component {

--- a/client/src/TagExplorer/TagExplorer.scss
+++ b/client/src/TagExplorer/TagExplorer.scss
@@ -1,0 +1,5 @@
+h1 {
+  margin-top: 20px;
+  margin-bottom: 20px;
+  border-bottom: 3px solid #da3a38;
+}

--- a/client/src/TreeMap/TreeMap.scss
+++ b/client/src/TreeMap/TreeMap.scss
@@ -260,3 +260,9 @@ $treeMapTooltipColor: $primaryColor;
     }
   }
 }
+
+h1 {
+  margin-top: 20px;
+  margin-bottom: 20px;
+  border-bottom: 3px solid #da3a38;
+}

--- a/client/src/extended_bootstrap_css/bootstrap-wet-fixes-extensions.scss
+++ b/client/src/extended_bootstrap_css/bootstrap-wet-fixes-extensions.scss
@@ -17,10 +17,6 @@ body {
   margin: 0;
 }
 
-h1 {
-  border-bottom: 3px solid $highlightColor;
-}
-
 hr {
   border-color: $separatorColor;
 }
@@ -190,11 +186,6 @@ div#app:focus {
 }
 
 /* fonts */
-
-h1 {
-  margin-top: 20px;
-  margin-bottom: 20px;
-}
 h2 {
   font-size: 140%;
   margin-top: 20px;

--- a/client/src/glossary/glossary.scss
+++ b/client/src/glossary/glossary.scss
@@ -1,5 +1,11 @@
 @import "src/common_css/common-variables";
 
+h1 {
+  margin-top: 20px;
+  margin-bottom: 20px;
+  border-bottom: 3px solid #da3a38;
+}
+
 dt.glossary-dt {
   font-size: 1.4em;
 

--- a/client/src/infographic/Infographic.scss
+++ b/client/src/infographic/Infographic.scss
@@ -81,5 +81,5 @@ of the advanced search for mobile */
 h1 {
   margin-top: 20px;
   margin-bottom: 20px;
-  border-bottom: 3px solid $highlightColor;
+  border-bottom: 3px solid #da3a38;
 }

--- a/client/src/infographic/Infographic.scss
+++ b/client/src/infographic/Infographic.scss
@@ -77,3 +77,9 @@ of the advanced search for mobile */
     overflow-x: visible;
   }
 }
+
+h1 {
+  margin-top: 20px;
+  margin-bottom: 20px;
+  border-bottom: 3px solid $highlightColor;
+}

--- a/client/src/metadata/metadata.js
+++ b/client/src/metadata/metadata.js
@@ -1,5 +1,6 @@
 import _ from "lodash";
 import React from "react";
+import "./metadata.scss";
 
 import {
   create_text_maker_component,

--- a/client/src/metadata/metadata.scss
+++ b/client/src/metadata/metadata.scss
@@ -1,0 +1,5 @@
+h1 {
+  margin-top: 20px;
+  margin-bottom: 20px;
+  border-bottom: 3px solid #da3a38;
+}

--- a/client/src/panels/panel_routes/IsolatedPanel.scss
+++ b/client/src/panels/panel_routes/IsolatedPanel.scss
@@ -1,0 +1,5 @@
+h1 {
+  margin-top: 20px;
+  margin-bottom: 20px;
+  border-bottom: 3px solid #da3a38;
+}

--- a/client/src/panels/panel_routes/PanelInventory.scss
+++ b/client/src/panels/panel_routes/PanelInventory.scss
@@ -1,0 +1,5 @@
+h1 {
+  margin-top: 20px;
+  margin-bottom: 20px;
+  border-bottom: 3px solid #da3a38;
+}

--- a/client/src/panels/panel_routes/SingleServiceRoute.scss
+++ b/client/src/panels/panel_routes/SingleServiceRoute.scss
@@ -1,0 +1,5 @@
+h1 {
+  margin-top: 20px;
+  margin-bottom: 20px;
+  border-bottom: 3px solid #da3a38;
+}

--- a/client/src/rpb/TablePicker.scss
+++ b/client/src/rpb/TablePicker.scss
@@ -132,3 +132,9 @@
   opacity: 0.01;
   transition: max-height 500ms ease-out, opacity 500ms ease-out;
 }
+
+h1 {
+  margin-top: 20px;
+  margin-bottom: 20px;
+  border-bottom: 3px solid #da3a38;
+}


### PR DESCRIPTION
Files where h1 tags are used:

- [x] EstimatesComparison
- [x] glossary
- [x] a11y_home (doesn't look affected by h1 change)
- [x] home (doesn't look affected by h1 change)
- [x] IgocExplorer
- [x] Infographic
- [x] metadata
- [x] IsolatedPanel
- [x] PanelInventory
- [x] SingleServiceRoute
- [x] index (not sure if this is affected by the h1 change)
- [x] TablePicker
- [x] Survey
- [x] TagExplorer
- [x] TreeMap
- [x] index.hbs.html (not sure if this is affected by the h1 change)