### PR TITLE
PA 2021

### DIFF
--- a/client/src/InfoBase/App.js
+++ b/client/src/InfoBase/App.js
@@ -225,10 +225,7 @@ export class App extends React.Component {
                 path="/start"
                 render={() => (is_a11y_mode ? <A11yHome /> : <Home />)}
               />
-              <Route
-                path="/"
-                render={() => (is_a11y_mode ? <A11yHome /> : <Home />)}
-              />
+              <Redirect from="/" to="/start" />
             </Switch>
             <PageDetails
               showSurvey={showSurvey}

--- a/client/src/common_text/template_globals.yaml
+++ b/client/src/common_text/template_globals.yaml
@@ -18,6 +18,11 @@ pa_last_year_5:
   en: 2016-17
   fr: 2016-2017
 
+# should always be in-sync with pa_last_year?
+pa_last_year_planned:
+  en: 2020-21
+  fr: 2020-2021
+
 tp_region_last_year:
   en: 2019-20
   fr: 2019-2020
@@ -56,9 +61,7 @@ est_last_year_5:
   en: 2016-17
   fr: 2016-2017
 
-pa_last_year_planned:
-  en: 2019-20
-  fr: 2019-2020
+
 
 planning_year_1:
   en: 2021-22

--- a/client/src/common_text/template_globals.yaml
+++ b/client/src/common_text/template_globals.yaml
@@ -3,20 +3,20 @@ current_fiscal_year:
   fr: 2021-2022
 
 pa_last_year:
+  en: 2020-21
+  fr: 2020-2021
+pa_last_year_2:
   en: 2019-20
   fr: 2019-2020
-pa_last_year_2:
+pa_last_year_3:
   en: 2018-19
   fr: 2018-2019
-pa_last_year_3:
+pa_last_year_4:
   en: 2017-18
   fr: 2017-2018
-pa_last_year_4:
+pa_last_year_5:
   en: 2016-17
   fr: 2016-2017
-pa_last_year_5:
-  en: 2015-16
-  fr: 2015-2016
 
 tp_region_last_year:
   en: 2019-20

--- a/client/src/core/NavComponents.js
+++ b/client/src/core/NavComponents.js
@@ -4,7 +4,10 @@ import ReactDOM from "react-dom";
 import { withRouter } from "react-router";
 
 import { AlertBanner } from "src/components/AlertBanner/AlertBanner";
+import { MultiColumnList } from "src/components/misc_util_components";
 
+import { PRE_DRR_PUBLIC_ACCOUNTS_LATE_FTE_MOCK_DOC } from "src/models/footnotes/dynamic_footnotes";
+import { Dept } from "src/models/subjects";
 import { trivial_text_maker } from "src/models/text";
 
 import { lang, is_a11y_mode } from "src/core/injected_build_constants";
@@ -146,6 +149,44 @@ const HeaderBanner = withRouter(
   }
 );
 
