### PR TITLE
Table filter vertical cut fix

### DIFF
--- a/client/src/components/DisplayTable/DisplayTable.scss
+++ b/client/src/components/DisplayTable/DisplayTable.scss
@@ -48,7 +48,7 @@ td {
 }
 
 .display-table-container {
-  overflow-x: auto;
+  //overflow-x: auto;
   margin-top: 20px;
   margin-bottom: 20px;
 

--- a/client/src/components/DisplayTable/DisplayTable.scss
+++ b/client/src/components/DisplayTable/DisplayTable.scss
@@ -136,3 +136,17 @@ table.display-table:not(.no-total-row) > tbody > tr > td {
 ::placeholder {
   font-weight: normal;
 }
+
+@media (max-width: 500px) {
+  .display-table-container {
+    overflow-x: auto;
+    margin-top: 20px;
+    margin-bottom: 20px;
+  
+    &.display-table-container--with-utils {
+      border-top-left-radius: $standardBorderRadius;
+      border-top-right-radius: $standardBorderRadius;
+      background-color: $tableBackgroundColor;
+    }
+  }
+}

--- a/client/src/components/DisplayTable/DisplayTable.scss
+++ b/client/src/components/DisplayTable/DisplayTable.scss
@@ -142,7 +142,7 @@ table.display-table:not(.no-total-row) > tbody > tr > td {
     overflow-x: auto;
     margin-top: 20px;
     margin-bottom: 20px;
-  
+
     &.display-table-container--with-utils {
       border-top-left-radius: $standardBorderRadius;
       border-top-right-radius: $standardBorderRadius;

--- a/client/src/components/DisplayTable/DisplayTable.scss
+++ b/client/src/components/DisplayTable/DisplayTable.scss
@@ -137,6 +137,7 @@ table.display-table:not(.no-total-row) > tbody > tr > td {
   font-weight: normal;
 }
 
+//For mobile devices
 @media (max-width: 500px) {
   .display-table-container {
     overflow-x: auto;

--- a/client/src/components/DisplayTable/DisplayTable.scss
+++ b/client/src/components/DisplayTable/DisplayTable.scss
@@ -48,7 +48,6 @@ td {
 }
 
 .display-table-container {
-  //overflow-x: auto;
   margin-top: 20px;
   margin-bottom: 20px;
 


### PR DESCRIPTION
Removed overflow on desktop and most tablets, but kept it on mobile devices as recommended in the discussions for this issue. I tested the changes on both mobile and desktop and the appearance and functionality of these changes seem to be alright, but if there are any recommended changes here just let me know.

If my assumptions on keeping the overflow the same on mobile devices is incorrect and should be changed as well, feel free to tell me.

(note: the max-width value was chosen based on documentation online that stated 460px width is the approximate best value for mobile devices. I increased it to 500 just for any edge cases- however i suspect that this should be swapped with the maxSmallDevice value regardless)