### PR TITLE
Fix infographic table of contents focus management

### DIFF
--- a/client/src/infographic/Infographic.js
+++ b/client/src/infographic/Infographic.js
@@ -235,6 +235,8 @@ class Infographic extends React.Component {
               />
             )}
           <TableOfContents
+            subject={subject}
+            active_bubble_id={active_bubble_id}
             panel_titles_by_key={_.chain(filtered_panel_keys)
               .map((panel_key) =>
                 PanelRegistry.lookup(panel_key, subject.subject_type)
@@ -243,9 +245,6 @@ class Infographic extends React.Component {
               .map((panel) => [panel.key, panel.get_title(subject)])
               .fromPairs()
               .value()}
-            scroll_to_panel_when_all_loading_done={
-              this.scroll_to_panel_when_all_loading_done
-            }
           />
           {!loading &&
             _.map(filtered_panel_keys, (panel_key) => (

--- a/client/src/infographic/TableOfContents.js
+++ b/client/src/infographic/TableOfContents.js
@@ -5,10 +5,11 @@ import {
   StatelessDetails,
   create_text_maker_component,
   UnlabeledTombstone,
-  LinkStyled,
 } from "src/components/index";
 
 import { separatorColor } from "src/style_constants/index";
+
+import { infograph_options_href_template } from "./infographic_link";
 
 import text from "./TableOfContents.yaml";
 
@@ -23,8 +24,7 @@ export default class TableOfContents extends React.Component {
   }
   on_click = () => this.setState({ is_open: !this.state.is_open });
   render() {
-    const { panel_titles_by_key, scroll_to_panel_when_all_loading_done } =
-      this.props;
+    const { subject, active_bubble_id, panel_titles_by_key } = this.props;
 
     const { is_open } = this.state;
 
@@ -47,14 +47,16 @@ export default class TableOfContents extends React.Component {
             >
               <UnlabeledTombstone
                 items={_.map(panel_titles_by_key, (panel_title, panel_key) => (
-                  <LinkStyled
+                  <a
                     key={panel_key}
-                    on_click={() =>
-                      scroll_to_panel_when_all_loading_done(panel_key)
-                    }
+                    href={infograph_options_href_template(
+                      subject,
+                      active_bubble_id,
+                      { panel_key }
+                    )}
                   >
                     {panel_title}
-                  </LinkStyled>
+                  </a>
                 ))}
               />
             </div>

--- a/client/src/panels/PanelRenderer.js
+++ b/client/src/panels/PanelRenderer.js
@@ -24,7 +24,8 @@ export const PanelRenderer = withRouter(
         return null;
       }
       return (
-        <div id={panel_key}>
+        /* -1 tab index necessary for direct panel links to (consistently) manage focus in a keyboard nav friendly way */
+        <div id={panel_key} tabIndex="-1">
           <Provider
             value={{
               active_bubble_id,


### PR DESCRIPTION
Fixes #1317

Funny quirk, the table of contents shared its scroll to mechanism with the functionality for directly linking to a panel. Directly linking to a panel DID (appear) to manage focus as desired, which is probably why no one checked that the table of contents did as well. That was a fluke, the `.focus()` call didn't actually do anything (targeted an unfocusable element), linking to the panel only _seemed_ to manage focus as expected because, when nothing on the screen has focus yet, the first keyboard navigation lands on the first focusable thing _on screen_, so scrolling the view was enough (on Chrome, not testing widely, not sure if this is in the spec or not). Ha.