### PR TITLE
Upgrade client to TS 4.6 (trivial)

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -110,7 +110,6 @@
         "@typescript-eslint/parser": "^5.8",
         "axe-core": "^4.3.1",
         "babel-loader": "^8.1.0",
-        "babel-plugin-istanbul": "^6.1.1",
         "bundle-stats-webpack-plugin": "^3.2.0",
         "circular-dependency-plugin": "^5.2.2",
         "css-loader": "^6.0.0",
@@ -145,7 +144,7 @@
         "sass-loader": "^12.0.0",
         "script-loader": "^0.7.0",
         "style-loader": "^3.3.0",
-        "typescript": "^4.5",
+        "typescript": "^4.6",
         "webpack": "^5.9.0",
         "webpack-retry-chunk-load-plugin": "^2.2.0"
       },
@@ -18757,9 +18756,10 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.5.4",
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.2.tgz",
+      "integrity": "sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==",
       "dev": true,
-      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -32627,7 +32627,9 @@
       }
     },
     "typescript": {
-      "version": "4.5.4",
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.2.tgz",
+      "integrity": "sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==",
       "dev": true
     },
     "uglify-js": {

--- a/client/package.json
+++ b/client/package.json
@@ -157,7 +157,7 @@
     "sass-loader": "^12.0.0",
     "script-loader": "^0.7.0",
     "style-loader": "^3.3.0",
-    "typescript": "^4.5",
+    "typescript": "^4.6",
     "webpack": "^5.9.0",
     "webpack-retry-chunk-load-plugin": "^2.2.0"
   },


### PR DESCRIPTION
[TS 4.6](https://devblogs.microsoft.com/typescript/announcing-typescript-4-6/) is out. Not effected by the breaking changes, no action to take on the improvements/new features. Don't review this PR itself, it's trivial, instead I'd like extra eyes on the release blog post to double check that I didn't miss something non-trivial that we could/should do along side this update.

I feel like the [improved indexed access inference](https://devblogs.microsoft.com/typescript/announcing-typescript-4-6/#indexed-access-inference-improvements) is something that we've had to work around in the past, but not remembering concrete examples and probably not worth trying to find and clean them up right now. Nice that it's there though!