### PR TITLE
Wrap the GQL client's fetch in retry_promise

### DIFF
--- a/client/src/InfoBase/common_app_component_utils.js
+++ b/client/src/InfoBase/common_app_component_utils.js
@@ -4,7 +4,7 @@ import React from "react";
 import { log_standard_event } from "src/core/analytics";
 import { cdn_url, is_dev } from "src/core/injected_build_constants";
 
-import { retry_promise } from "src/general_utils";
+import { retrying_promise } from "src/general_utils";
 
 // Link tags for stylesheets should all have non null sheet properties
 const linked_stylesheets_loaded = () => {
@@ -42,6 +42,6 @@ const ensure_linked_stylesheets_load = () => {
 };
 
 const retrying_react_lazy = (import_promise) =>
-  React.lazy(() => retry_promise(import_promise));
+  React.lazy(() => retrying_promise(import_promise));
 
 export { ensure_linked_stylesheets_load, retrying_react_lazy };

--- a/client/src/general_utils.ts
+++ b/client/src/general_utils.ts
@@ -107,7 +107,7 @@ export const shallowEqualObjectsExceptKeys = <Type, Key extends keyof Type>(
 };
 
 export const retrying_promise = <T>(
-  promise_to_try: () => Promise<T>,
+  promise_to_try: (retry_count: number) => Promise<T>,
   options = {
     retries: 3,
     min_interval: 100,
@@ -127,7 +127,7 @@ export const retrying_promise = <T>(
     const jitter = interval * _.random(-jitter_magnitude, jitter_magnitude);
 
     return new Promise((resolve, reject) => {
-      promise_to_try()
+      promise_to_try(retry_count)
         .then(resolve)
         .catch((error: Error) =>
           setTimeout(() => {

--- a/client/src/general_utils.ts
+++ b/client/src/general_utils.ts
@@ -108,14 +108,19 @@ export const shallowEqualObjectsExceptKeys = <Type, Key extends keyof Type>(
 
 export const retrying_promise = <T>(
   promise_to_try: (retry_count: number) => Promise<T>,
-  options = {
-    retries: 3,
-    min_interval: 100,
-    max_interval: 500,
-    jitter_magnitude: 0.2,
-  }
+  options: {
+    retries?: number;
+    min_interval?: number;
+    max_interval?: number;
+    jitter_magnitude?: number;
+  } = {}
 ): Promise<T> => {
-  const { retries, min_interval, max_interval, jitter_magnitude } = options;
+  const {
+    retries = 3,
+    min_interval = 100,
+    max_interval = 500,
+    jitter_magnitude = 0.2,
+  } = options;
 
   const retry_promise = (retry_count = 0): Promise<T> => {
     const remaining_retries = retries - retry_count;

--- a/client/src/graphql_utils/graphql_utils.js
+++ b/client/src/graphql_utils/graphql_utils.js
@@ -1,6 +1,5 @@
 import { InMemoryCache, ApolloClient, useQuery } from "@apollo/client";
 import { BatchHttpLink } from "@apollo/client/link/batch-http/index";
-
 import _ from "lodash";
 import { useState } from "react";
 
@@ -14,6 +13,8 @@ import {
   is_dev,
   is_ci,
 } from "src/core/injected_build_constants";
+
+import { retry_promise } from "src/general_utils";
 
 const prod_api_url = `https://us-central1-ib-serverless-api-prod.cloudfunctions.net/prod-api-${sha}/graphql`;
 
@@ -66,7 +67,9 @@ const query_as_get_with_query_header = async (uri, options) => {
     },
   };
 
-  return fetch(uriWithVersionAndQueryHash, new_options).catch((error) => {
+  return retry_promise(() =>
+    fetch(uriWithVersionAndQueryHash, new_options)
+  ).catch((error) => {
     log_standard_event({
       SUBAPP: window.location.hash.replace("#", ""),
       MISC1: "API_CONNECTION_ERROR",

--- a/client/src/graphql_utils/graphql_utils.js
+++ b/client/src/graphql_utils/graphql_utils.js
@@ -1,7 +1,6 @@
 import { InMemoryCache, ApolloClient, useQuery } from "@apollo/client";
 import { BatchHttpLink } from "@apollo/client/link/batch-http/index";
 import _ from "lodash";
-import { useState } from "react";
 
 import string_hash from "string-hash";
 

--- a/client/src/graphql_utils/graphql_utils.js
+++ b/client/src/graphql_utils/graphql_utils.js
@@ -14,7 +14,7 @@ import {
   is_ci,
 } from "src/core/injected_build_constants";
 
-import { retry_promise } from "src/general_utils";
+import { retrying_promise } from "src/general_utils";
 
 const prod_api_url = `https://us-central1-ib-serverless-api-prod.cloudfunctions.net/prod-api-${sha}/graphql`;
 
@@ -67,7 +67,7 @@ const query_as_get_with_query_header = async (uri, options) => {
     },
   };
 
-  return retry_promise(() =>
+  return retrying_promise(() =>
     fetch(uriWithVersionAndQueryHash, new_options)
   ).catch((error) => {
     log_standard_event({


### PR DESCRIPTION
TODO:
  - [x] add `retry_promise` to the `fetch` used by the GQL client
  - [x]  `retry_promise` could use a few more features
    - [x] some growth factor on the intervals (probably exponential)
    - [x] maybe an option for an upper limit on the delay, to reign in the growth factor  
    - [x] random jitter on each timeout (... well, `setTimeout` naturally has some uncertain delay while the event loop works around to its callback, but some option to control an additional amount is easy enough)
  - [x] consider the impact on client logging. As is, the total request time will include the retries, but the logging won't know if, or how many, retries occurred. Maybe that's fine, or maybe that will throw off future usage of the analytics, hmm
    - shuffled things around, managed to get retry count info in to the logging

In September, 48 API queries errored (of 32773). 26 of those were failures to even connect to the server, a handful occurred after the initial preflights, and a few were actually in the processing of the received data (TODO: look in to those more). Small portion, but every one of them is unhandled and results in an error page for a user. Currently our highest source of them by far.

These aren't new! The trend goes back further, monthly API error counts on this order of magnitude have been long standing. What's new (as of mid August) is that unhandled error rejections actually hit the error boundary (overdue on that, oops). Before these probably resulted in endless spinners for users, now they result in the full error page. They also now end up in the primary error report, instead of only showing up in the specialized API error reports, which is admittedly the only reason I'm not noticing them.

Anyway, not enough information to positively diagnose the cause(s), and unlikely to be able to remedy them ourselves (e.g. if they're environmental on the user's end or across the network). Best I can tell, it's not 100% of requests failing for the impacted users. For now, letting the requests retry will hopefully knock out a lot of those error-screen producing cases.