### PR TITLE
Allow nulls as empties in sort utils functions

### DIFF
--- a/client/src/sort_utils.ts
+++ b/client/src/sort_utils.ts
@@ -2,18 +2,22 @@ import _ from "lodash";
 
 type SortComparator = 1 | 0 | -1;
 
-export const wrap_sort_with_undefined_handling = <T>(
-  a: T | undefined,
-  b: T | undefined,
+type EmptyValue = undefined | null;
+const is_empty = <T>(value: T | EmptyValue): value is EmptyValue =>
+  typeof value === "undefined" || value === null;
+
+export const wrap_sort_with_empty_handling = <T>(
+  a: T | EmptyValue,
+  b: T | EmptyValue,
   sort_func: (a: T, b: T) => SortComparator
 ): SortComparator => {
-  if (typeof a !== "undefined" && typeof b !== "undefined") {
+  if (!is_empty(a) && !is_empty(b)) {
     return sort_func(a, b);
   }
 
-  if (typeof a === "undefined" && typeof b !== "undefined") {
+  if (is_empty(a) && !is_empty(b)) {
     return -1;
-  } else if (typeof a !== "undefined" && typeof b === "undefined") {
+  } else if (!is_empty(a) && is_empty(b)) {
     return 1;
   }
   return 0;
@@ -28,10 +32,10 @@ export const wrap_sort_with_direction = <T>(
 const get_plain_string = (string: string) =>
   _.chain(string).deburr().lowerCase().value();
 export const string_sort_func = (
-  a: string | undefined,
-  b: string | undefined
+  a: string | EmptyValue,
+  b: string | EmptyValue
 ) =>
-  wrap_sort_with_undefined_handling(
+  wrap_sort_with_empty_handling(
     a,
     b,
     (a: string, b: string): SortComparator => {
@@ -49,10 +53,10 @@ export const string_sort_func = (
   );
 
 export const number_sort_func = (
-  a: number | undefined,
-  b: number | undefined
+  a: number | EmptyValue,
+  b: number | EmptyValue
 ) =>
-  wrap_sort_with_undefined_handling(
+  wrap_sort_with_empty_handling(
     a,
     b,
     (a: number, b: number): SortComparator => {
@@ -65,19 +69,19 @@ export const number_sort_func = (
     }
   );
 
-export const smart_sort_func = <T extends number | string | undefined>(
+export const smart_sort_func = <T extends string | number | EmptyValue>(
   a: T,
   b: T,
   reverse = false
 ): SortComparator => {
   if (
-    (typeof a === "string" || typeof a === "undefined") &&
-    (typeof b === "string" || typeof b === "undefined")
+    (typeof a === "string" || is_empty(a)) &&
+    (typeof b === "string" || is_empty(b))
   ) {
     return wrap_sort_with_direction(reverse, string_sort_func)(a, b);
   } else if (
-    (typeof a === "number" || typeof a === "undefined") &&
-    (typeof b === "number" || typeof b === "undefined")
+    (typeof a === "number" || is_empty(a)) &&
+    (typeof b === "number" || is_empty(b))
   ) {
     return wrap_sort_with_direction(reverse, number_sort_func)(a, b);
   } else {

--- a/client/src/sort_utils.unit-test.ts
+++ b/client/src/sort_utils.unit-test.ts
@@ -1,5 +1,5 @@
 import {
-  wrap_sort_with_undefined_handling,
+  wrap_sort_with_empty_handling,
   wrap_sort_with_direction,
   string_sort_func,
   number_sort_func,
@@ -16,18 +16,17 @@ function sort_func(a: number | string, b: number | string): -1 | 0 | 1 {
   }
 }
 
-describe("wrap_sort_with_undefined_handling", () => {
-  it("Sorting function that handles undefined arguments", () => {
-    expect(wrap_sort_with_undefined_handling(3, 10, sort_func)).toBe(-1);
-    expect(wrap_sort_with_undefined_handling(undefined, 10, sort_func)).toBe(
-      -1
+describe("wrap_sort_with_empty_handling", () => {
+  it("Sorting function that handles undefined/null arguments", () => {
+    expect(wrap_sort_with_empty_handling(3, 10, sort_func)).toBe(-1);
+    expect(wrap_sort_with_empty_handling(undefined, 10, sort_func)).toBe(-1);
+    expect(wrap_sort_with_empty_handling("3", undefined, sort_func)).toBe(1);
+    expect(wrap_sort_with_empty_handling(undefined, undefined, sort_func)).toBe(
+      0
     );
-    expect(wrap_sort_with_undefined_handling("3", undefined, sort_func)).toBe(
-      1
-    );
-    expect(
-      wrap_sort_with_undefined_handling(undefined, undefined, sort_func)
-    ).toBe(0);
+    expect(wrap_sort_with_empty_handling(null, 10, sort_func)).toBe(-1);
+    expect(wrap_sort_with_empty_handling("3", null, sort_func)).toBe(1);
+    expect(wrap_sort_with_empty_handling(null, null, sort_func)).toBe(0);
   });
 });
 
@@ -50,20 +49,26 @@ describe("string_sort_func", () => {
 });
 
 describe("number_sort_func", () => {
-  it("Sorts numbers with undefined handling", () => {
+  it("Sorts numbers with undefined/null handling", () => {
     expect(number_sort_func(3, 10)).toBe(-1);
     expect(number_sort_func(undefined, 10)).toBe(-1);
     expect(number_sort_func(3, undefined)).toBe(1);
     expect(number_sort_func(undefined, undefined)).toBe(0);
+    expect(number_sort_func(null, 10)).toBe(-1);
+    expect(number_sort_func(3, null)).toBe(1);
+    expect(number_sort_func(null, null)).toBe(0);
   });
 });
 
 describe("smart_sort_func", () => {
-  it("Sorting function that handles strings, numbers, and undefined", () => {
+  it("Sorting function that handles strings, numbers, and undefined/null", () => {
     expect(smart_sort_func("hello", "world")).toBe(1);
     expect(smart_sort_func(4, 22)).toBe(-1);
     expect(smart_sort_func(undefined, 10)).toBe(-1);
     expect(smart_sort_func("bbbbbb", undefined)).toBe(1);
     expect(smart_sort_func(undefined, undefined)).toBe(0);
+    expect(smart_sort_func(null, 10)).toBe(-1);
+    expect(smart_sort_func("bbbbbb", null)).toBe(1);
+    expect(smart_sort_func(null, null)).toBe(0);
   });
 });


### PR DESCRIPTION
Previously only handled `undefined`s as allowed empty values. Some consumers of these sort utils (indirectly, via `DisplayTable` defaults) were using `null` values for empty cells, so sorting these tables threw errors. Allowing either is acceptable, and easier for sure than hunting down all the direct/indirect consumers of these utils and trying to standardize on what value an empty cell should use!