### PR TITLE
fix z-index of dropdown menu and its svg

### DIFF
--- a/client/src/components/DropdownMenu/DropdownMenu.scss
+++ b/client/src/components/DropdownMenu/DropdownMenu.scss
@@ -3,7 +3,6 @@
 .dropdown {
   position: relative;
   display: inline-block;
-  z-index: 1001;
   height: 100%;
 
   &--is-open {
@@ -33,6 +32,7 @@
   box-shadow: 0px 8px 16px 0px rgba(0, 0, 0, 0.4);
   padding: 12px 16px;
   border-radius: $standardBorderRadius;
+  z-index: 99;
 }
 .close-dropdown {
   &:hover,


### PR DESCRIPTION

Fixed the problem where SVG floats on top of other dropdown menu

![image (1)](https://user-images.githubusercontent.com/29746626/143906220-0688619a-4191-4dd0-888a-ff09eb07ff29.png)

but not sure what's going on with the weird style on IE. Been playing around with IE DOM inspector and the dropdown button style seem to be changing somewhat randomly