### PR TITLE
SortDirection converted from toggling to specific direction sorting

### DIFF
--- a/client/src/EstimatesComparison/scheme.js
+++ b/client/src/EstimatesComparison/scheme.js
@@ -501,12 +501,13 @@ export class EstimatesExplorer extends AbstractExplorerScheme {
       };
     }
     if (type === "column_header_click") {
-      const { is_descending, sort_col } = state;
-      const clicked_col = payload;
+      const { sort_col } = state;
+      const clicked_col = payload.col_key;
+      const direction = payload.direction;
       const mods =
         clicked_col === sort_col
-          ? { is_descending: !is_descending }
-          : { is_descending: true, sort_col: clicked_col };
+          ? { is_descending: direction === "DESC" }
+          : { is_descending: direction === "DESC", sort_col: clicked_col };
       return { ...state, ...mods };
     } else {
       return state;
@@ -527,8 +528,11 @@ export class EstimatesExplorer extends AbstractExplorerScheme {
 
   @bound
   map_dispatch_to_props(dispatch) {
-    const col_click = (col_key) =>
-      dispatch({ type: "column_header_click", payload: col_key });
+    const col_click = (col_key, direction) =>
+      dispatch({
+        type: "column_header_click",
+        payload: { col_key, direction },
+      });
     const toggle_stat_filter = () => dispatch({ type: "toggle_stat_filter" });
     const toggle_legal_titles = () => dispatch({ type: "toggle_legal_titles" });
 

--- a/client/src/TagExplorer/resource_scheme.js
+++ b/client/src/TagExplorer/resource_scheme.js
@@ -229,8 +229,11 @@ export class ResourceScheme extends AbstractExplorerScheme {
 
   @bound
   map_dispatch_to_props(dispatch) {
-    const col_click = (col_key) =>
-      dispatch({ type: "column_header_click", payload: col_key });
+    const col_click = (col_key, direction) =>
+      dispatch({
+        type: "column_header_click",
+        payload: { col_key, direction },
+      });
 
     return {
       ...super.map_dispatch_to_props(dispatch),
@@ -273,14 +276,13 @@ export class ResourceScheme extends AbstractExplorerScheme {
     } else if (type === "set_hierarchy_scheme") {
       return { ...state, hierarchy_scheme: payload };
     } else if (type === "column_header_click") {
-      const { is_descending, sort_col } = state;
-      const clicked_col = payload;
-
+      const { sort_col } = state;
+      const clicked_col = payload.col_key;
+      const direction = payload.direction;
       const mods =
         clicked_col === sort_col
-          ? { is_descending: !is_descending }
-          : { is_descending: true, sort_col: clicked_col };
-
+          ? { is_descending: direction === "DESC" }
+          : { is_descending: direction === "DESC", sort_col: clicked_col };
       return { ...state, ...mods };
     } else if (type === "set_year") {
       return { ...state, year: payload };

--- a/client/src/components/DisplayTable/DisplayTable.tsx
+++ b/client/src/components/DisplayTable/DisplayTable.tsx
@@ -156,6 +156,8 @@ export class _DisplayTable extends React.Component<
       current_page: 0,
       show_pagination_load_spinner: false,
     };
+
+    this.sortCol = this.sortCol.bind(this);
   }
   static getDerivedStateFromProps(
     nextProps: _DisplayTableProps,
@@ -225,6 +227,15 @@ export class _DisplayTable extends React.Component<
 
   componentWillUnmount() {
     this.debounced_stop_loading.cancel();
+  }
+
+  sortCol(column_key: string, dir: string) {
+    console.log("clicked");
+    this.setState({
+      sort_by: column_key,
+      descending: dir === "DESC",
+      current_page: 0,
+    });
   }
 
   render() {
@@ -513,21 +524,12 @@ export class _DisplayTable extends React.Component<
                   return (
                     <td key={column_key} style={{ textAlign: "center" }}>
                       {sortable && (
-                        <div
-                          onClick={() =>
-                            this.setState({
-                              sort_by: column_key,
-                              descending:
-                                this.state.sort_by === column_key
-                                  ? !this.state.descending
-                                  : true,
-                              current_page: 0,
-                            })
-                          }
-                        >
+                        <div>
                           <SortDirections
                             asc={!descending && sort_by === column_key}
                             desc={descending && sort_by === column_key}
+                            sortFunction={this.sortCol}
+                            col={column_key}
                           />
                         </div>
                       )}

--- a/client/src/components/SortDirection/SortDirection.tsx
+++ b/client/src/components/SortDirection/SortDirection.tsx
@@ -7,15 +7,21 @@ import "./SortDirection.scss";
 interface SortDirectionProps {
   sortDirection: string;
   active: boolean;
+  sortFunction: CallableFunction;
+  col: string;
 }
 interface SortDirectionsProps {
   asc: boolean;
   desc: boolean;
+  sortFunction: CallableFunction;
+  col: string;
 }
 
 export const SortDirection = ({
   sortDirection,
   active,
+  sortFunction,
+  col,
 }: SortDirectionProps) => (
   <button
     className="SortIndicator"
@@ -27,6 +33,7 @@ export const SortDirection = ({
       sortDirection === "ASC" ? "a11y_sort_asc" : "a11y_sort_desc"
     )}
     aria-pressed={active}
+    onClick={() => sortFunction(col, sortDirection)}
   >
     {active
       ? sortDirection === "ASC"
@@ -38,9 +45,24 @@ export const SortDirection = ({
   </button>
 );
 
-export const SortDirections = ({ asc, desc }: SortDirectionsProps) => (
+export const SortDirections = ({
+  asc,
+  desc,
+  sortFunction,
+  col,
+}: SortDirectionsProps) => (
   <div className="text-nowrap">
-    <SortDirection sortDirection="ASC" active={asc} />
-    <SortDirection sortDirection="DESC" active={desc} />
+    <SortDirection
+      sortDirection="ASC"
+      active={asc}
+      sortFunction={sortFunction}
+      col={col}
+    />
+    <SortDirection
+      sortDirection="DESC"
+      active={desc}
+      sortFunction={sortFunction}
+      col={col}
+    />
   </div>
 );

--- a/client/src/explorer_common/explorer_components.js
+++ b/client/src/explorer_common/explorer_components.js
@@ -47,15 +47,15 @@ export const ExplorerHeader = ({
                 ? { ...computed_col_styles[id], textAlign: "center" }
                 : computed_col_styles[id]
             }
-            onClick={() => col_click(id)}
             tabIndex={0}
-            role="button"
           >
             {header_display}
             {is_sortable && (
               <SortDirections
                 asc={!is_descending && sort_col === id}
                 desc={is_descending && sort_col === id}
+                sortFunction={col_click}
+                col={id}
               />
             )}
           </div>

--- a/client/src/panels/panel_declarations/misc/resource_structure/rooted_resource_scheme.js
+++ b/client/src/panels/panel_declarations/misc/resource_structure/rooted_resource_scheme.js
@@ -165,14 +165,13 @@ export class SingleTagResourceExplorer extends AbstractExplorerScheme {
   scheme_reducer = (state = {}, action) => {
     const { type, payload } = action;
     if (type === "column_header_click") {
-      const { is_descending, sort_col } = state;
-      const clicked_col = payload;
-
+      const { sort_col } = state;
+      const clicked_col = payload.col_key;
+      const direction = payload.direction;
       const mods =
         clicked_col === sort_col
-          ? { is_descending: !is_descending }
-          : { is_descending: true, sort_col: clicked_col };
-
+          ? { is_descending: direction === "DESC" }
+          : { is_descending: direction === "DESC", sort_col: clicked_col };
       return { ...state, ...mods };
     } else if (type === "set_year") {
       return { ...state, year: payload };
@@ -183,8 +182,11 @@ export class SingleTagResourceExplorer extends AbstractExplorerScheme {
 
   @bound
   map_dispatch_to_props(dispatch) {
-    const col_click = (col_key) =>
-      dispatch({ type: "column_header_click", payload: col_key });
+    const col_click = (col_key, direction) =>
+      dispatch({
+        type: "column_header_click",
+        payload: { col_key, direction },
+      });
     const set_year = (year) => dispatch({ type: "set_year", payload: year });
 
     return {


### PR DESCRIPTION
The arrows used to act like one toggling button, didn't matter which arrow you clicked, the sorting direction just toggled back and forth. Direction is now sorted per the arrow you click. Column header is no longer clickable but maybe we leave the header act as toggle? Will update the SortDirection stories to match new format.