### PR TITLE
Scroll to and focus utility

### DIFF
--- a/client/src/components/BackToTop/BackToTop.stories.tsx
+++ b/client/src/components/BackToTop/BackToTop.stories.tsx
@@ -14,14 +14,7 @@ const BackToTopTemplate: Story<TemplateProps> = ({ focusId }) => (
     <div id="wb-info" style={{ height: "300px", borderTop: "2px black solid" }}>
       Footer
     </div>
-    <BackToTop
-      focus={() => {
-        const test_element = document.getElementById("#test");
-        if (test_element) {
-          test_element.focus();
-        }
-      }}
-    />
+    <BackToTop scroll_target={document.getElementById("#test")} />
   </Fragment>
 );
 

--- a/client/src/components/BackToTop/BackToTop.tsx
+++ b/client/src/components/BackToTop/BackToTop.tsx
@@ -6,11 +6,12 @@ import "intersection-observer";
 import { trivial_text_maker } from "src/models/text";
 
 import { is_mobile } from "src/core/feature_detection";
+import { scroll_to_top } from "src/core/NavComponents";
 
 import "./BackToTop.scss";
 
 interface BackToTopProps {
-  focus: () => void;
+  scroll_target: HTMLElement | null | undefined;
 }
 interface BackToTopState {
   show_back_to_top: boolean;
@@ -64,8 +65,7 @@ export class BackToTop extends React.Component<BackToTopProps, BackToTopState> {
   }
 
   handleClick() {
-    document.body.scrollTop = document.documentElement.scrollTop = 0;
-    this.props.focus();
+    scroll_to_top(this.props.scroll_target);
   }
 
   render() {

--- a/client/src/core/NavComponents.js
+++ b/client/src/core/NavComponents.js
@@ -195,7 +195,7 @@ export const scroll_into_view_and_focus = (
     } else {
       this.setAttribute("tabindex", original_tabindex);
     }
-    this.removeEvenListener("blur", reset_tabindex);
+    this.removeEventListener("blur", reset_tabindex);
   };
   element.addEventListener("blur", reset_tabindex);
 

--- a/client/src/core/NavComponents.js
+++ b/client/src/core/NavComponents.js
@@ -181,6 +181,25 @@ export class StandardRouteContainer extends React.Component {
   }
 }
 
