### PR TITLE
Search services

### DIFF
--- a/client/src/InfoBase/App.js
+++ b/client/src/InfoBase/App.js
@@ -194,7 +194,7 @@ export class App extends React.Component {
                 component={TagExplorer}
               />
               <Route
-                path="/dept/:subject_id/service-panels/:service_id?"
+                path="/dept/:subject_id/service/:service_id?"
                 component={SingleServiceRoute}
               />
               <Route

--- a/client/src/components/Typeahead/Typeahead.tsx
+++ b/client/src/components/Typeahead/Typeahead.tsx
@@ -75,12 +75,13 @@ export class Typeahead extends React.Component<TypeaheadProps, TypeaheadState> {
 
   constructor(props: TypeaheadProps) {
     super(props);
+    const { query_value, min_length } = props;
 
     this.menu_id = _.uniqueId("typeahead-");
 
     this.state = {
-      input_value: props.query_value,
-      may_show_menu: false,
+      input_value: query_value,
+      may_show_menu: query_value.length >= min_length,
       selection_cursor: default_selection_cursor,
     };
   }

--- a/client/src/core/injected_build_constants.ts
+++ b/client/src/core/injected_build_constants.ts
@@ -24,4 +24,4 @@ export const cdn_url = typeof CDN_URL !== "undefined" && CDN_URL;
 
 export const local_ip = is_dev && typeof LOCAL_IP !== "undefined" && LOCAL_IP;
 
-export const services_feature_flag = is_dev && false;
+export const services_feature_flag = is_dev && true;

--- a/client/src/infographic/Infographic.js
+++ b/client/src/infographic/Infographic.js
@@ -201,6 +201,7 @@ class InfoGraph_ extends React.Component {
             initial_search_options={{
               include_orgs_normal_data: true,
               include_orgs_limited_data: true,
+              include_services: true,
               include_crsos: true,
               include_programs: true,
               include_tags_goco: true,

--- a/client/src/link_utils.js
+++ b/client/src/link_utils.js
@@ -14,6 +14,9 @@ const glossary_href = (subject_or_id, first_character = "#") => {
     return `${first_character}glossary/${id}`;
   }
 };
+const service_href = (org_id, service_id) => {
+  return `/dept/${org_id}/service/${service_id}`;
+};
 
 const smart_href_template = (entity, first_character) => {
   if (entity.table && entity.table.constructor === Table) {
@@ -22,6 +25,8 @@ const smart_href_template = (entity, first_character) => {
     return glossary_href(entity, first_character);
   } else if (is_subject_instance(entity)) {
     return infograph_href_template(entity, null, first_character);
+  } else if (entity.__typename === "Service") {
+    return service_href(entity.org_id, entity.id);
   } else {
     throw new Error(
       `${entity} does not belong to a class with a known href template`

--- a/client/src/models/populate_services.js
+++ b/client/src/models/populate_services.js
@@ -291,7 +291,7 @@ export const useSingleService = (service_id) => {
     throw new Error(error);
   }
   if (!loading) {
-    return { ...res, data: data.root.service[0] };
+    return { ...res, data: data.root.service };
   }
   return res;
 };

--- a/client/src/models/populate_services.js
+++ b/client/src/models/populate_services.js
@@ -291,7 +291,7 @@ export const useSingleService = (service_id) => {
     throw new Error(error);
   }
   if (!loading) {
-    return { ...res, data: data.root.service };
+    return { ...res, data: data.root.service[0] };
   }
   return res;
 };

--- a/client/src/panels/panel_declarations/services/provided_services_list.js
+++ b/client/src/panels/panel_declarations/services/provided_services_list.js
@@ -73,7 +73,7 @@ const ProvidedServicesListPanel = ({ subject }) => {
             filtered_sorted_data,
             ({ name, id, org_id, service_type, description }) => (
               <React.Fragment key={id}>
-                <a href={`#dept/${org_id}/service-panels/${id}`}>{name}</a>
+                <a href={`#dept/${org_id}/service/${id}`}>{name}</a>
                 <p>{description}</p>
                 <div
                   style={{
@@ -99,7 +99,7 @@ const ProvidedServicesListPanel = ({ subject }) => {
                       </span>
                     ))}
                   </div>
-                  <a href={`#dept/${org_id}/service-panels/${id}`}>
+                  <a href={`#dept/${org_id}/service/${id}`}>
                     <button className="btn-ib-primary">
                       <TM k="view_service" />
                     </button>

--- a/client/src/panels/panel_declarations/services/single_service_panels/service_overview.js
+++ b/client/src/panels/panel_declarations/services/single_service_panels/service_overview.js
@@ -127,7 +127,7 @@ export class ServiceOverview extends React.Component {
           <dd>
             {_.map(all_urls, (urls, url_type) =>
               _.map(urls, (url, i) => (
-                <p key={url}>
+                <p key={_.uniqueId()}>
                   <a href={url} target="_blank" rel="noopener noreferrer">
                     {`${text_maker(url_type)} ${i + 1}`}
                   </a>

--- a/client/src/search/EverythingSearch.js
+++ b/client/src/search/EverythingSearch.js
@@ -23,6 +23,7 @@ import {
   who_we_help as who_we_help_search_config,
   datasets as table_search_config,
   glossary_lite as glossary_lite_search_config,
+  services as services_search_config,
 } from "./search_configs";
 import { SearchConfigTypeahead } from "./SearchConfigTypeahead";
 
@@ -61,6 +62,7 @@ const search_options_hierarchy = {
   other_options: {
     label: text_maker("other_options_label"),
     child_options: {
+      include_services: { label: text_maker("services") },
       include_glossary: { label: text_maker("glossary") },
       include_tables: { label: text_maker("metadata") },
     },
@@ -112,6 +114,10 @@ const EverythingSearch = withRouter(
         ...props.initial_search_options,
       };
     }
+    get_gql_search_configs = () => {
+      const { include_services } = this.state;
+      return _.compact([include_services && services_search_config]);
+    };
     get_search_configs = () => {
       const { reject_gov, reject_dead_orgs } = this.props;
 
@@ -177,6 +183,7 @@ const EverythingSearch = withRouter(
       return (
         <div className="col-12 col-lg-12 p-0">
           <SearchConfigTypeahead
+            gql_search_configs={this.get_gql_search_configs()}
             placeholder={placeholder}
             search_configs={this.get_search_configs()}
             utility_buttons={
@@ -284,6 +291,7 @@ EverythingSearch.defaultProps = {
     include_tags_hwh: true,
     include_tags_wwh: true,
 
+    include_services: true,
     include_glossary: false,
     include_tables: false,
   },

--- a/client/src/search/SearchConfigTypeahead.js
+++ b/client/src/search/SearchConfigTypeahead.js
@@ -40,7 +40,9 @@ const get_all_options = _.memoize((search_configs) =>
       })
   )
 );
-const get_gql_query = (gql_search_configs) => gql`
+const get_gql_query = (gql_search_configs) =>
+  gql_search_configs.length > 0 &&
+  gql`
   query($lang: String!) {
     root(lang: $lang) {
       ${_.reduce(
@@ -69,7 +71,10 @@ const get_config_groups = _.memoize((search_configs) =>
 
 const useSearchQuery = (gql_search_configs) => {
   const query = get_gql_query(gql_search_configs);
-  const res = useQuery(query, { variables: { lang } });
+  const res = useQuery(query, {
+    skip: gql_search_configs.length === 0,
+    variables: { lang },
+  });
   if (!res.loading) {
     const data = _.flatMap(
       gql_search_configs,
@@ -119,8 +124,6 @@ export const SearchConfigTypeahead = (props) => {
       const config_groups = get_config_groups(
         _.concat(search_configs, gql_search_configs)
       );
-      console.log(all_options);
-      console.log(config_groups);
 
       return _.chain(all_options)
         .filter(({ config_group_name, data }) =>

--- a/client/src/search/SearchConfigTypeahead.js
+++ b/client/src/search/SearchConfigTypeahead.js
@@ -40,9 +40,7 @@ const get_all_options = _.memoize((search_configs) =>
       })
   )
 );
-const get_gql_query = (gql_search_configs) =>
-  gql_search_configs.length > 0 &&
-  gql`
+const get_gql_query = (gql_search_configs) => gql`
   query($lang: String!) {
     root(lang: $lang) {
       ${_.reduce(
@@ -51,7 +49,7 @@ const get_gql_query = (gql_search_configs) =>
       ${query_result}
       ${query}
       `,
-        ``
+        `non_field`
       )}
     }
   }

--- a/client/src/search/SearchConfigTypeahead.js
+++ b/client/src/search/SearchConfigTypeahead.js
@@ -37,13 +37,10 @@ const get_config_groups = _.memoize((search_configs) =>
 export const SearchConfigTypeahead = (props) => {
   const { on_select, search_configs, gql_search_configs } = props;
   const [query_value, set_query_value] = useState("");
-  const { loading, data: gql_queried_data } = useSearchQuery(
+  const { data: gql_queried_data } = useSearchQuery(
     query_value,
     gql_search_configs
   );
-  if (loading) {
-    return <LeafSpinner config_name="inline_panel" />;
-  }
 
   const on_query = (query_value) => {
     log_standard_event({
@@ -58,10 +55,9 @@ export const SearchConfigTypeahead = (props) => {
   };
   const get_search_results = () => {
     if (query_value) {
-      const all_options = _.concat(
-        get_all_options(search_configs),
-        gql_queried_data
-      );
+      const all_options = gql_queried_data
+        ? _.concat(get_all_options(search_configs), gql_queried_data)
+        : get_all_options(search_configs);
       const config_groups = get_config_groups(
         _.concat(search_configs, gql_search_configs)
       );

--- a/client/src/search/SearchConfigTypeahead.js
+++ b/client/src/search/SearchConfigTypeahead.js
@@ -1,60 +1,132 @@
+import { gql, useQuery } from "@apollo/client";
 import _ from "lodash";
-import React from "react";
+import React, { useState } from "react";
 
-import { Typeahead } from "src/components/index";
+import { Typeahead, LeafSpinner } from "src/components/index";
 
 import { log_standard_event } from "src/core/analytics";
+import { lang } from "src/core/injected_build_constants";
 
 import { InfoBaseHighlighter } from "src/search/search_utils";
 
-export class SearchConfigTypeahead extends React.Component {
-  constructor(props) {
-    super(props);
+const format_data = (
+  name_function,
+  menu_content_function,
+  data,
+  config_group_name
+) => ({
+  data,
+  name: name_function(data),
+  menu_content: (search) =>
+    _.isFunction(menu_content_function) ? (
+      menu_content_function(data, search, name_function)
+    ) : (
+      <InfoBaseHighlighter search={search} content={name_function(data)} />
+    ),
+  config_group_name,
+});
 
-    this.state = {
-      query_value: "",
-    };
+const get_all_options = _.memoize((search_configs) =>
+  _.flatMap(
+    search_configs,
+    ({ get_data, name_function, menu_content_function, config_name }) =>
+      _.map(get_data(), (data) => {
+        return format_data(
+          name_function,
+          menu_content_function,
+          data,
+          config_name
+        );
+      })
+  )
+);
+const get_gql_query = (gql_search_configs) => gql`
+  query($lang: String!) {
+    root(lang: $lang) {
+      ${_.reduce(
+        gql_search_configs,
+        (query_result, { query }) => `
+      ${query_result}
+      ${query}
+      `,
+        ``
+      )}
+    }
+  }
+`;
+const get_config_groups = _.memoize((search_configs) =>
+  _.chain(search_configs)
+    .map(({ header_function, filter, config_name }, ix) => [
+      config_name,
+      {
+        group_header: header_function(),
+        group_filter: filter,
+      },
+    ])
+    .fromPairs()
+    .value()
+);
+
+const useSearchQuery = (gql_search_configs) => {
+  const query = get_gql_query(gql_search_configs);
+  const res = useQuery(query, { variables: { lang } });
+  if (!res.loading) {
+    const data = _.flatMap(
+      gql_search_configs,
+      ({
+        queried_data_accessor,
+        name_function,
+        menu_content_function,
+        config_name,
+      }) => {
+        return _.map(res.data.root[queried_data_accessor], (row) =>
+          format_data(name_function, menu_content_function, row, config_name)
+        );
+      }
+    );
+
+    return { ...res, data };
+  }
+  return res;
+};
+
+export const SearchConfigTypeahead = (props) => {
+  const { on_select, search_configs, gql_search_configs } = props;
+  const [query_value, set_query_value] = useState("");
+  const { loading, data: gql_queried_data } =
+    useSearchQuery(gql_search_configs);
+  if (loading) {
+    return <LeafSpinner config_name="inline_panel" />;
   }
 
-  on_query = (query_value) => {
+  const on_query = (query_value) => {
     log_standard_event({
       SUBAPP: window.location.hash.replace("#", ""),
       MISC1: `TYPEAHEAD_SEARCH_QUERY`,
       MISC2: `query: ${query_value}, search_configs: ${_.map(
-        this.props.search_configs,
+        props.search_configs,
         "config_name"
       )}`,
     });
-
-    this.setState({ query_value });
+    set_query_value(query_value);
   };
-
-  render() {
-    const { query_value } = this.state;
-
-    return (
-      <Typeahead
-        {...this.props}
-        on_query={this.on_query}
-        query_value={query_value}
-        results={this.results}
-      />
-    );
-  }
-
-  get results() {
-    const { on_select, search_configs } = this.props;
-    const { query_value } = this.state;
-
+  const get_search_results = () => {
     if (query_value) {
-      const all_options = this.get_all_options(search_configs);
-      const config_groups = this.get_config_groups(search_configs);
+      const all_options = _.concat(
+        get_all_options(search_configs),
+        gql_queried_data
+      );
+      const config_groups = get_config_groups(
+        _.concat(search_configs, gql_search_configs)
+      );
+      console.log(all_options);
+      console.log(config_groups);
 
       return _.chain(all_options)
-        .filter(({ config_group_index, data }) =>
-          config_groups[config_group_index].group_filter(query_value, data)
+        .filter(({ config_group_name, data }) =>
+          config_groups[config_group_name].group_filter(query_value, data)
         )
-        .groupBy("config_group_index")
+        .groupBy("config_group_name")
         .flatMap((results, group_index) =>
           _.map(results, (result, index) => ({
             is_first_in_group: index === 0,
@@ -74,10 +146,7 @@ export class SearchConfigTypeahead extends React.Component {
             if (_.isFunction(on_select)) {
               on_select(result.data);
             }
-
-            this.setState({
-              query_value: "",
-            });
+            set_query_value("");
           },
           content: result.menu_content(query_value),
           plain_text: result.name,
@@ -87,29 +156,14 @@ export class SearchConfigTypeahead extends React.Component {
     } else {
       return [];
     }
-  }
-  get_all_options = _.memoize((search_configs) =>
-    _.flatMap(search_configs, (search_config, ix) =>
-      _.map(search_config.get_data(), (data) => ({
-        data,
-        name: search_config.name_function(data),
-        menu_content: (search) =>
-          _.isFunction(search_config.menu_content_function) ? (
-            search_config.menu_content_function(data, search)
-          ) : (
-            <InfoBaseHighlighter
-              search={search}
-              content={search_config.name_function(data)}
-            />
-          ),
-        config_group_index: ix,
-      }))
-    )
+  };
+
+  return (
+    <Typeahead
+      {...props}
+      on_query={on_query}
+      query_value={query_value}
+      results={get_search_results()}
+    />
   );
-  get_config_groups = _.memoize((search_configs) =>
-    _.map(search_configs, (search_config, ix) => ({
-      group_header: search_config.header_function(),
-      group_filter: search_config.filter,
-    }))
-  );
-}
+};

--- a/client/src/search/search_configs.js
+++ b/client/src/search/search_configs.js
@@ -67,13 +67,10 @@ const LimitedDataDisplay = (search, name) => (
 const org_templates = {
   header_function: () => trivial_text_maker("orgs"),
   name_function: (org) => org.name,
-  menu_content_function: function (org, search) {
+  menu_content_function: function (org, search, name_function) {
     if (org.subject_type === "gov") {
       return (
-        <InfoBaseHighlighter
-          search={search}
-          content={this.name_function(org)}
-        />
+        <InfoBaseHighlighter search={search} content={name_function(org)} />
       );
     }
 
@@ -298,8 +295,8 @@ const programs = {
       ["name", "old_name", "activity_code"],
       "programs"
     )(datum),
-  menu_content_function: function (program, search) {
-    const name = this.name_function(program);
+  menu_content_function: function (program, search, name_function) {
+    const name = name_function(program);
 
     if (program.old_name) {
       const reg_exps = query_to_reg_exps(search);
@@ -347,6 +344,21 @@ const crsos = {
   filter: (query, datum) =>
     memoized_re_matchers(query, ["name", "activity_code"], "crsos")(datum),
 };
+const services = {
+  config_name: "services",
+  header_function: () => trivial_text_maker("services"),
+  name_function: (service) => service.name,
+  query: `
+    service {
+      id
+      org_id
+      name
+    }
+  `,
+  queried_data_accessor: "service",
+  filter: (query, datum) =>
+    memoized_re_matchers(query, ["name"], "services")(datum),
+};
 
 export {
   highlight_search_match,
@@ -360,4 +372,5 @@ export {
   datasets,
   glossary,
   glossary_lite,
+  services,
 };

--- a/client/src/search/search_configs.js
+++ b/client/src/search/search_configs.js
@@ -348,14 +348,14 @@ const services = {
   config_name: "services",
   header_function: () => trivial_text_maker("services"),
   name_function: (service) => service.name,
-  query: `
-    service {
+  query: (query_value) => `
+    search_services(name_query: "${query_value}") {
       id
       org_id
       name
     }
   `,
-  queried_data_accessor: "service",
+  queried_data_accessor: "search_services",
   filter: (query, datum) =>
     memoized_re_matchers(query, ["name"], "services")(datum),
 };

--- a/client/src/search/search_configs.js
+++ b/client/src/search/search_configs.js
@@ -347,7 +347,8 @@ const crsos = {
 const services = {
   config_name: "services",
   header_function: () => trivial_text_maker("services"),
-  name_function: (service) => service.name,
+  name_function: (service) =>
+    `${service.name} - ${Dept.lookup(service.org_id).name}`,
   query: (query_value) => `
     search_services(name_query: "${query_value}") {
       id

--- a/client/src/search/search_configs.js
+++ b/client/src/search/search_configs.js
@@ -348,7 +348,7 @@ const services = {
   config_name: "services",
   header_function: () => trivial_text_maker("services"),
   name_function: (service) =>
-    `${service.name} - ${Dept.lookup(service.org_id).name}`,
+    `${service.name} - ${Dept.store.lookup(service.org_id).name}`,
   query: (query_value) => `
     search_services(name_query: "${query_value}") {
       id

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -19,7 +19,7 @@
         "lodash": "^4.17.21",
         "lz-string": "^1.4.4",
         "md5": "^2.2.1",
-        "mongoose": "^5.10.12"
+        "mongoose": "^5.13.9"
       },
       "devDependencies": {
         "@babel/cli": "^7.8.4",

--- a/server/package.json
+++ b/server/package.json
@@ -19,7 +19,7 @@
     "lodash": "^4.17.21",
     "lz-string": "^1.4.4",
     "md5": "^2.2.1",
-    "mongoose": "^5.10.12"
+    "mongoose": "^5.13.9"
   },
   "devDependencies": {
     "@babel/cli": "^7.8.4",

--- a/server/src/models/services/models.js
+++ b/server/src/models/services/models.js
@@ -91,6 +91,7 @@ export default function (model_singleton) {
     standards: [ServiceStandardSchema],
     service_report: [ServiceReportSchema],
   });
+  ServiceSchema.index({ name_en: "text", name_fr: "text" });
 
   const ServiceGeneralStatsSchema = mongoose.Schema({
     id: pkey_type(),

--- a/server/src/models/services/schema.js
+++ b/server/src/models/services/schema.js
@@ -4,7 +4,7 @@ import { bilingual_field } from "../schema_utils.js";
 
 const schema = `
   extend type Root{
-    services(id: String): [Service]
+    service(id: String!): Service
     search_services(name_query: String): [Service]
   }
   extend type Gov{
@@ -168,7 +168,7 @@ export default function ({ models, loaders }) {
 
   const resolvers = {
     Root: {
-      services: async (_x, { id }) => await Service.find(id ? { id } : {}), //SI_TODO need to find a way to "load all" for service loader
+      service: (_x, { id }) => service_loader.load(id),
       search_services: async (_x, { name_query }) =>
         await Service.find({
           $text: { $search: `"${name_query}"` }, // Double quotes for exact phrase

--- a/server/src/models/services/schema.js
+++ b/server/src/models/services/schema.js
@@ -4,7 +4,8 @@ import { bilingual_field } from "../schema_utils.js";
 
 const schema = `
   extend type Root{
-    service(id: String): [Service]
+    services(id: String): [Service]
+    search_services(name_query: String): [Service]
   }
   extend type Gov{
     service_summary: ServiceSummary
@@ -167,7 +168,11 @@ export default function ({ models, loaders }) {
 
   const resolvers = {
     Root: {
-      service: async (_x, { id }) => await Service.find(id ? { id } : {}), //SI_TODO need to find a way to "load all" for service loader
+      services: async (_x, { id }) => await Service.find(id ? { id } : {}), //SI_TODO need to find a way to "load all" for service loader
+      search_services: async (_x, { name_query }) =>
+        await Service.find({
+          $text: { $search: `"${name_query}"` }, // Double quotes for exact phrase
+        }),
     },
     Gov: {
       service_summary: () => gov_service_summary_loader.load("gov"),

--- a/server/src/models/services/schema.js
+++ b/server/src/models/services/schema.js
@@ -4,7 +4,7 @@ import { bilingual_field } from "../schema_utils.js";
 
 const schema = `
   extend type Root{
-    service(id: String!): Service
+    service(id: String): [Service]
   }
   extend type Gov{
     service_summary: ServiceSummary
@@ -167,7 +167,7 @@ export default function ({ models, loaders }) {
 
   const resolvers = {
     Root: {
-      service: (_x, { id }) => service_loader.load(id),
+      service: async (_x, { id }) => await Service.find(id ? { id } : {}), //SI_TODO need to find a way to "load all" for service loader
     },
     Gov: {
       service_summary: () => gov_service_summary_loader.load("gov"),


### PR DESCRIPTION
TODO:
- [x] Typeahead "refreshing" when data loads
- [ ] Disable stemming ([here](https://docs.mongodb.com/manual/reference/operator/query/text/#stemmed-words) and [here](https://docs.mongodb.com/manual/core/index-text/))
  - I've tried ```  ServiceSchema.index(
    { name_en: "text", name_fr: "text" },
    { default_language: "none", language: "none", language_override: "none" }
  );```
  - `name_en: { ...str_type, index: true, language: "none" },
    name_fr: { ...str_type, index: true, language: "none" },`
  -  `Service.find({
          $text: { $search: `"${name_query}"`, $language: "none" },
        }),`
  - For e.g.: Try searching `agr` (No services), then `agri` (search properly). Also `publi` (no services), then `public` (search properly)
- I've tried using simple `.find({name: input_value})` but I can't get it to search as "contains" (I've tried regex). Case insensitivity and diacritics insensitivity should be do-able with [collation](https://docs.mongodb.com/manual/reference/collation/) but I haven't tried it with that yet