### PR TITLE
Mongo connection string env var cleanup 

### DIFF
--- a/form_backend/scripts/util/set_transient_secrets.sh
+++ b/form_backend/scripts/util/set_transient_secrets.sh
@@ -36,7 +36,7 @@ echo "USE_REMOTE_DB: '$USE_REMOTE_DB'" >> $scratch/envs.yaml
 echo "CURRENT_SHA: '$CURRENT_SHA'" >> $scratch/envs.yaml
 
 export MDB_NAME=$(lpass show FORM_BACKEND_MDB_NAME --notes)
-export MDB_CONNECT_STRING=$(lpass show FORM_BACKEND_MDB_CONNECT_STRING_3 --notes)
+export MDB_CONNECT_STRING=$(lpass show FORM_BACKEND_MDB_CONNECT_STRING --notes)
 export MDB_USERNAME=$(lpass show FORM_BACKEND_MDB_USER --notes)
 export MDB_PW=$(lpass show FORM_BACKEND_MDB_PW --notes)
 echo "MDB_NAME: '$MDB_NAME'" >> $scratch/envs.yaml

--- a/server/scripts/deploy/ci_deploy_function.sh
+++ b/server/scripts/deploy/ci_deploy_function.sh
@@ -3,7 +3,7 @@ set -e
 
 touch ./envs.yaml
 echo "MDB_NAME: '$MDB_NAME'" >> ./envs.yaml
-echo "MDB_CONNECT_STRING: '$MDB_CONNECT_STRING_3'" >> ./envs.yaml
+echo "MDB_CONNECT_STRING: '$MDB_CONNECT_STRING'" >> ./envs.yaml
 echo "MDB_USERNAME: '$MDB_USERNAME'" >> ./envs.yaml
 echo "MDB_PW: '$MDB_PW'" >> ./envs.yaml
 

--- a/server/scripts/deploy/set_transient_data_secrets.sh
+++ b/server/scripts/deploy/set_transient_data_secrets.sh
@@ -11,6 +11,6 @@ function cleanup {
 }
 trap cleanup EXIT
 
-export MDB_CONNECT_STRING=$(lpass show MDB_CONNECT_STRING_3 --notes)
+export MDB_CONNECT_STRING=$(lpass show MDB_CONNECT_STRING --notes)
 export MDB_USERNAME=$(lpass show MDB_WRITE_USER --notes)
 export MDB_PW=$(lpass show MDB_WRITE_PW --notes)

--- a/server/scripts/deploy/set_transient_function_secrets.sh
+++ b/server/scripts/deploy/set_transient_function_secrets.sh
@@ -30,7 +30,7 @@ export PROJECT=$(lpass show PROD_API_PROJECT_ID --notes)
 touch $scratch/envs.yaml
 echo "MDB_NAME: '$MDB_NAME'" >> $scratch/envs.yaml
 
-export MDB_CONNECT_STRING=$(lpass show MDB_CONNECT_STRING_3 --notes)
+export MDB_CONNECT_STRING=$(lpass show MDB_CONNECT_STRING --notes)
 export MDB_USERNAME=$(lpass show MDB_READ_USER --notes)
 export MDB_PW=$(lpass show MDB_READ_PW --notes)
 echo "MDB_CONNECT_STRING: '$MDB_CONNECT_STRING'" >> $scratch/envs.yaml


### PR DESCRIPTION
To avoid potential future confusion/gotchas, we should drop the old V1 connection strings from our secret management solution and rename the currently-used V3 strings to not reference their version anymore.

This can be done immediately after merging for the production secrets within our secret manager, but to support dev link deploys on other open branches we need to keep copies of the dev env var both with and without the _3 suffix. See #1506
