### PR TITLE
Make survey popup campaigns periodic

### DIFF
--- a/client/src/Survey/SurveyPopup.js
+++ b/client/src/Survey/SurveyPopup.js
@@ -68,7 +68,7 @@ export class SurveyPopup extends React.Component {
 
   handlePopupButtonPress = (button_type) => {
     log_standard_event({
-      SUBAPP: this.props.location.pathname,
+      SUBAPP: window.location.pathname,
       MISC1: "SURVEY_POPUP",
       MISC2: `interaction: ${button_type}`,
     });
@@ -89,12 +89,6 @@ export class SurveyPopup extends React.Component {
     if (!show_popup) {
       return null;
     }
-
-    log_standard_event({
-      SUBAPP: this.props.location.pathname,
-      MISC1: "SURVEY_POPUP",
-      MISC2: "displayed",
-    });
 
     return (
       <FixedPopover

--- a/client/src/Survey/SurveyPopup.js
+++ b/client/src/Survey/SurveyPopup.js
@@ -151,7 +151,13 @@ export class SurveyPopup extends React.Component {
           </Fragment>
         }
         footer={
-          <div style={{ display: "flex", justifyContent: "space-evenly" }}>
+          <div
+            style={{
+              width: "100%",
+              display: "flex",
+              justifyContent: "space-evenly",
+            }}
+          >
             {_.map(["later", "no"], (button_type) => (
               <button
                 key={button_type}

--- a/client/src/Survey/SurveyPopup.js
+++ b/client/src/Survey/SurveyPopup.js
@@ -20,12 +20,11 @@ import text from "./SurveyPopup.yaml";
 
 const { TM, text_maker } = create_text_maker_component(text);
 
+const POSTPONE_TIMEOUT_PERIOD = 1000 * 60 * 60 * 24;
+
 const currentDate = new Date();
 
-const get_path_root = (path) =>
-  _.chain(path).replace(/^\//, "").split("/").first().value();
-
-const is_survey_campaign_ongoing = () => {
+const is_survey_campaign_period = (() => {
   if (is_dev || is_dev_link) {
     return false;
   }
@@ -36,70 +35,47 @@ const is_survey_campaign_ongoing = () => {
   const is_second_half_of_month = currentDate.getDate() > 14;
 
   return is_start_of_trimester && is_second_half_of_month;
-};
+})();
 
 const key_suffix = `--${currentDate.getFullYear()}-${currentDate.getMonth()}`;
+
 const postponed_since_storage_key =
   "infobase_survey_popup_postponed_since" + key_suffix;
+
 const is_deactivated_storage_key =
   "infobase_survey_popup_deactivated" + key_suffix;
-const page_visit_count_storage_key =
-  "infobase_survey_popup_page_visit_count" + key_suffix;
-
-const get_state_defaults = () => {
-  const postponed_since = localStorage.getItem(postponed_since_storage_key);
-  const is_deactivated = localStorage.getItem(is_deactivated_storage_key);
-  const page_visit_count = localStorage.getItem(page_visit_count_storage_key);
-
-  const milliseconds_in_a_day = 1000 * 60 * 60 * 24;
-  const is_currently_postponed = !_.isNull(postponed_since)
-    ? Date.now() - +postponed_since >= milliseconds_in_a_day
-    : false;
-
-  return {
-    active:
-      !is_currently_postponed &&
-      (!_.isNull(is_deactivated) ? is_deactivated !== "true" : true),
-    page_visit_count: !_.isNull(page_visit_count) ? +page_visit_count : 1,
-  };
-};
 
 export const SurveyPopup = withRouter(
   class _SurveyPopup extends React.Component {
     constructor(props) {
       super(props);
 
-      props.history.listen(({ pathname }) => {
-        if (
-          this.state.active &&
-          this.state.previous_path_root !== get_path_root(pathname)
-        ) {
-          const new_page_visit_count = this.state.page_visit_count + 1;
+      const is_deactivated_storage_value = localStorage.getItem(
+        is_deactivated_storage_key
+      );
+      const is_deactivated_by_user = is_deactivated_storage_value === "true";
 
-          localStorage.setItem(
-            page_visit_count_storage_key,
-            new_page_visit_count
-          );
+      const postponed_since_storage_value = localStorage.getItem(
+        postponed_since_storage_key
+      );
+      const is_postponed_by_user = !_.isNull(postponed_since_storage_value)
+        ? Date.now() - +postponed_since_storage_value >= POSTPONE_TIMEOUT_PERIOD
+        : false;
 
-          this.setState({
-            page_visit_count: new_page_visit_count,
-            previous_path_root: get_path_root(pathname),
-          });
-        }
-      });
-
-      const { active, page_visit_count } = get_state_defaults();
+      const is_active =
+        is_survey_campaign_period &&
+        !is_postponed_by_user &&
+        !is_deactivated_by_user;
 
       this.state = {
-        active: active,
-        page_visit_count: page_visit_count,
-        previous_path_root: null,
+        is_active,
+        landing_page: props.location.pathname,
       };
     }
 
-    handleButtonPress = (button_type) => {
+    handlePopupButtonPress = (button_type) => {
       log_standard_event({
-        SUBAPP: window.location.hash.replace("#", "") || "start",
+        SUBAPP: this.props.location.pathname,
         MISC1: "SURVEY_POPUP",
         MISC2: `interaction: ${button_type}`,
       });
@@ -107,121 +83,106 @@ export const SurveyPopup = withRouter(
       if (_.includes(["yes", "no", "short_survey_submitted"], button_type)) {
         localStorage.setItem(is_deactivated_storage_key, "true");
       } else if (button_type === "later") {
+        localStorage.setItem(is_deactivated_storage_key, "false");
         localStorage.setItem(postponed_since_storage_key, Date.now());
       }
 
-      this.setState({ active: false });
+      this.setState({ is_active: false });
     };
 
-    static getDerivedStateFromProps(props) {
-      if (props.showSurvey) {
-        return { active: false };
-      }
-
-      return null;
-    }
-
-    shouldComponentUpdate(_nextProps, nextState) {
-      const page_changed =
-        this.state.page_visit_count !== nextState.page_visit_count;
-      const is_closing = this.state.active !== nextState.active;
-
-      return page_changed || is_closing;
-    }
-
     render() {
-      const { active, page_visit_count } = this.state;
+      const { is_active, landing_page } = this.state;
 
       const should_show =
-        is_survey_campaign_ongoing() && active && page_visit_count >= 4;
+        is_active && this.props.location.pathname !== landing_page;
 
       if (should_show) {
-        clearTimeout(this.timeout);
-        this.timeout = null;
         log_standard_event({
-          SUBAPP: window.location.hash.replace("#", "") || "start",
+          SUBAPP: this.props.location.pathname,
           MISC1: "SURVEY_POPUP",
           MISC2: "displayed",
         });
+
+        return (
+          <FixedPopover
+            show={should_show}
+            title={
+              <Fragment>
+                <IconFeedback
+                  aria_label={text_maker("suvey_popup_header")}
+                  color={tertiaryColor}
+                  alternate_color={false}
+                />
+                {text_maker("suvey_popup_header")}
+              </Fragment>
+            }
+            body={
+              <Fragment>
+                <div
+                  style={{
+                    fontSize: "0.9em",
+                    display: "flex",
+                    flexDirection: "column",
+                  }}
+                >
+                  <TM k="survey_popup_body" />
+                </div>
+                <div
+                  style={{ display: "flex", justifyContent: "space-evenly" }}
+                >
+                  <a
+                    className="link-unstyled btn btn-ib-primary"
+                    onClick={() => this.handlePopupButtonPress("yes")}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    href={"#survey"}
+                  >
+                    {text_maker(`survey_popup_yes`)}
+                  </a>
+                </div>
+                <div
+                  className="mrgn-tp-md"
+                  style={{
+                    fontSize: "0.9em",
+                    display: "flex",
+                    flexDirection: "column",
+                    textAlign: "left",
+                    borderTop: "1px solid #e5e5e5",
+                  }}
+                >
+                  <TM
+                    k="simplified_survey_header"
+                    style={{ alignSelf: "center", fontSize: "1.4em" }}
+                  />
+                  <FormFrontend
+                    template_name="feedback_simplified"
+                    include_privacy={false}
+                    top_border={false}
+                    on_submitted={() =>
+                      this.handlePopupButtonPress("short_survey_submitted")
+                    }
+                  />
+                </div>
+              </Fragment>
+            }
+            footer={
+              <div style={{ display: "flex", justifyContent: "space-evenly" }}>
+                {_.map(["later", "no"], (button_type) => (
+                  <button
+                    key={button_type}
+                    className="btn btn-ib-primary"
+                    onClick={() => this.handlePopupButtonPress(button_type)}
+                  >
+                    {text_maker(`survey_popup_${button_type}`)}
+                  </button>
+                ))}
+              </div>
+            }
+          />
+        );
       } else {
         return null;
       }
-
-      return (
-        <FixedPopover
-          show={should_show}
-          title={
-            <Fragment>
-              <IconFeedback
-                aria_label={text_maker("suvey_popup_header")}
-                color={tertiaryColor}
-                alternate_color={false}
-              />
-              {text_maker("suvey_popup_header")}
-            </Fragment>
-          }
-          body={
-            <Fragment>
-              <div
-                style={{
-                  fontSize: "0.9em",
-                  display: "flex",
-                  flexDirection: "column",
-                }}
-              >
-                <TM k="survey_popup_body" />
-              </div>
-              <div style={{ display: "flex", justifyContent: "space-evenly" }}>
-                <a
-                  className="link-unstyled btn btn-ib-primary"
-                  onClick={() => this.handleButtonPress("yes")}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  href={"#survey"}
-                >
-                  {text_maker(`survey_popup_yes`)}
-                </a>
-              </div>
-              <div
-                className="mrgn-tp-md"
-                style={{
-                  fontSize: "0.9em",
-                  display: "flex",
-                  flexDirection: "column",
-                  textAlign: "left",
-                  borderTop: "1px solid #e5e5e5",
-                }}
-              >
-                <TM
-                  k="simplified_survey_header"
-                  style={{ alignSelf: "center", fontSize: "1.4em" }}
-                />
-                <FormFrontend
-                  template_name="feedback_simplified"
-                  include_privacy={false}
-                  top_border={false}
-                  on_submitted={() =>
-                    this.handleButtonPress("short_survey_submitted")
-                  }
-                />
-              </div>
-            </Fragment>
-          }
-          footer={
-            <div style={{ display: "flex", justifyContent: "space-evenly" }}>
-              {_.map(["later", "no"], (button_type) => (
-                <button
-                  key={button_type}
-                  className="btn btn-ib-primary"
-                  onClick={() => this.handleButtonPress(button_type)}
-                >
-                  {text_maker(`survey_popup_${button_type}`)}
-                </button>
-              ))}
-            </div>
-          }
-        />
-      );
     }
   }
 );

--- a/client/src/Survey/SurveyPopup.js
+++ b/client/src/Survey/SurveyPopup.js
@@ -1,6 +1,5 @@
 import _ from "lodash";
 import React, { Fragment } from "react";
-import { withRouter } from "react-router";
 
 import {
   FixedPopover,
@@ -20,15 +19,11 @@ import text from "./SurveyPopup.yaml";
 
 const { TM, text_maker } = create_text_maker_component(text);
 
-const POSTPONE_TIMEOUT_PERIOD = 1000 * 60 * 60 * 24;
+const POSTPONE_TIMEOUT_PERIOD = 1000 * 60 * 60 * 12;
 
 const currentDate = new Date();
 
 const is_survey_campaign_period = (() => {
-  if (is_dev || is_dev_link) {
-    return false;
-  }
-
   // Reminder: months are 0-indexed, years and days aren't
   const is_start_of_trimester = _.includes([0, 4, 8], currentDate.getMonth());
 
@@ -37,152 +32,144 @@ const is_survey_campaign_period = (() => {
   return is_start_of_trimester && is_second_half_of_month;
 })();
 
+// Note: suffix based on year and month to bust cached settings between current, and potential future, campaign periods
 const key_suffix = `--${currentDate.getFullYear()}-${currentDate.getMonth()}`;
-
 const postponed_since_storage_key =
   "infobase_survey_popup_postponed_since" + key_suffix;
-
 const is_deactivated_storage_key =
   "infobase_survey_popup_deactivated" + key_suffix;
 
-export const SurveyPopup = withRouter(
-  class _SurveyPopup extends React.Component {
-    constructor(props) {
-      super(props);
+export class SurveyPopup extends React.Component {
+  constructor(props) {
+    super(props);
 
-      const is_deactivated_storage_value = localStorage.getItem(
-        is_deactivated_storage_key
-      );
-      const is_deactivated_by_user = is_deactivated_storage_value === "true";
+    const is_deactivated_storage_value = localStorage.getItem(
+      is_deactivated_storage_key
+    );
+    const is_deactivated_by_user = is_deactivated_storage_value === "true";
 
-      const postponed_since_storage_value = localStorage.getItem(
-        postponed_since_storage_key
-      );
-      const is_postponed_by_user = !_.isNull(postponed_since_storage_value)
-        ? Date.now() - +postponed_since_storage_value >= POSTPONE_TIMEOUT_PERIOD
-        : false;
+    const postponed_since_storage_value = localStorage.getItem(
+      postponed_since_storage_key
+    );
+    const is_postponed_by_user = !_.isNull(postponed_since_storage_value)
+      ? Date.now() - +postponed_since_storage_value >= POSTPONE_TIMEOUT_PERIOD
+      : false;
 
-      const is_active =
-        is_survey_campaign_period &&
-        !is_postponed_by_user &&
-        !is_deactivated_by_user;
+    const show_popup =
+      !(is_dev || is_dev_link) &&
+      is_survey_campaign_period &&
+      !is_deactivated_by_user &&
+      !is_postponed_by_user;
 
-      this.state = {
-        is_active,
-        landing_page: props.location.pathname,
-      };
-    }
-
-    handlePopupButtonPress = (button_type) => {
-      log_standard_event({
-        SUBAPP: this.props.location.pathname,
-        MISC1: "SURVEY_POPUP",
-        MISC2: `interaction: ${button_type}`,
-      });
-
-      if (_.includes(["yes", "no", "short_survey_submitted"], button_type)) {
-        localStorage.setItem(is_deactivated_storage_key, "true");
-      } else if (button_type === "later") {
-        localStorage.setItem(is_deactivated_storage_key, "false");
-        localStorage.setItem(postponed_since_storage_key, Date.now());
-      }
-
-      this.setState({ is_active: false });
+    this.state = {
+      show_popup,
     };
-
-    render() {
-      const { is_active, landing_page } = this.state;
-
-      const should_show =
-        is_active && this.props.location.pathname !== landing_page;
-
-      if (should_show) {
-        log_standard_event({
-          SUBAPP: this.props.location.pathname,
-          MISC1: "SURVEY_POPUP",
-          MISC2: "displayed",
-        });
-
-        return (
-          <FixedPopover
-            show={should_show}
-            title={
-              <Fragment>
-                <IconFeedback
-                  aria_label={text_maker("suvey_popup_header")}
-                  color={tertiaryColor}
-                  alternate_color={false}
-                />
-                {text_maker("suvey_popup_header")}
-              </Fragment>
-            }
-            body={
-              <Fragment>
-                <div
-                  style={{
-                    fontSize: "0.9em",
-                    display: "flex",
-                    flexDirection: "column",
-                  }}
-                >
-                  <TM k="survey_popup_body" />
-                </div>
-                <div
-                  style={{ display: "flex", justifyContent: "space-evenly" }}
-                >
-                  <a
-                    className="link-unstyled btn btn-ib-primary"
-                    onClick={() => this.handlePopupButtonPress("yes")}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    href={"#survey"}
-                  >
-                    {text_maker(`survey_popup_yes`)}
-                  </a>
-                </div>
-                <div
-                  className="mrgn-tp-md"
-                  style={{
-                    fontSize: "0.9em",
-                    display: "flex",
-                    flexDirection: "column",
-                    textAlign: "left",
-                    borderTop: "1px solid #e5e5e5",
-                  }}
-                >
-                  <TM
-                    k="simplified_survey_header"
-                    style={{ alignSelf: "center", fontSize: "1.4em" }}
-                  />
-                  <FormFrontend
-                    template_name="feedback_simplified"
-                    include_privacy={false}
-                    top_border={false}
-                    on_submitted={() =>
-                      this.handlePopupButtonPress("short_survey_submitted")
-                    }
-                  />
-                </div>
-              </Fragment>
-            }
-            footer={
-              <div style={{ display: "flex", justifyContent: "space-evenly" }}>
-                {_.map(["later", "no"], (button_type) => (
-                  <button
-                    key={button_type}
-                    className="btn btn-ib-primary"
-                    onClick={() => this.handlePopupButtonPress(button_type)}
-                  >
-                    {text_maker(`survey_popup_${button_type}`)}
-                  </button>
-                ))}
-              </div>
-            }
-          />
-        );
-      } else {
-        return null;
-      }
-    }
   }
-);
+
+  handlePopupButtonPress = (button_type) => {
+    log_standard_event({
+      SUBAPP: this.props.location.pathname,
+      MISC1: "SURVEY_POPUP",
+      MISC2: `interaction: ${button_type}`,
+    });
+
+    if (_.includes(["yes", "no", "short_survey_submitted"], button_type)) {
+      localStorage.setItem(is_deactivated_storage_key, "true");
+    } else if (button_type === "later") {
+      localStorage.setItem(is_deactivated_storage_key, "false");
+      localStorage.setItem(postponed_since_storage_key, Date.now());
+    }
+
+    this.setState({ show_popup: false });
+  };
+
+  render() {
+    const { show_popup } = this.state;
+
+    if (!show_popup) {
+      return null;
+    }
+
+    log_standard_event({
+      SUBAPP: this.props.location.pathname,
+      MISC1: "SURVEY_POPUP",
+      MISC2: "displayed",
+    });
+
+    return (
+      <FixedPopover
+        show={show_popup}
+        title={
+          <Fragment>
+            <IconFeedback
+              aria_label={text_maker("suvey_popup_header")}
+              color={tertiaryColor}
+              alternate_color={false}
+            />
+            {text_maker("suvey_popup_header")}
+          </Fragment>
+        }
+        body={
+          <Fragment>
+            <div
+              style={{
+                fontSize: "0.9em",
+                display: "flex",
+                flexDirection: "column",
+              }}
+            >
+              <TM k="survey_popup_body" />
+            </div>
+            <div style={{ display: "flex", justifyContent: "space-evenly" }}>
+              <a
+                className="link-unstyled btn btn-ib-primary"
+                onClick={() => this.handlePopupButtonPress("yes")}
+                target="_blank"
+                rel="noopener noreferrer"
+                href={"#survey"}
+              >
+                {text_maker(`survey_popup_yes`)}
+              </a>
+            </div>
+            <div
+              className="mrgn-tp-md"
+              style={{
+                fontSize: "0.9em",
+                display: "flex",
+                flexDirection: "column",
+                textAlign: "left",
+                borderTop: "1px solid #e5e5e5",
+              }}
+            >
+              <TM
+                k="simplified_survey_header"
+                style={{ alignSelf: "center", fontSize: "1.4em" }}
+              />
+              <FormFrontend
+                template_name="feedback_simplified"
+                include_privacy={false}
+                top_border={false}
+                on_submitted={() =>
+                  this.handlePopupButtonPress("short_survey_submitted")
+                }
+              />
+            </div>
+          </Fragment>
+        }
+        footer={
+          <div style={{ display: "flex", justifyContent: "space-evenly" }}>
+            {_.map(["later", "no"], (button_type) => (
+              <button
+                key={button_type}
+                className="btn btn-ib-primary"
+                onClick={() => this.handlePopupButtonPress(button_type)}
+              >
+                {text_maker(`survey_popup_${button_type}`)}
+              </button>
+            ))}
+          </div>
+        }
+      />
+    );
+  }
+}

--- a/client/src/components/modals_and_popovers/bootstrap_modal_exstension.scss
+++ b/client/src/components/modals_and_popovers/bootstrap_modal_exstension.scss
@@ -20,6 +20,7 @@ $margin: 30px;
   }
 }
 .modal-dialog__header-footer-layout {
+  width: 100%;
   display: flex;
   flex-direction: row;
   justify-content: space-between;


### PR DESCRIPTION
Currently three times a year, for the last half of January, May, and September.

Decided to fully simplify the logic for when the popup should display. Not trying to be smart about showing it after the user has had time to explore the site anymore, just showing it right away. The popup gives both the option to open the full survey in a new tab for later or to postpone for later. Given those, I think it's fine to leave it totally up to the user when they'll answer.