### PR TITLE
Fix Tombstone spilling out of profile panels

### DIFF
--- a/client/src/components/Tombstones/Tombstones.tsx
+++ b/client/src/components/Tombstones/Tombstones.tsx
@@ -24,7 +24,7 @@ interface LabeledTombstoneProps {
 }
 
 const LabeledTombstone = ({ labels_and_items }: LabeledTombstoneProps) => (
-  <dl className="tombstone-data-list">
+  <dl className="col tombstone-data-list">
     {_.map(labels_and_items, ([label, item], ix) => (
       <Fragment key={ix}>
         <div className="row tombstone-data-div">


### PR DESCRIPTION
Very subtle, but see the small grey lines extending out of the panel to the left
![image](https://user-images.githubusercontent.com/11301919/159797823-17f3b6cf-4d47-4a55-b0b3-9db00e7df8e9.png)

Reminder (possibly to my past self, ha): bootstrap rows should only appear as children of bootstrap columns! The rows use negative margins, without the column to offset for them you get misalignment like this.