### PR TITLE
Split cypress CI jobs in half

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -217,7 +217,7 @@ jobs:
 
       - run: (cd server && npm run snapshot_tests)
 
-  test_end_to_end:
+  cypress_tests:
     docker:
       - image: eaadtbs/ib-ci-cypress:4.0
         <<: *dockerhub_auth
@@ -225,10 +225,10 @@ jobs:
     environment:
       CYPRESS_CACHE_FOLDER: "~/InfoBase/client/.cache/Cypress"
     parameters:
-      TEST_BATCH_COUNT:
+      batch-count:
         type: integer
         default: 1
-      TEST_BATCH_INDEX:
+      batch-index:
         type: integer
         default: 0
     steps:
@@ -255,7 +255,7 @@ jobs:
           command: (cd client && npm run ci_serve)
           background: true
 
-      - run: (cd client && npm run cypress:run -- -e BATCH_COUNT=$TEST_BATCH_COUNT,BATCH_INDEX=$TEST_BATCH_INDEX)
+      - run: (cd client && npm run cypress:run -- -e BATCH_COUNT=<< parameters.batch-count >>,BATCH_INDEX=<< parameters.batch-index >>)
 
       - run: circleci step halt # held open at this point by the running server, force halt (returns successful)
 
@@ -371,22 +371,23 @@ workflows:
   build_test_deploy:
     jobs:
       - build
+
       - test_server:
           requires:
             - build
 
-      - test_end_to_end:
-          name: test_end_to_end--batch_1
-          TEST_BATCH_COUNT: 2
-          TEST_BATCH_INDEX: 0
+      - cypress_tests:
           requires:
             - test_server
-      - test_end_to_end:
-          name: test_end_to_end--batch_2
-          TEST_BATCH_COUNT: 2
-          TEST_BATCH_INDEX: 1
+          matrix:
+            parameters:
+              batch-count: [2]
+              batch-index: [0, 1]
+
+      - build_storybook:
           requires:
             - test_server
+          <<: *deploy_filter
 
       - deploy_data:
           requires:
@@ -396,16 +397,10 @@ workflows:
           requires:
             - deploy_data
           <<: *deploy_filter
-      - build_storybook:
-          # building and deploying storybook, conceptually, should be it's own job branch but, for now,
-          # sticking it here to balance time/container use efficiency against long running test_end_to_end job
-          requires:
-            - deploy_server
-          <<: *deploy_filter
 
       - deploy_client_and_storybook:
           requires:
+            - cypress_tests
             - build_storybook
-            - test_end_to_end--batch_1
-            - test_end_to_end--batch_2
+            - deploy_server
           <<: *deploy_filter

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -224,6 +224,13 @@ jobs:
     working_directory: "~/InfoBase"
     environment:
       CYPRESS_CACHE_FOLDER: "~/InfoBase/client/.cache/Cypress"
+    parameters:
+      TEST_BATCH_COUNT:
+        type: integer
+        default: 1
+      TEST_BATCH_INDEX:
+        type: integer
+        default: 0
     steps:
       - attach_workspace:
           at: ./
@@ -248,7 +255,7 @@ jobs:
           command: (cd client && npm run ci_serve)
           background: true
 
-      - run: (cd client && npm run cypress:run)
+      - run: (cd client && npm run cypress:run -- -e BATCH_COUNT=$TEST_BATCH_COUNT,BATCH_INDEX=$TEST_BATCH_INDEX)
 
       - run: circleci step halt # held open at this point by the running server, force halt (returns successful)
 
@@ -369,6 +376,13 @@ workflows:
             - build
 
       - test_end_to_end:
+          TEST_BATCH_COUNT: 2
+          TEST_BATCH_INDEX: 0
+          requires:
+            - test_server
+      - test_end_to_end:
+          TEST_BATCH_COUNT: 2
+          TEST_BATCH_INDEX: 1
           requires:
             - test_server
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -372,6 +372,11 @@ workflows:
     jobs:
       - build
 
+      - build_storybook:
+          requires:
+            - build
+          <<: *deploy_filter
+
       - test_server:
           requires:
             - build
@@ -384,11 +389,6 @@ workflows:
               batch-count: [2]
               batch-index: [0, 1]
 
-      - build_storybook:
-          requires:
-            - test_server
-          <<: *deploy_filter
-
       - deploy_data:
           requires:
             - test_server
@@ -400,7 +400,7 @@ workflows:
 
       - deploy_client_and_storybook:
           requires:
-            - cypress_tests
             - build_storybook
+            - cypress_tests
             - deploy_server
           <<: *deploy_filter

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,8 @@ archive_filter: &archive_filter
         - /__.*/
         - /archived__.*/
 
-version: 2
+version: 2.1
+
 jobs:
   test_form_backend:
     docker:
@@ -358,7 +359,6 @@ jobs:
       - run: if [[ $CIRCLE_BRANCH = master ]]; then ./scripts/ci_scripts/store_bundle_stats.sh; fi
 
 workflows:
