### PR TITLE
Server side service searching

### DIFF
--- a/client/src/core/injected_build_constants.ts
+++ b/client/src/core/injected_build_constants.ts
@@ -24,4 +24,4 @@ export const cdn_url = typeof CDN_URL !== "undefined" && CDN_URL;
 
 export const local_ip = is_dev && typeof LOCAL_IP !== "undefined" && LOCAL_IP;
 
-export const services_feature_flag = is_dev && false;
+export const services_feature_flag = is_dev && true;

--- a/client/src/models/populate_services.js
+++ b/client/src/models/populate_services.js
@@ -361,9 +361,9 @@ export const useServices = (query_options) => {
 export const { query_search_services, useSearchServices } = query_factory({
   query_name: "search_services",
   query: gql`
-    query($lang: String! = "${lang}", $name_regex: String!) {
+    query($lang: String! = "${lang}", $search_phrase: String!) {
       root(lang: $lang) {
-        search_services(name_regex: $name_regex) {
+        search_services(search_phrase: $search_phrase) {
           id
           org_id
           name

--- a/client/src/models/populate_services.js
+++ b/client/src/models/populate_services.js
@@ -361,9 +361,9 @@ export const useServices = (query_options) => {
 export const { query_search_services, useSearchServices } = query_factory({
   query_name: "search_services",
   query: gql`
-    query($lang: String! = "${lang}", $query: String!) {
+    query($lang: String! = "${lang}", $name_regex: String!) {
       root(lang: $lang) {
-        search_services(name_query: $query) {
+        search_services(name_regex: $name_regex) {
           id
           org_id
           name

--- a/client/src/search/search_configs.js
+++ b/client/src/search/search_configs.js
@@ -12,13 +12,13 @@ import { Table } from "src/core/TableClass";
 import { textColor } from "src/style_constants/index";
 
 import {
-  phrase_to_word_regex,
+  search_phrase_to_all_words_regex,
   highlight_search_match,
   SearchHighlighter,
 } from "./search_utils";
 
 const get_re_matcher = (accessors, query) => (obj) => {
-  const regex = phrase_to_word_regex(query);
+  const regex = search_phrase_to_all_words_regex(query);
 
   return _.chain(accessors)
     .map((accessor) => (_.isString(accessor) ? obj[accessor] : accessor(obj)))
@@ -332,7 +332,7 @@ const programs = {
     const name = name_function(program);
 
     if (program.old_name) {
-      const regex = phrase_to_word_regex(search);
+      const regex = search_phrase_to_all_words_regex(search);
 
       const matched_on_current_name = _.deburr(program.name).match(regex);
       const matched_on_old_name = _.deburr(program.old_name).match(regex);

--- a/client/src/search/search_configs.js
+++ b/client/src/search/search_configs.js
@@ -12,13 +12,13 @@ import { Table } from "src/core/TableClass";
 import { textColor } from "src/style_constants/index";
 
 import {
-  query_to_regex_pattern,
+  phrase_to_word_regex,
   highlight_search_match,
   SearchHighlighter,
 } from "./search_utils";
 
 const get_re_matcher = (accessors, query) => (obj) => {
-  const regex = new RegExp(query_to_regex_pattern(query), "gi");
+  const regex = phrase_to_word_regex(query);
 
   return _.chain(accessors)
     .map((accessor) => (_.isString(accessor) ? obj[accessor] : accessor(obj)))
@@ -332,7 +332,7 @@ const programs = {
     const name = name_function(program);
 
     if (program.old_name) {
-      const regex = new RegExp(query_to_regex_pattern(search), "gi");
+      const regex = phrase_to_word_regex(search);
 
       const matched_on_current_name = _.deburr(program.name).match(regex);
       const matched_on_old_name = _.deburr(program.old_name).match(regex);
@@ -397,8 +397,7 @@ const services = {
   name_function: (service) =>
     `${service.name} - ${Dept.store.lookup(service.org_id).name}`,
   menu_content_function: default_menu_content_function,
-  query: (query) =>
-    query_search_services({ name_regex: query_to_regex_pattern(query) }),
+  query: (query) => query_search_services({ search_phrase: query }),
 };
 
 export {

--- a/client/src/search/search_configs.js
+++ b/client/src/search/search_configs.js
@@ -397,7 +397,16 @@ const services = {
   name_function: (service) =>
     `${service.name} - ${Dept.store.lookup(service.org_id).name}`,
   menu_content_function: default_menu_content_function,
-  query: (query) => query_search_services({ search_phrase: query }),
+  query: (query) =>
+    _.chain(query)
+      .words()
+      .uniq()
+      .sort()
+      .join(" ")
+      .thru((cache_hit_friendly_query) =>
+        query_search_services({ search_phrase: cache_hit_friendly_query })
+      )
+      .value(),
 };
 
 export {

--- a/client/src/search/search_utils.tsx
+++ b/client/src/search/search_utils.tsx
@@ -8,7 +8,7 @@ const clean_phrase = (search_phrase: string) =>
 
 const get_length_sorted_words = (search_phrase: string) =>
   _.chain(search_phrase)
-    .split(" ")
+    .words()
     .uniq()
     .sortBy((word) => -word.length)
     .value();

--- a/client/src/search/search_utils.tsx
+++ b/client/src/search/search_utils.tsx
@@ -3,22 +3,18 @@ import React from "react";
 
 import { escapeRegExp } from "src/general_utils";
 
-const query_to_regex_pattern = (query: string) =>
+const phrase_to_word_regex = (query: string, regex_options = "gi") =>
   _.chain(query)
     .deburr()
     .thru(escapeRegExp)
     .split(" ")
     .sortBy((word) => -word.length)
     .join("|")
-    .thru((pattern) => `(${pattern})(?![^<]*>)`)
+    .thru((pattern) => new RegExp(`(${pattern})(?![^<]*>)`, regex_options))
     .value();
 
 const highlight_search_match = (search: string, content: string) =>
-  _.replace(
-    content,
-    new RegExp(query_to_regex_pattern(search), "gi"),
-    "<strong>$1</strong>"
-  );
+  _.replace(content, phrase_to_word_regex(search), "<strong>$1</strong>");
 
 const SearchHighlighter = ({
   search,
@@ -29,10 +25,7 @@ const SearchHighlighter = ({
 }) => {
   const split_token = "Ø";
   const string_split_on_matched_words = _.chain(content)
-    .replace(
-      new RegExp(query_to_regex_pattern(search), "gi"),
-      `${split_token}$1${split_token}`
-    )
+    .replace(phrase_to_word_regex(search), `${split_token}$1${split_token}`)
     .split(split_token)
     .value();
 
@@ -78,7 +71,7 @@ const format_data = <Data extends unknown>(
 });
 
 export {
-  query_to_regex_pattern,
+  phrase_to_word_regex,
   highlight_search_match,
   SearchHighlighter,
   format_data,

--- a/server/package.json
+++ b/server/package.json
@@ -52,10 +52,10 @@
     "transpile": "./scripts/deploy/build.sh",
     "start:transpile": "node transpiled_build/server.js",
     "populate_db": "node src/populate_db.js",
+    "populate_db:debug": "node --inspect-brk src/populate_db.js",
     "populate_db:remote": "(export USE_REMOTE_DB=1 && node src/populate_db.js)",
     "populate_db:watch": "nodemon --watch ../data -e csv --exec node src/populate_db.js",
     "populate_db:exitcrash": "nodemon --exitcrash --watch ../data -e csv --exec node src/populate_db.js",
-    "populate_db:debug": "nodemon --watch ../data -e csv --exec node --inspect src/populate_db.js",
     "mongod": "sh ../scripts/dev_scripts/local_mongod.sh -p 27017",
     "update_outage_info": "gsutil cp ./outage_msg.json gs://ib-outage-bucket/"
   },

--- a/server/src/models/search_utils.js
+++ b/server/src/models/search_utils.js
@@ -106,9 +106,13 @@ export const make_schema_with_search_terms = (
 
 export const get_search_terms_resolver =
   (model, bilingual = false) =>
-  async (_x, { search_phrase }, { lang }) =>
-    await model.find({
-      [`${search_terms_base_key}_${bilingual ? "bi" : lang}`]: {
+  async (_x, { search_phrase }, { lang }) => {
+    const search_terms_key = `${search_terms_base_key}_${
+      bilingual ? "bi" : lang
+    }`;
+
+    const results = await model.find({
+      [search_terms_key]: {
         $regex: _.chain(search_phrase)
           .deburr()
           // optimization note: pre-lowercasing both the content and regex should be better than using a case insensitive regex in mongo
@@ -123,3 +127,9 @@ export const get_search_terms_resolver =
           .value(),
       },
     });
+
+    return _.sortBy(
+      results,
+      (result) => result?.id || result[search_terms_key]
+    );
+  };

--- a/server/src/models/search_utils.js
+++ b/server/src/models/search_utils.js
@@ -1,0 +1,125 @@
+import _ from "lodash";
+import mongoose from "mongoose";
+
+const search_terms_base_key = "search_terms";
+
+const search_terms_def = _.chain(["en", "fr", "bi"])
+  .map((lang) => [
+    `${search_terms_base_key}_${lang}`,
+    { type: String, index: true },
+  ])
+  .fromPairs()
+  .value();
+
+const flatten_to_string = (searchable_content) => {
+  const recursive_flatten_to_string = (content) => {
+    if (_.isObject(content)) {
+      return _.chain(content)
+        .values()
+        .reduce(
+          (accumulator, value) =>
+            accumulator + recursive_flatten_to_string(value),
+          ""
+        )
+        .value();
+    } else {
+      return _.toString(content);
+    }
+  };
+
+  return recursive_flatten_to_string(searchable_content);
+};
+
+const add_derived_search_terms_to_doc = (doc, searchable_keys_by_lang) =>
+  _.chain(search_terms_def)
+    .keys()
+    .each((search_terms_field_key) => {
+      const search_field_lang = /.*_(.*?)$/.exec(search_terms_field_key)?.[1];
+
+      const searchable_fields = (() => {
+        if (search_field_lang === "bi") {
+          return _.pick(doc, _.flatMap(searchable_keys_by_lang));
+        } else {
+          return _.pick(
+            doc,
+            _.chain([
+              searchable_keys_by_lang?.[search_field_lang],
+              searchable_keys_by_lang?.both,
+            ])
+              .compact()
+              .flatten()
+              .value()
+          );
+        }
+      })();
+
+      // important that this stays in sync with the regex construction in get_search_terms_resolver, e.g. pre-deburred, pre-lower-cased
+      doc[search_terms_field_key] = _.chain(searchable_fields)
+        .flatMap((searchable_content) =>
+          _.chain(searchable_content)
+            .thru(flatten_to_string)
+            .deburr()
+            .toLower()
+            .words()
+            .value()
+        )
+        .uniq()
+        .sortBy((word) => -word.length)
+        .join(" ")
+        .value();
+    })
+    .value();
+
+export const make_schema_with_search_terms = (
+  schema_def,
+  ...searchable_keys
+) => {
+  const searchable_keys_by_lang = _.groupBy(
+    searchable_keys,
+    (field) => /.*_(en|fr)$/.exec(field)?.[1] || "both"
+  );
+
+  const schema = mongoose.Schema({
+    ...schema_def,
+    ...search_terms_def,
+  });
+
+  schema.pre("save", function (next) {
+    const doc = this;
+
+    add_derived_search_terms_to_doc(doc, searchable_keys_by_lang);
+
+    next();
+  });
+
+  // insertMany operations do not call save middleware, needs its own
+  schema.pre("insertMany", function (next, docs) {
+    _.each(docs, (doc) =>
+      add_derived_search_terms_to_doc(doc, searchable_keys_by_lang)
+    );
+
+    next();
+  });
+
+  return schema;
+};
+
+export const get_search_terms_resolver =
+  (model, bilingual = false) =>
+  async (_x, { search_phrase }, { lang }) =>
+    await model.find({
+      [`${search_terms_base_key}_${bilingual ? "bi" : lang}`]: {
+        $regex: _.chain(search_phrase)
+          .deburr()
+          // optimization note: pre-lowercasing both the content and regex should be better than using a case insensitive regex in mongo
+          .toLower()
+          // eslint-disable-next-line no-useless-escape
+          .replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, "\\$&")
+          .words()
+          .uniq()
+          // optimization note: should exit early on first unmatched word, check for longest words first since smaller could be common partials
+          .sortBy((word) => -word.length)
+          .reduce((pattern, word) => pattern + `(?=.*?${word})`, "^")
+          .value(),
+      },
+    });

--- a/server/src/models/search_utils.unit-test.js
+++ b/server/src/models/search_utils.unit-test.js
@@ -1,0 +1,26 @@
+// TODO want a lot more tests here, but I think I want to leave that till after https://github.com/TBS-EACPD/infobase/pull/1294 is merged.
+// For now, most functionality is covered by the services snapshot tests (NOT good enough long term, though)
+
+import { make_schema_with_search_terms } from "./search_utils.js";
+
+describe("make_schema_with_search_terms", function () {
+  const schema_def = {
+    id: { type: String, required: true, unique: true, index: true },
+    unsearchable: { type: String },
+    name_en: { type: String },
+    name_fr: { type: String },
+    lang_agnostic: { type: Number },
+  };
+  const schema = make_schema_with_search_terms(
+    schema_def,
+    "name_en",
+    "name_fr",
+    "lang_agnostic"
+  );
+
+  it("Adds en, fr, and bi search term fields to schema", () => {
+    expect(schema.paths).toHaveProperty("search_terms_en");
+    expect(schema.paths).toHaveProperty("search_terms_fr");
+    expect(schema.paths).toHaveProperty("search_terms_bi");
+  });
+});

--- a/server/src/models/services/__snapshots__/services.snapshot-test.js.snap
+++ b/server/src/models/services/__snapshots__/services.snapshot-test.js.snap
@@ -94,24 +94,24 @@ Array [
         ],
         "partial_word_search": Array [
           Object {
-            "id": "172",
-            "name": "Demandes de renseignements d'entités déclarantes",
+            "id": "171",
+            "name": "Communications de renseignements financiers",
           },
           Object {
-            "id": "204",
-            "name": "Entreprises de services monétaires – Recherche d’entités inscrites",
+            "id": "172",
+            "name": "Demandes de renseignements d'entités déclarantes",
           },
           Object {
             "id": "195",
             "name": "Registre des entreprises de services monétaires (ESM) – Inscription te maintenance",
           },
           Object {
-            "id": "978",
-            "name": "Demandes de renseignements du public et des médias",
+            "id": "204",
+            "name": "Entreprises de services monétaires – Recherche d’entités inscrites",
           },
           Object {
-            "id": "171",
-            "name": "Communications de renseignements financiers",
+            "id": "978",
+            "name": "Demandes de renseignements du public et des médias",
           },
         ],
       },

--- a/server/src/models/services/__snapshots__/services.snapshot-test.js.snap
+++ b/server/src/models/services/__snapshots__/services.snapshot-test.js.snap
@@ -48,6 +48,48 @@ Object {
 }
 `;
 
+exports[`services data Searching services by name 1`] = `
+Object {
+  "data": Object {
+    "root": Object {
+      "diacritical_search": Array [
+        Object {
+          "id": "172",
+          "name": "Demandes de renseignements d'entités déclarantes",
+        },
+        Object {
+          "id": "204",
+          "name": "Entreprises de services monétaires – Recherche d’entités inscrites",
+        },
+      ],
+      "multi_word_search": Array [],
+      "partial_word_search": Array [
+        Object {
+          "id": "172",
+          "name": "Demandes de renseignements d'entités déclarantes",
+        },
+        Object {
+          "id": "204",
+          "name": "Entreprises de services monétaires – Recherche d’entités inscrites",
+        },
+        Object {
+          "id": "195",
+          "name": "Registre des entreprises de services monétaires (ESM) – Inscription te maintenance",
+        },
+        Object {
+          "id": "978",
+          "name": "Demandes de renseignements du public et des médias",
+        },
+        Object {
+          "id": "171",
+          "name": "Communications de renseignements financiers",
+        },
+      ],
+    },
+  },
+}
+`;
+
 exports[`services data Single service 1`] = `
 Object {
   "data": Object {

--- a/server/src/models/services/__snapshots__/services.snapshot-test.js.snap
+++ b/server/src/models/services/__snapshots__/services.snapshot-test.js.snap
@@ -62,7 +62,12 @@ Object {
           "name": "Entreprises de services monétaires – Recherche d’entités inscrites",
         },
       ],
-      "multi_word_search": Array [],
+      "multi_word_search": Array [
+        Object {
+          "id": "172",
+          "name": "Demandes de renseignements d'entités déclarantes",
+        },
+      ],
       "partial_word_search": Array [
         Object {
           "id": "172",

--- a/server/src/models/services/__snapshots__/services.snapshot-test.js.snap
+++ b/server/src/models/services/__snapshots__/services.snapshot-test.js.snap
@@ -49,50 +49,75 @@ Object {
 `;
 
 exports[`services data Searching services by name 1`] = `
-Object {
-  "data": Object {
-    "root": Object {
-      "diacritical_search": Array [
-        Object {
-          "id": "172",
-          "name": "Demandes de renseignements d'entités déclarantes",
-        },
-        Object {
-          "id": "204",
-          "name": "Entreprises de services monétaires – Recherche d’entités inscrites",
-        },
-      ],
-      "multi_word_search": Array [
-        Object {
-          "id": "172",
-          "name": "Demandes de renseignements d'entités déclarantes",
-        },
-      ],
-      "partial_word_search": Array [
-        Object {
-          "id": "172",
-          "name": "Demandes de renseignements d'entités déclarantes",
-        },
-        Object {
-          "id": "204",
-          "name": "Entreprises de services monétaires – Recherche d’entités inscrites",
-        },
-        Object {
-          "id": "195",
-          "name": "Registre des entreprises de services monétaires (ESM) – Inscription te maintenance",
-        },
-        Object {
-          "id": "978",
-          "name": "Demandes de renseignements du public et des médias",
-        },
-        Object {
-          "id": "171",
-          "name": "Communications de renseignements financiers",
-        },
-      ],
+Array [
+  Object {
+    "data": Object {
+      "en_root": Object {
+        "search_by_english_word": Array [
+          Object {
+            "id": "172",
+            "name": "Enquiries for Reporting Entities",
+          },
+        ],
+        "search_by_french_word": Array [],
+      },
     },
   },
-}
+  Object {
+    "data": Object {
+      "fr_root": Object {
+        "diacritical_free_search": Array [
+          Object {
+            "id": "172",
+            "name": "Demandes de renseignements d'entités déclarantes",
+          },
+          Object {
+            "id": "204",
+            "name": "Entreprises de services monétaires – Recherche d’entités inscrites",
+          },
+        ],
+        "diacritical_search": Array [
+          Object {
+            "id": "172",
+            "name": "Demandes de renseignements d'entités déclarantes",
+          },
+          Object {
+            "id": "204",
+            "name": "Entreprises de services monétaires – Recherche d’entités inscrites",
+          },
+        ],
+        "multi_word_search": Array [
+          Object {
+            "id": "172",
+            "name": "Demandes de renseignements d'entités déclarantes",
+          },
+        ],
+        "partial_word_search": Array [
+          Object {
+            "id": "172",
+            "name": "Demandes de renseignements d'entités déclarantes",
+          },
+          Object {
+            "id": "204",
+            "name": "Entreprises de services monétaires – Recherche d’entités inscrites",
+          },
+          Object {
+            "id": "195",
+            "name": "Registre des entreprises de services monétaires (ESM) – Inscription te maintenance",
+          },
+          Object {
+            "id": "978",
+            "name": "Demandes de renseignements du public et des médias",
+          },
+          Object {
+            "id": "171",
+            "name": "Communications de renseignements financiers",
+          },
+        ],
+      },
+    },
+  },
+]
 `;
 
 exports[`services data Single service 1`] = `

--- a/server/src/models/services/models.js
+++ b/server/src/models/services/models.js
@@ -14,6 +14,7 @@ import {
   bilingual_str,
   bilingual,
 } from "../model_utils.js";
+import { make_schema_with_search_terms } from "../search_utils.js";
 
 export default function (model_singleton) {
   const ServiceReportSchema = mongoose.Schema({
@@ -60,38 +61,40 @@ export default function (model_singleton) {
     standard_report: [StandardReportSchema],
   });
 
-  const ServiceSchema = mongoose.Schema({
-    id: pkey_type(),
-    org_id: parent_fkey_type(),
-    program_activity_codes: [sparse_parent_fkey_type()],
-    report_years: [str_type],
-    first_active_year: str_type,
-    last_active_year: str_type,
-    is_active: { type: Boolean },
+  const ServiceSchema = make_schema_with_search_terms(
+    {
+      id: pkey_type(),
+      org_id: parent_fkey_type(),
+      program_activity_codes: [sparse_parent_fkey_type()],
+      report_years: [str_type],
+      first_active_year: str_type,
+      last_active_year: str_type,
+      is_active: { type: Boolean },
 
-    ...bilingual_str("name"),
-    ...bilingual_str("search_text"),
-    ...bilingual_str("description"),
-    ...bilingual("service_type", [str_type]),
-    ...bilingual("scope", [str_type]),
-    ...bilingual("designations", [str_type]),
-    ...bilingual("target_groups", [str_type]),
-    ...bilingual("feedback_channels", [str_type]),
-    ...bilingual("urls", [str_type]),
+      ...bilingual_str("name"),
+      ...bilingual_str("description"),
+      ...bilingual("service_type", [str_type]),
+      ...bilingual("scope", [str_type]),
+      ...bilingual("designations", [str_type]),
+      ...bilingual("target_groups", [str_type]),
+      ...bilingual("feedback_channels", [str_type]),
+      ...bilingual("urls", [str_type]),
 
-    last_gender_analysis: str_type,
+      last_gender_analysis: str_type,
 
-    collects_fees: { type: Boolean },
-    account_reg_digital_status: { type: Boolean },
-    authentication_status: { type: Boolean },
-    application_digital_status: { type: Boolean },
-    decision_digital_status: { type: Boolean },
-    issuance_digital_status: { type: Boolean },
-    issue_res_digital_status: { type: Boolean },
-    ...bilingual_str("digital_enablement_comment"),
-    standards: [ServiceStandardSchema],
-    service_report: [ServiceReportSchema],
-  });
+      collects_fees: { type: Boolean },
+      account_reg_digital_status: { type: Boolean },
+      authentication_status: { type: Boolean },
+      application_digital_status: { type: Boolean },
+      decision_digital_status: { type: Boolean },
+      issuance_digital_status: { type: Boolean },
+      issue_res_digital_status: { type: Boolean },
+      ...bilingual_str("digital_enablement_comment"),
+      standards: [ServiceStandardSchema],
+      service_report: [ServiceReportSchema],
+    },
+    ..._.keys(bilingual_str("name"))
+  );
 
   const ServiceGeneralStatsSchema = mongoose.Schema({
     id: pkey_type(),

--- a/server/src/models/services/models.js
+++ b/server/src/models/services/models.js
@@ -91,7 +91,6 @@ export default function (model_singleton) {
     standards: [ServiceStandardSchema],
     service_report: [ServiceReportSchema],
   });
-  ServiceSchema.index({ name_en: "text", name_fr: "text" });
 
   const ServiceGeneralStatsSchema = mongoose.Schema({
     id: pkey_type(),

--- a/server/src/models/services/models.js
+++ b/server/src/models/services/models.js
@@ -70,6 +70,7 @@ export default function (model_singleton) {
     is_active: { type: Boolean },
 
     ...bilingual_str("name"),
+    ...bilingual_str("search_text"),
     ...bilingual_str("description"),
     ...bilingual("service_type", [str_type]),
     ...bilingual("scope", [str_type]),

--- a/server/src/models/services/populate.js
+++ b/server/src/models/services/populate.js
@@ -113,8 +113,6 @@ export default async function ({ models }) {
         issuance_digital_status,
         issue_res_digital_status,
 
-        name_en,
-        name_fr,
         service_type_en,
         service_type_fr,
         service_type_codes,
@@ -178,10 +176,6 @@ export default async function ({ models }) {
           .compact()
           .value(),
 
-        name_en,
-        name_fr,
-        search_text_en: _.deburr(name_en),
-        search_text_fr: _.deburr(name_fr),
         ...multi_value_string_fields_to_arrays({
           service_type_en,
           service_type_fr,

--- a/server/src/models/services/populate.js
+++ b/server/src/models/services/populate.js
@@ -113,6 +113,8 @@ export default async function ({ models }) {
         issuance_digital_status,
         issue_res_digital_status,
 
+        name_en,
+        name_fr,
         service_type_en,
         service_type_fr,
         service_type_codes,
@@ -175,6 +177,11 @@ export default async function ({ models }) {
           .map((id) => id && `${dept_code}-${id}`)
           .compact()
           .value(),
+
+        name_en,
+        name_fr,
+        search_text_en: _.deburr(name_en),
+        search_text_fr: _.deburr(name_fr),
         ...multi_value_string_fields_to_arrays({
           service_type_en,
           service_type_fr,

--- a/server/src/models/services/schema.js
+++ b/server/src/models/services/schema.js
@@ -176,7 +176,10 @@ export default function ({ models, loaders }) {
               .deburr()
               // eslint-disable-next-line no-useless-escape
               .replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, "\\$&")
-              .replace(" ", "|")
+              .split(" ")
+              .uniq()
+              .sortBy((word) => -word.length)
+              .reduce((pattern, word) => pattern + `(?=.*?${word})`, "^")
               .value(),
             $options: "i",
           },

--- a/server/src/models/services/schema.js
+++ b/server/src/models/services/schema.js
@@ -5,7 +5,7 @@ import { bilingual_field } from "../schema_utils.js";
 const schema = `
   extend type Root{
     service(id: String!): Service
-    search_services(name_query: String): [Service]
+    search_services(name_regex: String!): [Service]
   }
   extend type Gov{
     service_summary: ServiceSummary
@@ -169,9 +169,12 @@ export default function ({ models, loaders }) {
   const resolvers = {
     Root: {
       service: (_x, { id }) => service_loader.load(id),
-      search_services: async (_x, { name_query }) =>
+      search_services: async (_x, { name_regex }, { lang }) =>
+        // TODO look for a package that can check regex safety/complexity, deny overly complex input
+        // ... or maybe accepting a regex pattern is just a terrible idea, maybe take a query string
+        // and just duplicate the client's string to query regex code here for now
         await Service.find({
-          $text: { $search: `"${name_query}"` }, // Double quotes for exact phrase
+          [`name_${lang}`]: { $regex: name_regex },
         }),
     },
     Gov: {

--- a/server/src/models/services/schema.js
+++ b/server/src/models/services/schema.js
@@ -1,6 +1,7 @@
 import _ from "lodash";
 
 import { bilingual_field } from "../schema_utils.js";
+import { get_search_terms_resolver } from "../search_utils.js";
 
 const schema = `
   extend type Root{
@@ -169,21 +170,7 @@ export default function ({ models, loaders }) {
   const resolvers = {
     Root: {
       service: (_x, { id }) => service_loader.load(id),
-      search_services: async (_x, { search_phrase }, { lang }) =>
-        await Service.find({
-          [`search_text_${lang}`]: {
-            $regex: _.chain(search_phrase)
-              .deburr()
-              // eslint-disable-next-line no-useless-escape
-              .replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, "\\$&")
-              .split(" ")
-              .uniq()
-              .sortBy((word) => -word.length)
-              .reduce((pattern, word) => pattern + `(?=.*?${word})`, "^")
-              .value(),
-            $options: "i",
-          },
-        }),
+      search_services: get_search_terms_resolver(Service),
     },
     Gov: {
       service_summary: () => gov_service_summary_loader.load("gov"),

--- a/server/src/models/services/services.snapshot-test.js
+++ b/server/src/models/services/services.snapshot-test.js
@@ -167,6 +167,16 @@ query{
   }
 }`;
 
+// TODO probably search with a handful of different patterns
+const search_services = `
+query{
+  root(lang: "en"){
+    search_services(name_regex: "TODO"){
+      ${service_fields}
+    }
+  }
+}`;
+
 const { execQuery } = global;
 
 describe("services data", function () {
@@ -188,6 +198,10 @@ describe("services data", function () {
   });
   it("Single service", async () => {
     const data = await execQuery(single_service, {});
+    return expect(data).toMatchSnapshot();
+  });
+  it("Searching services by name", async () => {
+    const data = await execQuery(search_services, {});
     return expect(data).toMatchSnapshot();
   });
 });

--- a/server/src/models/services/services.snapshot-test.js
+++ b/server/src/models/services/services.snapshot-test.js
@@ -170,9 +170,18 @@ query{
 // TODO probably search with a handful of different patterns
 const search_services = `
 query{
-  root(lang: "en"){
-    search_services(search_phrase: "TODO"){
-      ${service_fields}
+  root(lang: "fr"){
+    diacritical_search: search_services(search_phrase: "entités"){
+      id,
+      name
+    }
+    multi_word_search: search_services(search_phrase: "something renseignements whatever"){
+      id,
+      name
+    }
+    partial_word_search: search_services(search_phrase: "en"){
+      id,
+      name
     }
   }
 }`;

--- a/server/src/models/services/services.snapshot-test.js
+++ b/server/src/models/services/services.snapshot-test.js
@@ -171,7 +171,7 @@ query{
 const search_services = `
 query{
   root(lang: "en"){
-    search_services(name_regex: "TODO"){
+    search_services(search_phrase: "TODO"){
       ${service_fields}
     }
   }

--- a/server/src/models/services/services.snapshot-test.js
+++ b/server/src/models/services/services.snapshot-test.js
@@ -175,7 +175,7 @@ query{
       id,
       name
     }
-    multi_word_search: search_services(search_phrase: "something renseignements whatever"){
+    multi_word_search: search_services(search_phrase: "d'entités renseignements"){
       id,
       name
     }

--- a/server/src/models/services/services.snapshot-test.js
+++ b/server/src/models/services/services.snapshot-test.js
@@ -167,11 +167,27 @@ query{
   }
 }`;
 
-// TODO probably search with a handful of different patterns
-const search_services = `
+const search_services_en = `
 query{
-  root(lang: "fr"){
-    diacritical_search: search_services(search_phrase: "entités"){
+  en_root: root(lang: "en"){
+    search_by_french_word: search_services(search_phrase: "Entités"){
+      id,
+      name
+    }
+    search_by_english_word: search_services(search_phrase: "Entities"){
+      id,
+      name
+    }
+  }
+}`;
+const search_services_fr = `
+query{
+  fr_root: root(lang: "fr"){
+    diacritical_search: search_services(search_phrase: "Entités"){
+      id,
+      name
+    }
+    diacritical_free_search: search_services(search_phrase: "Entites"){
       id,
       name
     }
@@ -210,7 +226,8 @@ describe("services data", function () {
     return expect(data).toMatchSnapshot();
   });
   it("Searching services by name", async () => {
-    const data = await execQuery(search_services, {});
-    return expect(data).toMatchSnapshot();
+    const data_en = await execQuery(search_services_en, {});
+    const data_fr = await execQuery(search_services_fr, {});
+    return expect([data_en, data_fr]).toMatchSnapshot();
   });
 });


### PR DESCRIPTION
Taking over from #1244

TODO:
  - [x] lots of cleanup from first rough proof of concept commit
  - [x] extract server searching pattern, make `search_text` a model utility
    - maybe a field that derives from a list of other text fields, deburing, sorting, and uniq-ing their words
    - maybe with producing en, fr, AND bilingual fields
    - if we pre-lowercase the field and constructed regex, making it an index [should](https://docs.mongodb.com/manual/reference/operator/query/regex/#index-use) help optimize 
  - ~probably want to share `search_phrase_to_all_words_regex` between `client` and `server`~
    - hmm, woud mean writing it in JS and maintaining types on the side I guess, not perfect 
    - skipping for now, figuring out a good way to share common code is probably its own PR
  - [x] careful testing (ha, wish #1294 was merged already), make sure new searching retains old search's behaviour
  - [x] could be a small optimization to pre-process the search phrase in to sorted unique words before sending the request to the client, more chances to his cache that way
  - [ ] first search can be particularly slow, given the function wake up time. Thought I had the initial load waking the server up with an empty query? Is that query being cached or something, or am I forgetting how that was set up?