### PR TITLE
PinnedContent fixes/cleanup

### DIFF
--- a/client/src/components/PinnedContent/PinnedContent.js
+++ b/client/src/components/PinnedContent/PinnedContent.js
@@ -101,11 +101,11 @@ class NonA11yPinnedContent extends React.Component {
               {/* height resize dectector to sync the height of the content with the height of a placeholder div used,
               when the content is floating, to prevent the page content from shifting when the content catches/uncatches 
               on the initial location */}
-              <ReactResizeDetector handleHeight refreshMode="debounce">
+              <ReactResizeDetector handleHeight refreshMode="throttle">
                 {({ targetRef: contentRef }) => (
                   /* width resize dectector to sync the content's width with the width given to it's original rendering context
                   (grabbed from the placeholder), so that it stays consistent when transitioning to a fixed position*/
-                  <ReactResizeDetector handleWidth refreshMode="debounce">
+                  <ReactResizeDetector handleWidth refreshMode="throttle">
                     {({ targetRef: placeHolderRef }) => (
                       <>
                         <div

--- a/client/src/components/PinnedContent/PinnedContent.js
+++ b/client/src/components/PinnedContent/PinnedContent.js
@@ -87,7 +87,8 @@ class _PinnedContent extends React.Component {
 
           return (
             <div ref={ref}>
-              <ReactResizeDetector handleHeight>
+              {/* height resize detector to sync pinned content height with a placeholder div that's used, when pinned, to keep the page content from shifting */}
+              <ReactResizeDetector handleHeight refreshMode="debounce">
                 {({ targetRef }) => (
                   <>
                     {should_pin && (

--- a/client/src/components/PinnedContent/PinnedContent.js
+++ b/client/src/components/PinnedContent/PinnedContent.js
@@ -98,65 +98,80 @@ class NonA11yPinnedContent extends React.Component {
 
           return (
             <div ref={ref}>
-              {/* height resize detector to sync pinned content height with a placeholder div that's used, when pinned, to keep the page content from shifting */}
+              {/* height resize dectector to sync the height of the content with the height of a placeholder div used,
+              when the content is floating, to prevent the page content from shifting when the content catches/uncatches 
+              on the initial location */}
               <ReactResizeDetector handleHeight refreshMode="debounce">
-                {({ targetRef }) => (
-                  <>
-                    {should_pin && (
-                      <div style={{ height: targetRef.current.offsetHeight }} />
-                    )}
-                    <div
-                      ref={targetRef}
-                      style={{
-                        ...(should_pin && {
-                          position: "fixed",
-                          top: 0,
-                          zIndex: 2001,
-                        }),
-                      }}
-                    >
-                      <div style={{ position: "relative" }}>
-                        {children}
+                {({ targetRef: contentRef }) => (
+                  /* width resize dectector to sync the content's width with the width given to it's original rendering context
+                  (grabbed from the placeholder), so that it stays consistent when transitioning to a fixed position*/
+                  <ReactResizeDetector handleWidth refreshMode="debounce">
+                    {({ targetRef: placeHolderRef }) => (
+                      <>
                         <div
+                          ref={placeHolderRef}
                           style={{
-                            position: "absolute",
-                            top: "1rem",
-                            right: "1rem",
+                            width: "100%",
+                            height: should_pin
+                              ? contentRef.current?.offsetHeight
+                              : "0px",
+                          }}
+                        />
+                        <div
+                          ref={contentRef}
+                          style={{
+                            width: placeHolderRef.current?.offsetWidth,
+                            ...(should_pin && {
+                              position: "fixed",
+                              top: 0,
+                              zIndex: 2001,
+                            }),
                           }}
                         >
-                          <button
-                            onClick={this.click_pin}
-                            onKeyDown={this.tab_over_pin}
-                            style={{
-                              background: "none",
-                              border: "none",
-                            }}
-                            aria-label={text_maker(
-                              !this.is_pinned ? "pin" : "unpin"
-                            )}
-                          >
-                            {!this.is_pinned ? (
-                              <IconPin
-                                height="25px"
-                                width="25px"
-                                svg_style={{ verticalAlign: "Top" }}
-                                color={backgroundColor}
-                                alternate_color="false"
-                              />
-                            ) : (
-                              <IconUnpin
-                                height="25px"
-                                width="25px"
-                                svg_style={{ verticalAlign: "Top" }}
-                                color={backgroundColor}
-                                alternate_color="false"
-                              />
-                            )}
-                          </button>
+                          <div style={{ position: "relative" }}>
+                            {children}
+                            <div
+                              style={{
+                                position: "absolute",
+                                top: "1rem",
+                                right: "1rem",
+                              }}
+                            >
+                              <button
+                                onClick={this.click_pin}
+                                onKeyDown={this.tab_over_pin}
+                                style={{
+                                  background: "none",
+                                  border: "none",
+                                }}
+                                aria-label={text_maker(
+                                  !this.is_pinned ? "pin" : "unpin"
+                                )}
+                              >
+                                {!this.is_pinned ? (
+                                  <IconPin
+                                    height="25px"
+                                    width="25px"
+                                    svg_style={{ verticalAlign: "Top" }}
+                                    color={backgroundColor}
+                                    alternate_color="false"
+                                  />
+                                ) : (
+                                  <IconUnpin
+                                    height="25px"
+                                    width="25px"
+                                    svg_style={{ verticalAlign: "Top" }}
+                                    color={backgroundColor}
+                                    alternate_color="false"
+                                  />
+                                )}
+                              </button>
+                            </div>
+                          </div>
                         </div>
-                      </div>
-                    </div>
-                  </>
+                      </>
+                    )}
+                  </ReactResizeDetector>
                 )}
               </ReactResizeDetector>
             </div>

--- a/client/src/components/PinnedContent/PinnedContent.js
+++ b/client/src/components/PinnedContent/PinnedContent.js
@@ -55,129 +55,106 @@ class _PinnedContent extends React.Component {
         : default_pin_state;
     }
   }
+
   set_is_pinned = (is_pinned) => {
     set_pinned_content_local_storage(this.props.local_storage_name, is_pinned);
     this.setState({ is_pinned_local_storage_mirror: is_pinned });
   };
-
   pin_pressed = () => {
     this.set_is_pinned(!this.is_pinned);
-
-    this.setState({
-      content_height: 0,
-    });
   };
-
   handleKeyDown = (e) => {
     if (e.key === "Tab") {
       this.set_is_pinned(false);
     }
   };
 
-  update_content_height = _.debounce(() => {
-    this.setState({
-      content_height: this.content_ref.current.clientHeight,
-    });
-  }, this.props.height_update_delay);
-
   componentDidMount() {
     this.set_is_pinned(this.is_pinned);
-    this.update_content_height();
-  }
-
-  componentWillUnmount() {
-    this.update_content_height.cancel();
   }
 
   render() {
-    const { content_height } = this.state;
     const { children } = this.props;
 
     return (
-      <ReactResizeDetector handleWidth>
-        {({ width }) => (
-          <InView>
-            {({ inView, ref, entry }) => {
-              const should_pin =
-                this.is_pinned &&
-                !inView &&
-                entry &&
-                entry.boundingClientRect.top < 0;
+      <InView>
+        {({ inView, ref, entry }) => {
+          const should_pin =
+            this.is_pinned &&
+            !inView &&
+            entry &&
+            entry.boundingClientRect.top < 0;
 
-              return (
-                <div ref={ref}>
-                  {/* 
-                    this conditional div with height height: content_height acts as a placeholder to make scrolling
-                    smoother. Before adding this, stickying by "position: fixed" would take it out of the DOM block
-                    flow which would bump up the window due to the total block content being shortened.
-                    By adding this placeholder div, the height of the total block content remains the same,
-                    thus no longer causing the window to jump
-                  */}
-                  {should_pin && <div style={{ height: content_height }} />}
-                  {/* this div is for sticky styline, must be flex to include margins onto height */}
-                  <div
-                    style={{
-                      display: "flex",
-                      ...(should_pin && {
-                        position: "fixed",
-                        top: 0,
-                        zIndex: 2001,
-                      }),
-                    }}
-                    ref={this.content_ref}
-                  >
-                    <div style={{ position: "relative", width: width }}>
-                      {children}
-                      <div
-                        style={{
-                          position: "absolute",
-                          top: "1rem",
-                          right: "1rem",
-                        }}
-                      >
-                        <button
-                          onClick={this.pin_pressed}
+          return (
+            <div ref={ref}>
+              <ReactResizeDetector handleHeight>
+                {({ targetRef }) => (
+                  <>
+                    {should_pin && (
+                      <div style={{ height: targetRef.current.offsetHeight }} />
+                    )}
+                    <div
+                      style={{
+                        ...(should_pin && {
+                          position: "fixed",
+                          top: 0,
+                          zIndex: 2001,
+                        }),
+                      }}
+                      ref={targetRef}
+                    >
+                      <div style={{ position: "relative" }}>
+                        {children}
+                        <div
                           style={{
-                            background: "none",
-                            border: "none",
+                            position: "absolute",
+                            top: "1rem",
+                            right: "1rem",
                           }}
-                          aria-label={text_maker(
-                            !this.is_pinned ? "pin" : "unpin"
-                          )}
-                          onKeyDown={this.handleKeyDown}
                         >
-                          {!this.is_pinned ? (
-                            <IconPin
-                              height="25px"
-                              width="25px"
-                              svg_style={{ verticalAlign: "Top" }}
-                              color={backgroundColor}
-                              alternate_color="false"
-                            />
-                          ) : (
-                            <IconUnpin
-                              height="25px"
-                              width="25px"
-                              svg_style={{ verticalAlign: "Top" }}
-                              color={backgroundColor}
-                              alternate_color="false"
-                            />
-                          )}
-                        </button>
+                          <button
+                            onClick={this.pin_pressed}
+                            style={{
+                              background: "none",
+                              border: "none",
+                            }}
+                            aria-label={text_maker(
+                              !this.is_pinned ? "pin" : "unpin"
+                            )}
+                            onKeyDown={this.handleKeyDown}
+                          >
+                            {!this.is_pinned ? (
+                              <IconPin
+                                height="25px"
+                                width="25px"
+                                svg_style={{ verticalAlign: "Top" }}
+                                color={backgroundColor}
+                                alternate_color="false"
+                              />
+                            ) : (
+                              <IconUnpin
+                                height="25px"
+                                width="25px"
+                                svg_style={{ verticalAlign: "Top" }}
+                                color={backgroundColor}
+                                alternate_color="false"
+                              />
+                            )}
+                          </button>
+                        </div>
                       </div>
                     </div>
-                  </div>
-                </div>
-              );
-            }}
-          </InView>
-        )}
-      </ReactResizeDetector>
+                  </>
+                )}
+              </ReactResizeDetector>
+            </div>
+          );
+        }}
+      </InView>
     );
   }
 }
 _PinnedContent.defaultProps = {
-  height_update_delay: 1000,
   default_pin_state: has_local_storage,
 };
 


### PR DESCRIPTION
Found a real ugly bug with the PinnedContent, specifically with the FAQs on a route like the estimates comparison where it's initial state is open. The catch region placeholder only got it's height synced with the pinned content on mount, so if the content started tall and then got smaller (e.g. collapsing the FAQ drawer) the difference in height with the placeholder would create a dangerous region; scrolling up in to the placeholder and stopping within the difference between the two would cause the component to rapidly re-render, between being caught and un-caught. 

Cleaned up the component somewhat, and reworked the placeholder node's management to properly sync to the content (and vice versa, because the content, when floating, needs to get width from the place holder, haha).