-  version: 2
   test_form_backend:
     jobs:
       - test_form_backend

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -376,11 +376,13 @@ workflows:
             - build
 
       - test_end_to_end:
+          name: test_end_to_end--batch_1
           TEST_BATCH_COUNT: 2
           TEST_BATCH_INDEX: 0
           requires:
             - test_server
       - test_end_to_end:
+          name: test_end_to_end--batch_2
           TEST_BATCH_COUNT: 2
           TEST_BATCH_INDEX: 1
           requires:
@@ -404,5 +406,6 @@ workflows:
       - deploy_client_and_storybook:
           requires:
             - build_storybook
-            - test_end_to_end
+            - test_end_to_end--batch_1
+            - test_end_to_end--batch_2
           <<: *deploy_filter

--- a/client/cypress/integration/InfoBase/route_tests.spec.js
+++ b/client/cypress/integration/InfoBase/route_tests.spec.js
@@ -288,13 +288,13 @@ const run_tests_from_config = ({
   });
 
 describe("Route tests", () => {
-  const { BATCH_COUNT, BATCH_INDEX } = Cypress.env;
+  const { BATCH_COUNT, BATCH_INDEX } = Cypress.env();
 
   const batching = BATCH_COUNT || BATCH_INDEX;
 
   if (batching && (!_.isInteger(BATCH_COUNT) || !_.isInteger(BATCH_INDEX))) {
     throw new Error(
-      "When batching route load tests, set cypess env vars with integer values for both BATCH_COUNT and BATCH_INDEX." +
+      "When batching route load tests, set cypess env vars with integer values for both BATCH_COUNT and BATCH_INDEX. " +
         `Provided values were "${BATCH_COUNT}" and "${BATCH_INDEX}" respectively.`
     );
   }
@@ -304,7 +304,10 @@ describe("Route tests", () => {
       return route_load_tests_config;
     } else {
       // TODO would prefer to chunk by route x test_on.length, this is just the simple version to test the basic idea
-      return _.chunk(route_load_tests_config, BATCH_COUNT)[BATCH_INDEX];
+      return _.chunk(
+        route_load_tests_config,
+        _.ceil(route_load_tests_config.length / BATCH_COUNT)
+      )[BATCH_INDEX];
     }
   })();
 

--- a/client/cypress/integration/InfoBase/route_tests.spec.js
+++ b/client/cypress/integration/InfoBase/route_tests.spec.js
@@ -308,7 +308,12 @@ describe("Route tests", () => {
           test_config,
           ..._.fill(Array(test_config.test_on.length - 1), false),
         ])
-        .chunk(_.ceil(route_load_tests_config.length / BATCH_COUNT))
+        .thru((padded_test_configs) =>
+          _.chunk(
+            padded_test_configs,
+            _.ceil(padded_test_configs.length / BATCH_COUNT)
+          )
+        )
         .map(_.compact)
         .nth(BATCH_INDEX)
         .value();

--- a/client/cypress/integration/InfoBase/route_tests.spec.js
+++ b/client/cypress/integration/InfoBase/route_tests.spec.js
@@ -303,11 +303,15 @@ describe("Route tests", () => {
     if (!batching) {
       return route_load_tests_config;
     } else {
-      // TODO would prefer to chunk by route x test_on.length, this is just the simple version to test the basic idea
-      return _.chunk(
-        route_load_tests_config,
-        _.ceil(route_load_tests_config.length / BATCH_COUNT)
-      )[BATCH_INDEX];
+      return _.chain(route_load_tests_config)
+        .flatMap((test_config) => [
+          test_config,
+          ..._.fill(Array(test_config.test_on.length - 1), false),
+        ])
+        .chunk(_.ceil(route_load_tests_config.length / BATCH_COUNT))
+        .map(_.compact)
+        .nth(BATCH_INDEX)
+        .value();
     }
   })();
 


### PR DESCRIPTION
Not using cypress' parallelization "support", since it
  1) requires per-test config files, which we don't do for the route load tests
  2) requires you to use (and potentially pay for) their dashboard service. Not something we need or care about right now

Just a small tweak to `route_tests.spec.js` and the CI config to allow batching our route load tests configs. The outputs aren't reconciled, so you could potentially need to look in two places to find all route load errors after your CI job fails. Probably not worth the complexity to try and do more than this though, and it's a good 2-3 minute CI optimization!

After this merges, open an issue to look in to these libraries
  - https://github.com/Shelex/cypress-parallel-specs-locally lightweight, just some scripts to make it easy to manage running multiple cypress processes in parallel locally (i.e. within the same container). Would need to be mindful of memory usage, haven't been logging that on the cypress jobs
  - https://github.com/sorry-cypress/sorry-cypress heavier, more focused on fully replacing the cypress dashboard service (including it's parallel test orchestration component). Since we don't really need or want the first party dashboards anyway, not too likely we want to set this up either right now

If we start writing more robust per-route cypress tests (probably should eventually, and gradually replace the route load tests with them), might need to change the approach up. This is a specific solution based on how we do the route load test configs.
  