### PR TITLE
Move ResizeObserver polyfilling to dynamic_polyfills.ts

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -71,6 +71,7 @@
         "redux-promise-middleware": "^6.1.0",
         "regenerator-runtime": "^0.13.9",
         "reselect": "^3.0.1",
+        "resize-observer": "^1.0.4",
         "string-hash": "^1.1.3",
         "tippy.js": "^6.2.7",
         "tooltip.js": "^1.3.1",
@@ -17342,9 +17343,15 @@
       "version": "3.0.1",
       "license": "MIT"
     },
+    "node_modules/resize-observer": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/resize-observer/-/resize-observer-1.0.4.tgz",
+      "integrity": "sha512-AQ2MdkWTng9d6JtjHvljiQR949qdae91pjSNugGGeOFzKIuLHvoZIYhUTjePla5hCFDwQHrnkciAIzjzdsTZew=="
+    },
     "node_modules/resize-observer-polyfill": {
       "version": "1.5.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
     },
     "node_modules/resolve": {
       "version": "1.20.0",
@@ -31748,8 +31755,15 @@
     "reselect": {
       "version": "3.0.1"
     },
+    "resize-observer": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/resize-observer/-/resize-observer-1.0.4.tgz",
+      "integrity": "sha512-AQ2MdkWTng9d6JtjHvljiQR949qdae91pjSNugGGeOFzKIuLHvoZIYhUTjePla5hCFDwQHrnkciAIzjzdsTZew=="
+    },
     "resize-observer-polyfill": {
-      "version": "1.5.1"
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
     },
     "resolve": {
       "version": "1.20.0",

--- a/client/package.json
+++ b/client/package.json
@@ -84,6 +84,7 @@
     "redux-promise-middleware": "^6.1.0",
     "regenerator-runtime": "^0.13.9",
     "reselect": "^3.0.1",
+    "resize-observer": "^1.0.4",
     "string-hash": "^1.1.3",
     "tippy.js": "^6.2.7",
     "tooltip.js": "^1.3.1",

--- a/client/src/InfoBase/dynamic_polyfills.ts
+++ b/client/src/InfoBase/dynamic_polyfills.ts
@@ -57,6 +57,12 @@ async function intl_numberformat() {
   }
 }
 
+async function resize_observer() {
+  if (!window.ResizeObserver) {
+    import("resize-observer").then(({ install }) => install());
+  }
+}
+
 export const dynamic_polyfills = () =>
   Promise.all([
     dom4(),
@@ -65,4 +71,5 @@ export const dynamic_polyfills = () =>
     intl_locale(),
     intl_pluralrules(),
     intl_numberformat(),
+    resize_observer(),
   ]);

--- a/client/src/components/PinnedContent/PinnedContent.js
+++ b/client/src/components/PinnedContent/PinnedContent.js
@@ -2,7 +2,7 @@ import _ from "lodash";
 import React from "react";
 import { InView } from "react-intersection-observer";
 import "intersection-observer";
-import ReactResizeDetector from "react-resize-detector/build/withPolyfill";
+import ReactResizeDetector from "react-resize-detector";
 
 import { create_text_maker } from "src/models/text";
 

--- a/client/src/components/Typeahead/Typeahead.tsx
+++ b/client/src/components/Typeahead/Typeahead.tsx
@@ -2,7 +2,7 @@ import classNames from "classnames";
 import _ from "lodash";
 import type { ChangeEvent, KeyboardEvent, ReactElement } from "react";
 import React, { Fragment } from "react";
-import ReactResizeDetector from "react-resize-detector/build/withPolyfill";
+import ReactResizeDetector from "react-resize-detector";
 
 import type { List } from "react-virtualized";
 import { AutoSizer, CellMeasurer, CellMeasurerCache } from "react-virtualized";


### PR DESCRIPTION
Polyfilling for `ResizeObserver` is broken in production, testing this as a fix since there's benefits to this approach anyway and it should cover anything (undetermined whether it's the `react-resize-observer` library's built in polyfilling that broke or if some other library has started using it under the hood).