### PR TITLE
ErrorBoundary catch unhandled promise rejections

### DIFF
--- a/client/src/core/ErrorBoundary.js
+++ b/client/src/core/ErrorBoundary.js
@@ -44,6 +44,7 @@ export class ErrorBoundary extends React.Component {
   }
 
   get_state_from_unhandled_rejection = (event) => {
+    event.preventDefault();
     this.setState(state_from_error(event.reason));
   };
   componentDidMount() {


### PR DESCRIPTION
Allows `ErrorBoundary` to see unhandled promsie rejections, which are expected to be (and treated the same as) errors. Previously, these wouldn't trigger the `ErrorBoundary`. Will need to do a fairly thorough pass on the site just to make sure there weren't any "quiet" unhandled promise rejections that were previously allowed. 

No IE 11 support for `unhandledrejection` (unless babel is polyfilling promises in our prod builds, haven't double checked but it probably isn't since IE 11 has promises already). With its ever decreasing browser share, I think t hat's fine.