+const TemporaryPublicAccountsBanner = () => {
+  const route_filter = (match, history) =>
+    /^\/(start|tag-explorer|treemap|rpb)/.test(match.path);
+
+  const late_orgs =
+    PRE_DRR_PUBLIC_ACCOUNTS_LATE_FTE_MOCK_DOC.late_resources_orgs;
+  const column_count = late_orgs.length > 3 ? 3 : 2;
+  const li_class = column_count > 2 ? "font-small" : "";
+
+  const banner_content = (
+    <Fragment>
+      {
+        {
+          en: "The latest actual FTE values do not include values from the organizations listed below, as their data is not yet available. Updates will follow.",
+          fr: "Dépenses planifiées des organisations ci-dessous ne sont pas encore disponibles. Des mises à jour suivront au fur et à mesure de la transmission de ces données.",
+        }[lang]
+      }
+      <MultiColumnList
+        list_items={_.map(
+          late_orgs,
+          (org_id) => Dept.store.lookup(org_id).name
+        )}
+        column_count={column_count}
+        li_class={li_class}
+      />
+    </Fragment>
+  );
+
+  return (
+    <HeaderBanner
+      route_filter={route_filter}
+      banner_content={banner_content}
+      banner_class="warning"
+      additional_class_names="medium-panel-text"
+    />
+  );
+};
+
 export class StandardRouteContainer extends React.Component {
   componentDidMount() {
     //unless a route's component is sufficiently complicated, it should never unmount/remount a StandardRouteContainer
@@ -169,6 +210,7 @@ export class StandardRouteContainer extends React.Component {
         <DocumentDescription description_str={description} />
         <BreadCrumbs crumbs={breadcrumbs} />
         <HeaderBanner route_filter={_.constant(false)} />
+        <TemporaryPublicAccountsBanner />
         <AnalyticsSynchronizer route_key={route_key} />
         {shouldSyncLang !== false && <LangSynchronizer />}
         {!is_a11y_mode && (

--- a/client/src/home/home-data.js
+++ b/client/src/home/home-data.js
@@ -73,6 +73,21 @@ const featured_content_items = _.compact([
     is_new: "true",
   },
   {
+    text_key: "quick_link_gov_spending",
+    href: "#infographic/gov/gov/financial/.-.-(panel_key.-.-'welcome_mat)",
+    is_new: "true",
+  },
+  {
+    text_key: "quick_link_spending_by_program",
+    href: "#treemap/drf/spending/All/pa_last_year",
+    is_new: "true",
+  },
+  {
+    text_key: "quick_link_ftes_by_program",
+    href: "#treemap/drf_ftes/ftes/All/pa_last_year",
+    is_new: "true",
+  },
+  {
     text_key: "quick_link_service_inventory_2019",
     href: "#infographic/gov/gov/services/.-.-(panel_key.-.-'services_intro)",
     is_new: "true",
@@ -95,16 +110,8 @@ const featured_content_items = _.compact([
     href: "#infographic/gov/gov/results/.-.-(panel_key.-.-'gov_dp)",
   },
   {
-    text_key: "quick_link_main_estimates",
-    href: "#rpb/.-.-(table.-.-'orgVoteStatEstimates.-.-subject.-.-'gov_gov.-.-columns.-.-(.-.-'*7b*7best_last_year_4*7d*7d_estimates.-.-'*7b*7best_last_year_3*7d*7d_estimates.-.-'*7b*7best_last_year_2*7d*7d_estimates.-.-'*7b*7best_last_year*7d*7d_estimates.-.-'*7b*7best_in_year*7d*7d_estimates))",
-  },
-  {
     text_key: "quick_link_DRR_1920",
     href: "#infographic/gov/gov/results/.-.-(panel_key.-.-'gov_drr)",
-  },
-  {
-    text_key: "quick_link_gov_spending",
-    href: "#infographic/gov/gov/financial/.-.-(panel_key.-.-'welcome_mat)",
   },
   {
     text_key: "quick_link_tp_by_region",

--- a/client/src/home/home.yaml
+++ b/client/src/home/home.yaml
@@ -129,8 +129,8 @@ quick_link_auth_and_exp:
   fr: Autorisations et dépenses de 2017-2018
 
 quick_link_gov_spending:
-  en: 2019-20 Government Spending
-  fr: Dépenses du gouvernement de 2019-2020
+  en: 2020-21 Government Spending
+  fr: Dépenses du gouvernement de 2020-2021
 
 quick_link_tp_by_region:
   en: Transfer payments by recipient region
@@ -139,3 +139,11 @@ quick_link_tp_by_region:
 quick_link_service_inventory_2019:
   en: 2019-20 Service Inventory
   fr: Répertoire des services 2019-2020 
+
+quick_link_spending_by_program:
+  en: 2020-21 Spending by Program
+  fr: Dépenses par Programme de 2020-2021
+
+quick_link_ftes_by_program:
+  en: 2020-21 Full-Time Equivalents (FTEs) by Program
+  fr: Équivalents temps plein (ETP) par programme de 2020-2021

--- a/client/src/models/footnotes/dynamic_footnotes.ts
+++ b/client/src/models/footnotes/dynamic_footnotes.ts
@@ -21,8 +21,8 @@ const text_maker = create_text_maker(text);
 export const PRE_DRR_PUBLIC_ACCOUNTS_LATE_FTE_MOCK_DOC = {
   doc_type: "drr",
   year: run_template("{{pa_last_year}}"),
-  late_results_orgs: [],
-  late_resources_orgs: [],
+  late_results_orgs: [] as string[],
+  late_resources_orgs: [] as string[],
 };
 
 const expand_dept_cr_and_programs = (dept: InstanceType<typeof Dept>) => [

--- a/client/src/models/footnotes/dynamic_footnotes.ts
+++ b/client/src/models/footnotes/dynamic_footnotes.ts
@@ -22,15 +22,7 @@ export const PRE_DRR_PUBLIC_ACCOUNTS_LATE_FTE_MOCK_DOC = {
   doc_type: "drr",
   year: run_template("{{pa_last_year}}"),
   late_results_orgs: [] as string[],
-  late_resources_orgs: [
-    "118",
-    "124",
-    "133",
-    "151",
-    "278",
-    "295",
-    "350",
-  ] as string[],
+  late_resources_orgs: ["118", "133", "151", "278", "295", "350"] as string[],
 };
 
 const expand_dept_cr_and_programs = (dept: InstanceType<typeof Dept>) => [

--- a/client/src/models/footnotes/dynamic_footnotes.ts
+++ b/client/src/models/footnotes/dynamic_footnotes.ts
@@ -22,7 +22,15 @@ export const PRE_DRR_PUBLIC_ACCOUNTS_LATE_FTE_MOCK_DOC = {
   doc_type: "drr",
   year: run_template("{{pa_last_year}}"),
   late_results_orgs: [] as string[],
-  late_resources_orgs: [] as string[],
+  late_resources_orgs: [
+    "118",
+    "124",
+    "133",
+    "151",
+    "278",
+    "295",
+    "350",
+  ] as string[],
 };
 
 const expand_dept_cr_and_programs = (dept: InstanceType<typeof Dept>) => [

--- a/client/src/models/populate_initial_stores_from_lookups.ts
+++ b/client/src/models/populate_initial_stores_from_lookups.ts
@@ -27,10 +27,6 @@ export const populate_initial_stores_from_lookups = () =>
         [x: string]: string;
       } = JSON.parse(text);
 
-      // outlier for lookups json, a calculated output of the build base script, not a directly stringified csv. Either way,
-      // not processed the same as the rest, handled by footnote code
-      populate_global_footnotes(global_footnotes);
-
       const {
         glossary,
         faq,
@@ -71,6 +67,11 @@ export const populate_initial_stores_from_lookups = () =>
         program_tags,
         tags_to_programs
       );
+
+      // outlier for lookups json, a calculated output of the build base script, not a directly stringified csv. Either way,
+      // not processed the same as the rest, handled by footnote code
+      // Populate last, dynamic run-time footnotes may require Subjects to already be populated
+      populate_global_footnotes(global_footnotes);
     });
 
 // TODO, work with pipeline to clean up the headers in igoc_en.csv etc some time, strip the unwanted _en/_fr instances

--- a/client/src/models/results/results.js
+++ b/client/src/models/results/results.js
@@ -351,7 +351,7 @@ const build_doc_info_objects = (doc_type, docs) =>
 const drr_docs = build_doc_info_objects("drr", [
   {
     year_short: "2018",
-    resource_years: ["{{pa_last_year_2}}"],
+    resource_years: ["{{pa_last_year_3}}"],
     doc_url_en:
       "https://www.canada.ca/en/treasury-board-secretariat/services/departmental-performance-reports/2018-19-departmental-results-reports.html",
     doc_url_fr:
@@ -361,7 +361,7 @@ const drr_docs = build_doc_info_objects("drr", [
   },
   {
     year_short: "2019",
-    resource_years: ["{{pa_last_year}}"],
+    resource_years: ["{{pa_last_year_2}}"],
     doc_url_en:
       "https://www.canada.ca/en/treasury-board-secretariat/services/departmental-performance-reports/2019-20-departmental-results-reports.html",
     doc_url_fr:

--- a/client/src/panels/panel_declarations/finances/planned_actual_comparison/planned_actual_comparison.js
+++ b/client/src/panels/panel_declarations/finances/planned_actual_comparison/planned_actual_comparison.js
@@ -6,6 +6,7 @@ import { TextPanel } from "src/panels/panel_declarations/InfographicPanel";
 
 import { create_text_maker_component } from "src/components/index";
 
+import { PRE_DRR_PUBLIC_ACCOUNTS_LATE_FTE_MOCK_DOC } from "src/models/footnotes/dynamic_footnotes";
 import { get_footnotes_by_subject_and_topic } from "src/models/footnotes/footnotes";
 
 import { get_source_links } from "src/metadata/data_sources";
@@ -26,11 +27,25 @@ export const declare_planned_actual_comparison_panel = () =>
       source: (subject) => get_source_links(["DP", "DRR", "PA"]),
       calculate(subject) {
         if (subject.subject_type === "dept") {
-          if (!subject.is_dp_org) {
+          if (
+            !subject.is_dp_org ||
+            _.includes(
+              PRE_DRR_PUBLIC_ACCOUNTS_LATE_FTE_MOCK_DOC.late_resources_orgs,
+              subject.id
+            )
+          ) {
             return false;
           }
-        } else if (!subject.dept.is_dp_org) {
-          return false;
+        } else {
+          if (
+            !subject.dept.is_dp_org ||
+            _.includes(
+              PRE_DRR_PUBLIC_ACCOUNTS_LATE_FTE_MOCK_DOC.late_resources_orgs,
+              subject.dept.id
+            )
+          ) {
+            return false;
+          }
         }
 
         const { programSpending, programFtes } = this.tables;


### PR DESCRIPTION
TODO:
  - [x] roll years forward
  - [x] update featured content links
  - [x] dust off dynamic footnotes
  - [x] disable the planned_actual_comparison panel for departments with late FTEs
    - pipeline will output 0's for the pa_last_year_planned FTE _and_ spending columns for late depts, even if that's inaccurate (related to the unsubmitted departments not having a submission flag or something, probably the assumption that they've died in that case). To be sorted out with the pipeline at a later date 
      - [ ] do a quick check with the actual data, may be fine to re-enable this panel. Pipeline's been updated to properly capture the pa_last_year_planned spending for late departments, so it should still be usable (it'll just not include the FTE comparison for late depts for now, since it drops FTE references when actual FTEs are zero)
  - [ ] [used to](https://github.com/TBS-EACPD/infobase/blob/ab639bc62e342737d4049be102fb25ec5c5d0caa/client/src/core/NavComponents.js#L156) use a hacky temporary `HeaderBanner` in `NavComponents.js` to stick the list of late depts on all the (non-infographic) routes that presented FTEs, bring that back or maybe make it permanent and automatic?
    - [x] for now, bring back the old temporary banner
    - [ ] if time, or after the update, make a DRYer, permanent, solution
  