+export const scroll_into_view_and_focus = (element) => {
+  const original_tabindex = element.getAttribute("tabindex");
+
+  element.setAttribute("tabindex", "-1");
+
+  const reset_tabindex = function () {
+    if (_.isNull(original_tabindex)) {
+      this.removeAttribute("tabindex");
+    } else {
+      this.setAttribute("tabindex", original_tabindex);
+    }
+    this.removeEvenListener("blur", reset_tabindex);
+  };
+  element.addEventListener("blur", reset_tabindex);
+
+  element.scrollIntoView();
+  element.focus();
+};
+
 export class ScrollToTargetContainer extends React.Component {
   scrollToItem() {
     const { target_id } = this.props;
@@ -188,10 +207,7 @@ export class ScrollToTargetContainer extends React.Component {
     if (!_.isEmpty(target_id) && target_id !== "__") {
       var el = document.querySelector("#" + target_id);
       if (el) {
-        setTimeout(() => {
-          scrollTo(0, el.offsetTop);
-          el.focus();
-        });
+        setTimeout(() => scroll_into_view_and_focus(el));
       }
     }
   }

--- a/client/src/core/NavComponents.js
+++ b/client/src/core/NavComponents.js
@@ -3,7 +3,7 @@ import React, { Fragment } from "react";
 import ReactDOM from "react-dom";
 import { withRouter } from "react-router";
 
-import { AlertBanner } from "src/components/index";
+import { AlertBanner } from "src/components/AlertBanner/AlertBanner";
 
 import { trivial_text_maker } from "src/models/text";
 
@@ -203,8 +203,11 @@ export const scroll_into_view_and_focus = (
   element.focus();
 };
 
-export const scroll_to_top = (behaviour = "auto") =>
-  scroll_into_view_and_focus(document.getElementById("app-focus-root"), {
+export const scroll_to_top = (
+  top_element = document.getElementById("app-focus-root"),
+  behaviour = "auto"
+) =>
+  scroll_into_view_and_focus(top_element, {
     behaviour,
     block: "start",
     inline: "nearest",

--- a/client/src/core/NavComponents.js
+++ b/client/src/core/NavComponents.js
@@ -149,8 +149,8 @@ const HeaderBanner = withRouter(
 export class StandardRouteContainer extends React.Component {
   componentDidMount() {
     //unless a route's component is sufficiently complicated, it should never unmount/remount a StandardRouteContainer
-    //therefore, this component being unmounts/remounted implies a change between routes, which should always re-scroll
-    window.scrollTo(0, 0);
+    //therefore, this component being unmounted/remounted implies a change between routes, which should always re-scroll
+    scroll_to_top();
   }
   render() {
     const {
@@ -202,6 +202,13 @@ export const scroll_into_view_and_focus = (
   element.scrollIntoView(scroll_into_view_options);
   element.focus();
 };
+
+export const scroll_to_top = (behaviour = "auto") =>
+  scroll_into_view_and_focus(document.getElementById("app-focus-root"), {
+    behaviour,
+    block: "start",
+    inline: "nearest",
+  });
 
 export class ScrollToTargetContainer extends React.Component {
   scrollToItem() {

--- a/client/src/core/NavComponents.js
+++ b/client/src/core/NavComponents.js
@@ -181,7 +181,10 @@ export class StandardRouteContainer extends React.Component {
   }
 }
 
-export const scroll_into_view_and_focus = (element) => {
+export const scroll_into_view_and_focus = (
+  element,
+  scroll_into_view_options = {}
+) => {
   const original_tabindex = element.getAttribute("tabindex");
 
   element.setAttribute("tabindex", "-1");
@@ -196,7 +199,7 @@ export const scroll_into_view_and_focus = (element) => {
   };
   element.addEventListener("blur", reset_tabindex);
 
-  element.scrollIntoView();
+  element.scrollIntoView(scroll_into_view_options);
   element.focus();
 };
 

--- a/client/src/glossary/glossary.js
+++ b/client/src/glossary/glossary.js
@@ -11,6 +11,7 @@ import {
   StandardRouteContainer,
   ScrollToTargetContainer,
   scroll_into_view_and_focus,
+  scroll_to_top,
 } from "src/core/NavComponents";
 import { Table } from "src/core/TableClass";
 
@@ -147,9 +148,7 @@ const Glossary_ = ({ active_key, items_by_letter }) => (
                       href="#glossary"
                       onClick={(evt) => {
                         evt.preventDefault();
-                        document.body.scrollTop =
-                          document.documentElement.scrollTop = 0;
-                        document.getElementById("app-focus-root").focus();
+                        scroll_to_top();
                       }}
                     >
                       {text_maker("back_to_top")}
@@ -186,15 +185,7 @@ export default class Glossary extends React.Component {
           <TM k="glossary" />
         </h1>
         <ScrollToTargetContainer target_id={active_key}>
-          {!is_a11y_mode && (
-            <BackToTop
-              focus={() => {
-                document
-                  .querySelector("#glossary_search > div > div > input")
-                  .focus();
-              }}
-            />
-          )}
+          {!is_a11y_mode && <BackToTop />}
           <Glossary_
             active_key={active_key}
             items_by_letter={items_by_letter}

--- a/client/src/glossary/glossary.js
+++ b/client/src/glossary/glossary.js
@@ -10,6 +10,7 @@ import { is_a11y_mode } from "src/core/injected_build_constants";
 import {
   StandardRouteContainer,
   ScrollToTargetContainer,
+  scroll_into_view_and_focus,
 } from "src/core/NavComponents";
 import { Table } from "src/core/TableClass";
 
@@ -101,8 +102,8 @@ const Glossary_ = ({ active_key, items_by_letter }) => (
                 onClick={(evt) => {
                   evt.preventDefault();
                   const el = document.getElementById(`__${letter}`);
-                  el.scrollIntoView({ behavior: "instant" });
-                  el.focus();
+
+                  scroll_into_view_and_focus(el, { behavior: "instant" });
                 }}
               >
                 {letter}

--- a/client/src/infographic/Infographic.js
+++ b/client/src/infographic/Infographic.js
@@ -28,7 +28,10 @@ import {
   services_feature_flag,
   is_a11y_mode,
 } from "src/core/injected_build_constants";
-import { StandardRouteContainer } from "src/core/NavComponents";
+import {
+  StandardRouteContainer,
+  scroll_into_view_and_focus,
+} from "src/core/NavComponents";
 import { redirect_with_msg } from "src/core/RedirectHeader";
 
 import { shallowEqualObjectsOverKeys, SafeJSURL } from "src/general_utils";
@@ -160,8 +163,7 @@ class Infographic extends React.Component {
           false
         );
 
-        linked_to_panel.scrollIntoView();
-        linked_to_panel.focus();
+        scroll_into_view_and_focus(linked_to_panel);
       }
     }
   }, 100);

--- a/client/src/infographic/Infographic.js
+++ b/client/src/infographic/Infographic.js
@@ -31,6 +31,7 @@ import {
 import {
   StandardRouteContainer,
   scroll_into_view_and_focus,
+  scroll_to_top,
 } from "src/core/NavComponents";
 import { redirect_with_msg } from "src/core/RedirectHeader";
 
@@ -84,7 +85,7 @@ class AnalyticsSynchronizer extends React.Component {
   }
 }
 function reset_scroll() {
-  window.scrollTo(0, 0);
+  scroll_to_top();
 }
 
 const get_default_state_from_props = ({

--- a/client/src/panels/PanelRenderer.js
+++ b/client/src/panels/PanelRenderer.js
@@ -24,8 +24,7 @@ export const PanelRenderer = withRouter(
         return null;
       }
       return (
-        /* -1 tab index necessary for direct panel links to (consistently) manage focus in a keyboard nav friendly way */
-        <div id={panel_key} tabIndex="-1">
+        <div id={panel_key}>
           <Provider
             value={{
               active_bubble_id,

--- a/client/src/panels/panel_declarations/covid/covid_key_concepts.js
+++ b/client/src/panels/panel_declarations/covid/covid_key_concepts.js
@@ -5,6 +5,8 @@ import { declare_panel } from "src/panels/panel_declarations/common_panel_utils"
 
 import { PinnedFAQ } from "src/components/PinnedFAQ/PinnedFAQ";
 
+import { scroll_into_view_and_focus } from "src/core/NavComponents";
+
 import common_questions from "src/common_text/faq/common_questions.yaml";
 
 import { covid_create_text_maker_component } from "./covid_text_provider";
@@ -63,8 +65,7 @@ export const scroll_to_covid_key_concepts = () => {
   const covid_key_concept_panel = document.querySelector(`#${panel_key}`);
 
   if (!_.isNull(covid_key_concept_panel)) {
-    window.scrollTo(0, covid_key_concept_panel.offsetTop);
-    covid_key_concept_panel.focus();
+    scroll_into_view_and_focus(covid_key_concept_panel);
 
     // Ok, this is where it gets more brittle/hacky. Leaking up a bunch of knowledge about SomeThingsToKeepInMind/AutoAccordion
     // implementation. Should fail softly if those change, and as long as they don't it's a solid UX improvement


### PR DESCRIPTION
Generic solution to the general case of #1317, we had a number of scroll/focus management snippets and they were inconsistently friendly to tab navigation. This fixes that, regardless of the specific element/tabindex value of the scroll + focus target.