### PR TITLE
Avoid errors on non-ISO 8859-1 characters in search

### DIFF
--- a/client/src/graphql_utils/graphql_utils.js
+++ b/client/src/graphql_utils/graphql_utils.js
@@ -72,7 +72,7 @@ const query_as_get_with_query_header = async (uri, options) => {
     body: undefined,
     headers: {
       ...options.headers,
-      "gql-query": query,
+      "uri-encoded-gql-query": encodeURIComponent(query),
     },
   };
 
@@ -99,7 +99,12 @@ export function get_client() {
         uri: prod_api_url,
         // the fetchOptions method is overridden to GET by query_as_get_with_query_header for caching, but need BatchHttpLink
         // to think we're using POST for the batching behaviour we want
-        fetchOptions: { method: "POST" },
+        fetchOptions: {
+          method: "POST",
+          headers: {
+            "content-type": "application/json; charset=utf-8",
+          },
+        },
         fetch: query_as_get_with_query_header,
       }),
       cache: new InMemoryCache({

--- a/client/src/graphql_utils/graphql_utils.js
+++ b/client/src/graphql_utils/graphql_utils.js
@@ -101,9 +101,6 @@ export function get_client() {
         // to think we're using POST for the batching behaviour we want
         fetchOptions: {
           method: "POST",
-          headers: {
-            "content-type": "application/json; charset=utf-8",
-          },
         },
         fetch: query_as_get_with_query_header,
       }),

--- a/server/src/app.js
+++ b/server/src/app.js
@@ -32,7 +32,7 @@ app.use(
       "Authorization",
       "Content-Length",
       "X-Requested-With",
-      "gql-query",
+      "uri-encoded-gql-query",
     ],
   })
 );
@@ -44,7 +44,10 @@ app.use(function (req, res, next) {
   // Instead, the client makes a GET with a header containing the query
   // For caching, we also add a hash of the query as a GET parameter
   // Since apollo isn't expecting this type of request, we mutate it to make it look like a normal POST request
-  if (req.method === "GET" && !_.isEmpty(req.headers["gql-query"])) {
+  if (
+    req.method === "GET" &&
+    !_.isEmpty(req.headers["uri-encoded-gql-query"])
+  ) {
     console.log(`Request type: ${req.originalUrl}, GET with query header`);
     convert_GET_with_query_to_POST(req); // mutates req, changes made persist to subsequent middleware
   } else {

--- a/server/src/server_utils.js
+++ b/server/src/server_utils.js
@@ -12,7 +12,7 @@ const quiet_failing_json_parse = (json_string) => {
 // Side effect alert: this function mutates the suplied request object so that the conversion persists to subsequent server midleware
 // ... bit of a hack, and I'm not just talking about a function having side effects
 export const convert_GET_with_query_to_POST = (req) => {
-  const query = req.headers["gql-query"];
+  const query = decodeURIComponent(req.headers["uri-encoded-gql-query"]);
   req.method = "POST";
   req.body = JSON.parse(query);
 };
@@ -53,8 +53,8 @@ export const get_log_objects_for_request = (req) => {
 
   const method =
     req.method === "POST"
-      ? _.has(req.headers, "gql-query")
-        ? "GET with gql-query header, treated as POST"
+      ? _.has(req.headers, "uri-encoded-gql-query")
+        ? "GET with uri-encoded-gql-query header, treated as POST"
         : "POST"
       : req.method;
 

--- a/server/src/server_utils.unit-test.js
+++ b/server/src/server_utils.unit-test.js
@@ -12,11 +12,13 @@ const variable_string = JSON.stringify(variables_val);
 const query_object = [{ query, variables: variable_string }];
 
 describe("convert_GET_with_query_to_POST", function () {
-  it("Mutates a GET with an gql-query header in to a standard POST with the query in its body", () => {
+  it("Mutates a GET with an uri-encoded-gql-query header in to a standard POST with the query in its body", () => {
     const GET_with_compressed_query = {
       method: "GET",
       headers: {
-        "gql-query": JSON.stringify(query_object),
+        "uri-encoded-gql-query": encodeURIComponent(
+          JSON.stringify(query_object)
+        ),
       },
     };
 
@@ -26,7 +28,9 @@ describe("convert_GET_with_query_to_POST", function () {
     const expected_POST = {
       method: "POST",
       headers: {
-        "gql-query": JSON.stringify(query_object),
+        "uri-encoded-gql-query": encodeURIComponent(
+          JSON.stringify(query_object)
+        ),
       },
       body: [
         {
@@ -166,10 +170,12 @@ describe("get_log_objects_for_request", function () {
     const GET_with_compressed_query = {
       method: "GET",
       headers: {
-        "gql-query": JSON.stringify({
-          query,
-          variables: variables_val,
-        }),
+        "uri-encoded-gql-query": encodeURIComponent(
+          JSON.stringify({
+            query,
+            variables: variables_val,
+          })
+        ),
         origin: "test",
       },
     };
@@ -188,7 +194,7 @@ describe("get_log_objects_for_request", function () {
 
     // should be the only difference between this and the regular POST case
     expect(log_object.method).toEqual(
-      "GET with gql-query header, treated as POST"
+      "GET with uri-encoded-gql-query header, treated as POST"
     );
   });
 });


### PR DESCRIPTION
We'd been seeing this occasionally in the logs since the service inventory searching was deployed. I believe it was previously misread as a failure to parse the _response_'s header, but it was actually an error thrown inside the apollo client while parsing the request before it even sent.

E.g. searching this crashes the client "Ḃ, ḃ, Ċ, ċ, Ḋ, ḋ, Ḟ, ḟ, Ġ, ġ, Ṁ, ṁ, Ṗ, ṗ, Ṡ, ṡ, Ṫ, ṫ"

As far as I can tell, everything involved _should_ be able to handle UTF-8 characters, worth looking in to this a bit more (potentially open an issue with apollo-client if I can recreate in a test project, without any of the monkey business we're up to here).

Patching around this by URI encoding the hacky query header on the client side, decoding it on the server side.