### PR TITLE
Moved copyable-hidden style to utils.scss

### DIFF
--- a/client/src/common_css/common_css_index.side-effects.js
+++ b/client/src/common_css/common_css_index.side-effects.js
@@ -1,1 +1,2 @@
 import "./site.scss";
+import "./utils.scss";

--- a/client/src/common_css/site.scss
+++ b/client/src/common_css/site.scss
@@ -142,11 +142,6 @@ strong,
   }
 }
 
-.copyable-hidden {
-  position: absolute;
-  left: -999em;
-}
-
 .text-only-page-root {
   h2,
   h3,

--- a/client/src/common_css/utils.scss
+++ b/client/src/common_css/utils.scss
@@ -1,0 +1,4 @@
+.copyable-hidden {
+  position: absolute;
+  left: -999em;
+}

--- a/client/src/panels/panel_declarations/results/result_flat_table.scss
+++ b/client/src/panels/panel_declarations/results/result_flat_table.scss
@@ -27,8 +27,3 @@
     width: 2%;
   }
 }
-
-.copyable-hidden {
-  position: absolute;
-  left: -999em;
-}

--- a/client/src/panels/panel_declarations/results/result_flat_table.scss
+++ b/client/src/panels/panel_declarations/results/result_flat_table.scss
@@ -27,3 +27,8 @@
     width: 2%;
   }
 }
+
+.copyable-hidden {
+  position: absolute;
+  left: -999em;
+}


### PR DESCRIPTION
https://github.com/TBS-EACPD/infobase/issues/1022
Only found this style within result_flat_table.js, so it makes sense to move it. However, I am not sure where this file is exactly on the GC Infobase website.