### PR TITLE
Cypress error tracking

### DIFF
--- a/client/cypress/plugins/index.js
+++ b/client/cypress/plugins/index.js
@@ -15,5 +15,11 @@ module.exports = (on, config) => {
 
       return null;
     },
+    error(message) {
+      console.error("\x1b[31m", "ERROR:", message, "\x1b[0m");
+    },
+    warn(message) {
+      console.warn("\x1b[33m", "WARNING:", message, "\x1b[0m");
+    },
   });
 };

--- a/client/cypress/support/commands.js
+++ b/client/cypress/support/commands.js
@@ -17,3 +17,18 @@ Cypress.Commands.add("terminalLog", (violations) => {
 
   cy.task("table", violationData);
 });
+
+Cypress.on("window:before:load", (win) => {
+  cy.stub(win.console, "error", (msg) => {
+    if (msg.includes('No reducer provided for key "app"')) {
+      return null;
+    }
+
+    cy.now("task", "error", msg);
+    throw new Error(msg);
+  });
+
+  cy.stub(win.console, "warn", (msg) => {
+    cy.now("task", "warn", msg);
+  });
+});


### PR DESCRIPTION
Added functionality so that Cypress can track error logs on console and fail tests accordingly.