### PR TITLE
Add consistent all-test `tests` shorthand scripts

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -25,6 +25,7 @@
     "cypress:debug": "cypress run --headed",
     "unit_tests": "npx jest --coverage --config jest_configs/unit_tests.config.js",
     "unit_tests:debug": "NODE_OPTIONS='--inspect-brk' npx jest --runInBand --coverage -config jest_configs/unit_tests.config.js",
+    "tests": "npm run unit_tests",
     "type_check": "npx tsc --noEmit",
     "gqlgen": "graphql-codegen --config codegen.yml",
     "gqlgen:watch": "nodemon --watch ../server/.dev_artifacts -e .graphql --exec 'graphql-codegen --config codegen.yml --watch'"

--- a/form_backend/package.json
+++ b/form_backend/package.json
@@ -35,6 +35,7 @@
     "integration_tests:debug": "NODE_OPTIONS='--inspect-brk' npx jest --runInBand --coverage --forceExit --config jest_configs/integration_tests.config.js",
     "end_to_end_tests": "npx jest --coverage --forceExit  --config jest_configs/end_to_end_tests.config.js",
     "end_to_end_tests:debug": "NODE_OPTIONS='--inspect-brk' npx jest --runInBand --coverage --forceExit  --config jest_configs/end_to_end_tests.config.js",
+    "tests": "npm run unit_tests; npm run integration_tests; npm run end_to_end_tests",
     "prod_deploy": "sh ./scripts/deploy/prod_deploy_form_backend_function.sh",
     "mongod": "sh ../scripts/dev_scripts/local_mongod.sh -p 27018",
     "extract_data:dev": "sh ./scripts/extract_data/extract_data.sh -m dev",

--- a/form_backend/src/form_backend.end-to-end-test.js
+++ b/form_backend/src/form_backend.end-to-end-test.js
@@ -23,18 +23,10 @@ const mock_send_to_slack = send_to_slack.mockImplementation(() =>
 );
 
 import { run_form_backend } from "./form_backend.js";
