### PR TITLE
Fix RPB route load config and RPB Axe warnings

### DIFF
--- a/client/cypress/integration/InfoBase/route_tests.spec.js
+++ b/client/cypress/integration/InfoBase/route_tests.spec.js
@@ -281,12 +281,15 @@ const run_tests_from_config = ({
           "not.exist"
         );
 
-        //Once basic routes a11y critical issues are fix, can remove this if statement
-        if (!skip_axe && (app == "eng" || app == "fra")) {
+        if (
+          !skip_axe &&
+          /* TODO fix all axe warning on the a11y routes, drop the next line */
+          !/basic-/.test(app)
+        ) {
           cy.injectAxe();
           cy.checkA11y(
             null,
-            { includedImpacts: ["critical"] },
+            { includedImpacts: ["critical", "serious", "moderate"] },
             cy.terminalLog,
             false
           );

--- a/client/cypress/integration/InfoBase/route_tests.spec.js
+++ b/client/cypress/integration/InfoBase/route_tests.spec.js
@@ -289,7 +289,7 @@ const run_tests_from_config = ({
           cy.injectAxe();
           cy.checkA11y(
             null,
-            { includedImpacts: ["critical", "serious", "moderate"] },
+            { includedImpacts: ["critical"] }, // TODO expand to include serious, fix those, then expand to include moderate as well
             cy.terminalLog,
             false
           );

--- a/client/cypress/integration/InfoBase/route_tests.spec.js
+++ b/client/cypress/integration/InfoBase/route_tests.spec.js
@@ -9,7 +9,7 @@ const route_load_tests_config = [
   },
   {
     name: "Homepage",
-    route: "",
+    route: "start",
     test_on: ["eng", "fra", "basic-eng", "basic-fra"],
   },
   {
@@ -242,8 +242,7 @@ const route_load_tests_config = [
   },
   {
     name: "Report Builder - Report",
-    route:
-      "rpb/~(columns~(~'thisyearexpenditures)~subject~'gov_gov~'dimension~'major_voted_stat~table~'orgVoteStatQfr~sort_col~'dept~descending~false~filter~'All)",
+    route: "rpb/.-.-(table.-.-'orgEmployeeType)",
     test_on: ["eng", "basic-eng"],
   },
   {

--- a/client/src/components/DisplayTable/DisplayTable.yaml
+++ b/client/src/components/DisplayTable/DisplayTable.yaml
@@ -35,6 +35,9 @@ filter_data:
 no_data_table:
   en: No data available for this table. Please check any filters applied.
   fr: Aucune donnée n'est disponible pour ce tableau. Veuillez vérifier les filtres utilisés.
+table_pagination:
+  en: Table pagination
+  fr: Pagination des tableaux
 ellipsis_end:
   transform: [handlebars]
   en: Page {{page_num}}. Click this, then move right to view more options.

--- a/client/src/components/DisplayTable/DisplayTableUtils.js
+++ b/client/src/components/DisplayTable/DisplayTableUtils.js
@@ -435,9 +435,9 @@ export const SelectPageSize = ({
 
   const dropdown_content = (
     <form className="paginate_by_dropdown">
-      <div style={{ marginBottom: 10 }}>
+      <ul className="list-unstyled" style={{ marginBottom: 10 }}>
         {_.map(options, ({ label, value }) => (
-          <form key={value}>
+          <li key={value}>
             <label className={"normal-radio-btn-label"}>
               <input
                 onClick={() => on_select(value)}
@@ -448,9 +448,9 @@ export const SelectPageSize = ({
               />
               <span style={{ marginLeft: "3px" }}>{label}</span>
             </label>
-          </form>
+          </li>
         ))}
-      </div>
+      </ul>
     </form>
   );
 

--- a/client/src/components/DisplayTable/DisplayTableUtils.js
+++ b/client/src/components/DisplayTable/DisplayTableUtils.js
@@ -373,6 +373,8 @@ export const SelectPage = ({
             <div
               className="col-12 d-flex justify-content-center"
               style={{ flexWrap: "wrap" }}
+              role="tablist"
+              aria-label={text_maker("table_pagination")}
             >
               {_.map(page_options, (page_num, index) => (
                 <button

--- a/client/src/rpb/granular_view.js
+++ b/client/src/rpb/granular_view.js
@@ -148,39 +148,36 @@ class GranularView extends React.Component {
 
     const dropdown_content = (
       <div className="group_filter_dropdown">
-        {_.map(groupings, (current_grouping) => (
-          <div style={{ marginBottom: 10 }} key={`${current_grouping}-div`}>
-            <div>
-              <input
-                type={"radio"}
-                id={current_grouping}
-                name={"rpb_group_filter"}
-                key={current_grouping}
-                onClick={() => {
-                  on_set_grouping({
-                    grouping: current_grouping,
-                  });
-                }}
-                defaultChecked={current_grouping === grouping}
-              />
-              <label
-                htmlFor={current_grouping}
-                className={"normal-radio-btn-label"}
-                key={`${current_grouping}-radio-btn-label`}
-              >
-                {current_grouping === "default" ||
-                !_.find(sorted_key_columns, ["nick", current_grouping])
-                  ? text_maker(current_grouping)
-                  : current_grouping === "dept"
-                  ? text_maker("org")
-                  : _.find(sorted_key_columns, ["nick", current_grouping])
-                      .header[lang] ||
-                    _.find(sorted_key_columns, ["nick", current_grouping])
-                      .header["en"]}
-              </label>
+        {_.map(groupings, (current_grouping) => {
+          const group_id = `rpb_group_filter_${current_grouping}`;
+          return (
+            <div style={{ marginBottom: 10 }} key={`${current_grouping}-div`}>
+              <div>
+                <input
+                  id={group_id}
+                  type={"radio"}
+                  onClick={() => {
+                    on_set_grouping({
+                      grouping: current_grouping,
+                    });
+                  }}
+                  defaultChecked={current_grouping === grouping}
+                />
+                <label htmlFor={group_id} className={"normal-radio-btn-label"}>
+                  {current_grouping === "default" ||
+                  !_.find(sorted_key_columns, ["nick", current_grouping])
+                    ? text_maker(current_grouping)
+                    : current_grouping === "dept"
+                    ? text_maker("org")
+                    : _.find(sorted_key_columns, ["nick", current_grouping])
+                        .header[lang] ||
+                      _.find(sorted_key_columns, ["nick", current_grouping])
+                        .header["en"]}
+                </label>
+              </div>
             </div>
-          </div>
-        ))}
+          );
+        })}
       </div>
     );
 

--- a/client/src/rpb/granular_view.js
+++ b/client/src/rpb/granular_view.js
@@ -43,11 +43,7 @@ class GranularView extends React.Component {
         </LabeledBox>
 
         {table.rpb_banner && <AlertBanner>{table.rpb_banner}</AlertBanner>}
-        <div
-          role="main"
-          aria-label={text_maker("main_rpb_content")}
-          id="rpb-main-content"
-        >
+        <div aria-label={text_maker("main_rpb_content")} id="rpb-main-content">
           {this.get_table_content()}
         </div>
       </div>


### PR DESCRIPTION
RPB route load test config was using an out of date link, was falling back to the table picker instead of rendering an actual report view. Meant the Axe issues on the actual reports were overlooked too.

TODO:
 - [x] fix RPB report route test config
 - [x] fix axe issues
 - [x] open follow up issue about expanding the tested Axe impacts to include serious and moderate (maybe minor too). I think the main gotcha with that is a lot of false positives on colour contrast? TBC
   - opened as #1342