### PR TITLE
Convert fake service footnotes

### DIFF
--- a/client/src/panels/panel_declarations/services/single_service_panels/service_digital_status.js
+++ b/client/src/panels/panel_declarations/services/single_service_panels/service_digital_status.js
@@ -25,9 +25,9 @@ export class ServiceDigitalStatus extends React.Component {
 
     const footnote = service.digital_enablement_comment && [
       create_footnote({
-        id: service.id,
+        id: "",
         subject_type: service.subject_type,
-        subject_id: service.subject_id,
+        subject_id: service.id,
         topic_keys: ["DIGITAL_STATUS"],
         text: service.digital_enablement_comment,
       }),

--- a/client/src/panels/panel_declarations/services/single_service_panels/service_digital_status.js
+++ b/client/src/panels/panel_declarations/services/single_service_panels/service_digital_status.js
@@ -25,7 +25,7 @@ export class ServiceDigitalStatus extends React.Component {
 
     const footnote = service.digital_enablement_comment && [
       create_footnote({
-        id: "",
+        id: service.digital_enablement_comment,
         subject_type: service.subject_type,
         subject_id: service.id,
         topic_keys: ["DIGITAL_STATUS"],

--- a/client/src/panels/panel_declarations/services/single_service_panels/service_digital_status.js
+++ b/client/src/panels/panel_declarations/services/single_service_panels/service_digital_status.js
@@ -15,7 +15,7 @@ import {
   DisplayTable,
 } from "src/components/index";
 
-import { create_fake_footnote } from "src/models/footnotes/footnotes";
+import { create_footnote } from "src/models/footnotes/footnotes";
 
 const { text_maker, TM } = create_text_maker_component(text);
 
@@ -24,7 +24,10 @@ export class ServiceDigitalStatus extends React.Component {
     const { service, title, sources, datasets } = this.props;
 
     const footnote = service.digital_enablement_comment && [
-      create_fake_footnote({
+      create_footnote({
+        id: service.id,
+        subject_type: service.subject_type,
+        subject_id: service.subject_id,
         topic_keys: ["DIGITAL_STATUS"],
         text: service.digital_enablement_comment,
       }),

--- a/client/src/panels/panel_declarations/services/single_service_panels/service_standards.js
+++ b/client/src/panels/panel_declarations/services/single_service_panels/service_standards.js
@@ -214,7 +214,7 @@ export const declare_single_service_standards_panel = () =>
 
         let footnotes = _.concat(
           create_footnote({
-            id: "",
+            id: text_maker("new_standards_data"),
             subject_type: subject.subject_type,
             subject_id: subject.id,
             topic_keys: ["SERVICE_STANDARDS"],
@@ -225,7 +225,7 @@ export const declare_single_service_standards_panel = () =>
               (standard) =>
                 standard.other_type_comment &&
                 create_footnote({
-                  id: "",
+                  id: standard.other_type_comment,
                   subject_type: subject.subject_type,
                   subject_id: subject.id,
                   topic_keys: ["OTHER_TYPE_COMMENT"],
@@ -240,7 +240,7 @@ export const declare_single_service_standards_panel = () =>
           footnotes = _.concat(
             footnotes,
             create_footnote({
-              id: "",
+              id: text_maker("IRCC_hotfix"),
               subject_type: subject.subject_type,
               subject_id: subject.id,
               topic_keys: ["SERVICE_STANDARDS"],

--- a/client/src/panels/panel_declarations/services/single_service_panels/service_standards.js
+++ b/client/src/panels/panel_declarations/services/single_service_panels/service_standards.js
@@ -14,7 +14,9 @@ import {
   TabsStateful,
 } from "src/components/index";
 
-import { create_fake_footnote } from "src/models/footnotes/footnotes";
+//import { create_fake_footnote } from "src/models/footnotes/footnotes";
+
+import { create_footnote } from "src/models/footnotes/footnotes";
 
 import { newIBCategoryColors } from "src/core/color_schemes";
 import { formats } from "src/core/format";
@@ -211,7 +213,10 @@ export const declare_single_service_standards_panel = () =>
           .value();
 
         let footnotes = _.concat(
-          create_fake_footnote({
+          create_footnote({
+            id: "",
+            subject_type: "service",
+            subject_id: subject.id,
             topic_keys: ["SERVICE_STANDARDS"],
             text: text_maker("new_standards_data"),
           }),
@@ -219,7 +224,10 @@ export const declare_single_service_standards_panel = () =>
             .map(
               (standard) =>
                 standard.other_type_comment &&
-                create_fake_footnote({
+                create_footnote({
+                  id: "",
+                  subject_type: "service",
+                  subject_id: subject.id,
                   topic_keys: ["OTHER_TYPE_COMMENT"],
                   text: standard.other_type_comment,
                 })
@@ -231,7 +239,10 @@ export const declare_single_service_standards_panel = () =>
         if (subject.id === "1491") {
           footnotes = _.concat(
             footnotes,
-            create_fake_footnote({
+            create_footnote({
+              id: "",
+              subject_type: "service",
+              subject_id: subject.id,
               topic_keys: ["SERVICE_STANDARDS"],
               text: text_maker("IRCC_hotfix"),
             })

--- a/client/src/panels/panel_declarations/services/single_service_panels/service_standards.js
+++ b/client/src/panels/panel_declarations/services/single_service_panels/service_standards.js
@@ -215,7 +215,7 @@ export const declare_single_service_standards_panel = () =>
         let footnotes = _.concat(
           create_footnote({
             id: "",
-            subject_type: "service",
+            subject_type: subject.subject_type,
             subject_id: subject.id,
             topic_keys: ["SERVICE_STANDARDS"],
             text: text_maker("new_standards_data"),
@@ -226,7 +226,7 @@ export const declare_single_service_standards_panel = () =>
                 standard.other_type_comment &&
                 create_footnote({
                   id: "",
-                  subject_type: "service",
+                  subject_type: subject.subject_type,
                   subject_id: subject.id,
                   topic_keys: ["OTHER_TYPE_COMMENT"],
                   text: standard.other_type_comment,
@@ -241,7 +241,7 @@ export const declare_single_service_standards_panel = () =>
             footnotes,
             create_footnote({
               id: "",
-              subject_type: "service",
+              subject_type: subject.subject_type,
               subject_id: subject.id,
               topic_keys: ["SERVICE_STANDARDS"],
               text: text_maker("IRCC_hotfix"),

--- a/client/src/panels/panel_declarations/services/single_service_panels/service_standards.js
+++ b/client/src/panels/panel_declarations/services/single_service_panels/service_standards.js
@@ -14,8 +14,6 @@ import {
   TabsStateful,
 } from "src/components/index";
 
-//import { create_fake_footnote } from "src/models/footnotes/footnotes";
-
 import { create_footnote } from "src/models/footnotes/footnotes";
 
 import { newIBCategoryColors } from "src/core/color_schemes";


### PR DESCRIPTION
Pretty iffy on this one- in particular on what is meant to be used for the ID values of create_footnote. I looked through footnote.csv, but there were seemingly no examples to follow of service related footnotes except for a few that did not seem to give me any proper confirmation as to what to use for id values (perhaps that's intentional since they were originally fake).

Perhaps I've misunderstood what converting the "fake" footnotes to "proper form" meant however, and that doesn't mean making them real footnotes per say.

Feel free to tell me if I'm very far off track here or if there's anything I should change.

(Note: currently getting error when opening services now. I suspect this may be because this branch is not up to date with master, will rebase soon to check)