### PR TITLE
Bring back MAX_OLD_SPACE_SIZE env var usage for client webpack build scripts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -198,7 +198,7 @@ jobs:
             - prod-build-{{ .Branch }}{{ .Revision }}-v2
       - run:
           command: |
-            [ -f "client/$BUILD_DIR/InfoBase/app/app-a11y-en.min.js" ] || (cd client && ./scripts/deploy/build_all.sh -c "half" -o "PROD_SOURCE_MAP STATS $([[$CIRCLE_BRANCH = master]] && echo "STATS-BASELINE")")
+            [ -f "client/$BUILD_DIR/InfoBase/app/app-a11y-en.min.js" ] || (cd client && ./scripts/deploy/build_all.sh -c "half" -m 1536 -o "PROD_SOURCE_MAP STATS $([[$CIRCLE_BRANCH = master]] && echo "STATS-BASELINE")")
       - save_cache:
           key: prod-build-{{ .Branch }}-{{ .Revision }}-v2
           paths:

--- a/client/package.json
+++ b/client/package.json
@@ -7,7 +7,7 @@
     "build_static": "node build_code/copy_static_assets.js",
     "build_static:debug": "node --inspect-brk build_code/copy_static_assets.js",
     "build_static:watch": "nodemon --exitcrash --watch ../data --watch build_code --watch src/extended_bootstrap_css --watch src/png --watch src/svg --watch src/InfoBase/index.hbs.html --watch src/InfoBase/index_data.ts -e csv,js,css,scss,png,svg build_code/copy_static_assets.js",
-    "webpack": "node build_code/webpack_starter.js",
+    "webpack": "node --max-old-space-size=${MAX_OLD_SPACE_SIZE:-2048} build_code/webpack_starter.js",
     "webpack:debug": "node --inspect-brk build_code/webpack_starter.js",
     "serve": "http-server -a 127.0.0.1",
     "serve:ci": "http-server -s -a 127.0.0.1",

--- a/client/scripts/deploy/build_all.sh
+++ b/client/scripts/deploy/build_all.sh
@@ -2,10 +2,12 @@
 set -e # will exit if any command has non-zero exit value 
 
 concurrency="full"
+max_old_space_size=2048
 while getopts "c:o:" opt; do
   case ${opt} in
     c) concurrency=$OPTARG;;
     o) options=$OPTARG;;
+    m) max_old_space_size=$OPTARG;;
   esac
 done
 
@@ -13,6 +15,9 @@ if [[ ! $concurrency =~ ^(full|half|none)$ ]]; then
   echo "Concurrency options, -c, are full, half, or none"
   exit 1
 fi
+
+# calls to npm run webpack... use this env var when set
+export MAX_OLD_SPACE_SIZE=$max_old_space_size
 
 [ -e $BUILD_DIR/InfoBase ] && rm -r $BUILD_DIR/InfoBase # clean up build dir
 


### PR DESCRIPTION
Dropped it as cleanup, it seemed no longer necessary, but CI jobs have started running out of memory occasionally. 