-beforeAll((done) => {
-  run_form_backend();
-  done();
-});
 
 describe("End-to-end tests for form_backend endpoints", () => {
-  const prod_test_url =
-    "https://us-central1-report-a-problem-email-244220.cloudfunctions.net/prod-email-backend";
-  const local_test_url = `http://127.0.0.1:7331`;
-
-  const test_against_prod = false;
-  const test_url = test_against_prod ? prod_test_url : local_test_url;
+  const form_backend = run_form_backend();
+  const test_url = `http://127.0.0.1:${form_backend.get("port")}`;
 
   const make_form_template_names_request = () =>
     axios.get(`${test_url}/form_template_names`);

--- a/form_backend/src/form_backend.js
+++ b/form_backend/src/form_backend.js
@@ -72,7 +72,7 @@ const make_form_backend = (templates) => {
   });
 
   form_backend.get("/form_template_names", (request, response) =>
-    response.status("200").send(
+    response.status(200).send(
       _.chain(templates)
         .keys()
         .filter((template_name) => !/\.test$/.test(template_name))
@@ -88,10 +88,10 @@ const make_form_backend = (templates) => {
     if (_.isUndefined(requested_template)) {
       const error_message =
         "Bad Request: form template request has invalid or missing `template_name` value";
-      response.status("400").send(error_message);
+      response.status(400).send(error_message);
       log_error_case(request, error_message);
     } else {
-      response.status("200").json(templates[template_name]);
+      response.status(200).json(templates[template_name]);
     }
   });
 
@@ -117,7 +117,7 @@ const make_form_backend = (templates) => {
       const error_message =
         "Bad Request: submitted form content either doesn't correspond to any templates, " +
         "or does not validate against its corresponding template";
-      response.status("400").send(error_message);
+      response.status(400).send(error_message);
       log_error_case(request, error_message);
     } else {
       const this_client_is_in_timeout = throttle_requests_by_client(
@@ -126,7 +126,7 @@ const make_form_backend = (templates) => {
       if (process.env.IS_PROD_SERVER && this_client_is_in_timeout) {
         const error_message =
           "Bad Request: too many recent requests from your IP, try again later.";
-        response.status("400").send(error_message);
+        response.status(400).send(error_message);
         log_error_case(request, error_message);
         return null;
       } else {
@@ -145,11 +145,11 @@ const make_form_backend = (templates) => {
           completed_template
         )
           .then(() => {
-            response.send("200");
+            response.status(200).send();
             log_success_case(request);
           })
           .catch((error) => {
-            response.status("500").send(`Internal Server Error: ${error}`);
+            response.status(500).send(`Internal Server Error: ${error}`);
             log_error_case(request, error);
           });
       }
@@ -160,7 +160,7 @@ const make_form_backend = (templates) => {
 
   form_backend.use((err, req, res, next) => {
     console.error(err.stack);
-    res.status("500").send("Internal server error");
+    res.status(500).send("Internal server error");
     next(err);
   });
 

--- a/form_backend/src/form_backend.js
+++ b/form_backend/src/form_backend.js
@@ -177,11 +177,16 @@ const run_form_backend = () => {
   const form_backend = make_form_backend(templates);
 
   if (!process.env.IS_PROD_SERVER) {
-    form_backend.set("port", 7331);
-    form_backend.listen(form_backend.get("port"), () => {
-      const port = form_backend.get("port");
-      console.log(`InfoBase form backend running at http://127.0.0.1:${port}`);
-    });
+    // Note: telling express to listen on port "0" actually means "pick any free port". 7331 is our arbitrarily selected dev port
+    const form_backend_server = form_backend.listen(
+      process.env.NODE_ENV === "test" ? 0 : 7331
+    );
+    form_backend.set("port", form_backend_server.address().port);
+    console.log(
+      `InfoBase form backend running at http://127.0.0.1:${form_backend.get(
+        "port"
+      )}`
+    );
   }
 
   return form_backend;

--- a/form_backend/src/index.unit-test.js
+++ b/form_backend/src/index.unit-test.js
@@ -1,12 +1,11 @@
 import axios from "axios";
 
-// index.js has an on-load side effect of starting the server
-import { form_backend } from "./index.js"; // eslint-disable-line no-unused-vars
+import { form_backend } from "./index.js";
 
 describe("form_backend/index.js (the GCF entry point)", () => {
-  it("Starts server as an on-load side-effect", async () => {
+  it("Starts express server as an on-load side-effect", async () => {
     const server_response = await axios.get(
-      `http://127.0.0.1:7331/form_template_names`
+      `http://127.0.0.1:${form_backend.get("port")}/form_template_names`
     );
     return expect(server_response.status).toBe(200);
   });

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "infobase_tmux_init": "npm run tmux_env",
     "tmux_env": "sh scripts/dev_scripts/tmux_env.sh",
     "refresh_pipeline_data": "sh scripts/dev_scripts/refresh_pipeline_data.sh",
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "tests": "(cd client && npm run tests); (cd server && npm run tests); (cd form_backend && npm run tests)"
   },
   "authors": [
     "Alex Cousineau-Leduc",

--- a/server/package.json
+++ b/server/package.json
@@ -41,7 +41,7 @@
     "unit_tests": "npx jest --coverage --forceExit --config jest_configs/unit_tests.config.js",
     "unit_tests:watch": "npx jest --watch --config jest_configs/unit_tests.config.js",
     "unit_tests:debug": "NODE_OPTIONS='--inspect-brk' npx --runInBand --coverage --forceExit --config jest_configs/unit_tests.config.js",
-    "test": "(npm run unit_tests && npm run snapshot_tests && npm run merge_coverage_reports)",
+    "tests": "npm run unit_tests; npm run snapshot_tests",
     "start": "nodemon --config nodemon_start_config.json --watch src --watch package-lock.json --watch ../data -e csv,json,js --exec node src/dev_server.js",
     "start:debug": "nodemon --watch src --watch package-lock.json --exec node --inspect-brk ./src/dev_server.js",
     "populate_db": "node src/populate_db.js",


### PR DESCRIPTION
Also fixed an issue when trying to run certain form backend tests while also running a local dev instance (or, in theory, running those tests in parallel). 