### PR TITLE
Cypress error tracking cleanup

### DIFF
--- a/client/cypress/support/commands.js
+++ b/client/cypress/support/commands.js
@@ -17,18 +17,3 @@ Cypress.Commands.add("terminalLog", (violations) => {
 
   cy.task("table", violationData);
 });
-
-Cypress.on("window:before:load", (win) => {
-  cy.stub(win.console, "error", (msg) => {
-    if (msg.includes('No reducer provided for key "app"')) {
-      return null;
-    }
-
-    cy.now("task", "error", msg);
-    throw new Error(msg);
-  });
-
-  cy.stub(win.console, "warn", (msg) => {
-    cy.now("task", "warn", msg);
-  });
-});


### PR DESCRIPTION
Removed a bandaid fix for cypress's error tracking. There was a specific case earlier on that was causing the Error Boundary route to throw a console error which doesn't fail cypress tests by default. This is no longer the case and the extra tweaks to cypress were sometimes cluttering actual errors.