### PR TITLE
Reduce heightclipper usage

### DIFF
--- a/client/src/components/DisplayTable/DisplayTable.tsx
+++ b/client/src/components/DisplayTable/DisplayTable.tsx
@@ -487,8 +487,8 @@ export class _DisplayTable extends React.Component<
         num_items={_.size(sorted_filtered_data)}
         num_options_max={page_size_num_options_max}
       />
-    ); 
-    
+    );
+
     const util_components_with_defaults = _.chain({
       ...util_components_default,
       ...util_components,
@@ -500,7 +500,7 @@ export class _DisplayTable extends React.Component<
     const paginated_data = _.chunk(
       sorted_filtered_data,
       !enable_pagination ? _.size(sorted_filtered_data) : page_size
-    ); 
+    );
 
     const number_of_pages = paginated_data.length;
 
@@ -808,27 +808,24 @@ export class DisplayTable extends React.Component<DisplayTableProps> {
         is_sortable: supplied_column_config.is_sortable && showing_sort,
       })
     );
-      if(this.props.page_size_increment==undefined){
-    return (
-      <_DisplayTable
-        {...this.props}
-        column_configs={smart_column_configs}
-        enable_pagination={
-          _.size(data) > _DisplayTable.defaultProps.page_size_increment
-        }
-      />
-    );
-      }
-      else{
-        return (
-          <_DisplayTable
-            {...this.props}
-            column_configs={smart_column_configs}
-            enable_pagination={
-              _.size(data) > this.props.page_size_increment
-            }
-          />
-        );
-      }
+    if (this.props.page_size_increment == undefined) {
+      return (
+        <_DisplayTable
+          {...this.props}
+          column_configs={smart_column_configs}
+          enable_pagination={
+            _.size(data) > _DisplayTable.defaultProps.page_size_increment
+          }
+        />
+      );
+    } else {
+      return (
+        <_DisplayTable
+          {...this.props}
+          column_configs={smart_column_configs}
+          enable_pagination={_.size(data) > this.props.page_size_increment}
+        />
+      );
+    }
   }
 }

--- a/client/src/components/DisplayTable/DisplayTable.tsx
+++ b/client/src/components/DisplayTable/DisplayTable.tsx
@@ -487,8 +487,8 @@ export class _DisplayTable extends React.Component<
         num_items={_.size(sorted_filtered_data)}
         num_options_max={page_size_num_options_max}
       />
-    );
-
+    ); 
+    
     const util_components_with_defaults = _.chain({
       ...util_components_default,
       ...util_components,
@@ -500,7 +500,7 @@ export class _DisplayTable extends React.Component<
     const paginated_data = _.chunk(
       sorted_filtered_data,
       !enable_pagination ? _.size(sorted_filtered_data) : page_size
-    );
+    ); 
 
     const number_of_pages = paginated_data.length;
 
@@ -814,7 +814,7 @@ export class DisplayTable extends React.Component<DisplayTableProps> {
         {...this.props}
         column_configs={smart_column_configs}
         enable_pagination={
-          _.size(data) > _DisplayTable.defaultProps.page_size_increment
+          _.size(data) > this.props.page_size_increment
         }
       />
     );

--- a/client/src/components/DisplayTable/DisplayTable.tsx
+++ b/client/src/components/DisplayTable/DisplayTable.tsx
@@ -808,15 +808,27 @@ export class DisplayTable extends React.Component<DisplayTableProps> {
         is_sortable: supplied_column_config.is_sortable && showing_sort,
       })
     );
-
+      if(this.props.page_size_increment==undefined){
     return (
       <_DisplayTable
         {...this.props}
         column_configs={smart_column_configs}
         enable_pagination={
-          _.size(data) > this.props.page_size_increment
+          _.size(data) > _DisplayTable.defaultProps.page_size_increment
         }
       />
     );
+      }
+      else{
+        return (
+          <_DisplayTable
+            {...this.props}
+            column_configs={smart_column_configs}
+            enable_pagination={
+              _.size(data) > this.props.page_size_increment
+            }
+          />
+        );
+      }
   }
 }

--- a/client/src/panels/panel_declarations/finances/auth_exp_planned_spending/auth_exp_planned_spending.js
+++ b/client/src/panels/panel_declarations/finances/auth_exp_planned_spending/auth_exp_planned_spending.js
@@ -6,7 +6,7 @@ import { InfographicPanel } from "src/panels/panel_declarations/InfographicPanel
 import { declare_panel } from "src/panels/PanelRegistry";
 
 import {
-  HeightClipper,
+  //HeightClipper,
   create_text_maker_component,
   Details,
   GraphOverlay,

--- a/client/src/panels/panel_declarations/finances/auth_exp_planned_spending/auth_exp_planned_spending.js
+++ b/client/src/panels/panel_declarations/finances/auth_exp_planned_spending/auth_exp_planned_spending.js
@@ -455,7 +455,7 @@ class LapseByVotesGraph extends React.Component {
           args={{ lapse_unit: is_showing_lapse_pct ? "%" : "$" }}
           style={{ textAlign: "center" }}
         />
-        <HeightClipper clipHeight={200}>{lapse_infograph}</HeightClipper>
+        {lapse_infograph}
       </div>
     );
   }

--- a/client/src/panels/panel_declarations/finances/detailed_program_spending_split/detailed_program_spending_split.js
+++ b/client/src/panels/panel_declarations/finances/detailed_program_spending_split/detailed_program_spending_split.js
@@ -3,10 +3,7 @@ import { scaleOrdinal } from "d3-scale";
 import _ from "lodash";
 import React from "react";
 
-import {
-  HeightClippedGraph,
-  TspanLineWrapper,
-} from "src/panels/panel_declarations/common_panel_components";
+import { TspanLineWrapper } from "src/panels/panel_declarations/common_panel_components";
 import { InfographicPanel } from "src/panels/panel_declarations/InfographicPanel";
 import { declare_panel } from "src/panels/PanelRegistry";
 
@@ -609,13 +606,11 @@ export const declare_detailed_program_spending_split_panel = () =>
                 />
               </div>
               <div>
-                <HeightClippedGraph clipHeight={300}>
-                  <DetailedProgramSplit
-                    flat_data={flat_data}
-                    arrangements={arrangements}
-                    top_3_so_nums={top_3_so_nums}
-                  />
-                </HeightClippedGraph>
+                <DetailedProgramSplit
+                  flat_data={flat_data}
+                  arrangements={arrangements}
+                  top_3_so_nums={top_3_so_nums}
+                />
               </div>
             </div>
           </InfographicPanel>

--- a/client/src/panels/panel_declarations/results/gov_dp.js
+++ b/client/src/panels/panel_declarations/results/gov_dp.js
@@ -117,13 +117,14 @@ const DpSummary = () => {
           }}
         />
       </div>
-      <HeightClippedGraph clipHeight={330}>
+      
         <DisplayTable
           table_name={"Government DP"}
           data={rows_of_counts_by_dept}
           column_configs={column_configs}
+          page_size_increment={15}
         />
-      </HeightClippedGraph>
+      
     </Fragment>
   );
 

--- a/client/src/panels/panel_declarations/results/gov_dp.js
+++ b/client/src/panels/panel_declarations/results/gov_dp.js
@@ -1,7 +1,6 @@
 import _ from "lodash";
 import React, { Fragment, useState } from "react";
 
-import { HeightClippedGraph } from "src/panels/panel_declarations/common_panel_components";
 import { InfographicPanel } from "src/panels/panel_declarations/InfographicPanel";
 import { declare_panel } from "src/panels/PanelRegistry";
 
@@ -117,14 +116,13 @@ const DpSummary = () => {
           }}
         />
       </div>
-      
-        <DisplayTable
-          table_name={"Government DP"}
-          data={rows_of_counts_by_dept}
-          column_configs={column_configs}
-          page_size_increment={15}
-        />
-      
+
+      <DisplayTable
+        table_name={"Government DP"}
+        data={rows_of_counts_by_dept}
+        column_configs={column_configs}
+        page_size_increment={15}
+      />
     </Fragment>
   );
 

--- a/client/src/panels/panel_declarations/results/gov_drr.js
+++ b/client/src/panels/panel_declarations/results/gov_drr.js
@@ -133,13 +133,14 @@ const DrrSummary = () => {
         <div className="medium-panel-text">
           <TM k="gov_drr_summary_org_table_text" />
         </div>
-        <HeightClippedGraph clipHeight={330}>
+        
           <DisplayTable
             table_name={"Government DRR"}
             data={rows_of_counts_by_dept}
             column_configs={column_configs}
+            page_size_increment={15}
           />
-        </HeightClippedGraph>
+        
       </div>
     </div>
   );

--- a/client/src/panels/panel_declarations/results/gov_drr.js
+++ b/client/src/panels/panel_declarations/results/gov_drr.js
@@ -1,7 +1,6 @@
 import _ from "lodash";
 import React, { useState } from "react";
 
-import { HeightClippedGraph } from "src/panels/panel_declarations/common_panel_components";
 import { InfographicPanel } from "src/panels/panel_declarations/InfographicPanel";
 import { declare_panel } from "src/panels/PanelRegistry";
 
@@ -133,14 +132,13 @@ const DrrSummary = () => {
         <div className="medium-panel-text">
           <TM k="gov_drr_summary_org_table_text" />
         </div>
-        
-          <DisplayTable
-            table_name={"Government DRR"}
-            data={rows_of_counts_by_dept}
-            column_configs={column_configs}
-            page_size_increment={15}
-          />
-        
+
+        <DisplayTable
+          table_name={"Government DRR"}
+          data={rows_of_counts_by_dept}
+          column_configs={column_configs}
+          page_size_increment={15}
+        />
       </div>
     </div>
   );

--- a/client/src/panels/panel_declarations/services/services_channels.js
+++ b/client/src/panels/panel_declarations/services/services_channels.js
@@ -1,7 +1,11 @@
 import _ from "lodash";
+
 import React, { useEffect, useState } from "react";
+
 //import {HeightClippedGraph}
+
 import { InfographicPanel } from "src/panels/panel_declarations/InfographicPanel";
+
 import { declare_panel } from "src/panels/PanelRegistry";
 
 import {

--- a/client/src/panels/panel_declarations/services/services_channels.js
+++ b/client/src/panels/panel_declarations/services/services_channels.js
@@ -221,32 +221,32 @@ const ServicesChannelsPanel = ({ subject }) => {
         />
       ) : (
         //<HeightClippedGraph clipHeight={300}>
-          <div style={{ marginTop: "50px" }} className="col-12 col-lg-12">
-            <div style={{ textAlign: "center" }}>
-              <TM
-                style={{ fontWeight: 700 }}
-                className="medium-panel-text"
-                k="application_breakdown_by_channel"
-              />
-            </div>
-            <div style={{ display: "flex", justifyContent: "center" }}>
-              <Select
-                id="services_channels_select"
-                title={text_maker("select_period")}
-                selected={active_year}
-                options={_.map(report_years, (year) => ({
-                  id: year,
-                  display: formats.year_to_fiscal_year_raw(year),
-                }))}
-                onSelect={(year) => set_active_year(year)}
-              />
-            </div>
-            <WrappedNivoPie
-              data={channel_pct_data}
-              is_money={false}
-              display_horizontal={true}
+        <div style={{ marginTop: "50px" }} className="col-12 col-lg-12">
+          <div style={{ textAlign: "center" }}>
+            <TM
+              style={{ fontWeight: 700 }}
+              className="medium-panel-text"
+              k="application_breakdown_by_channel"
             />
           </div>
+          <div style={{ display: "flex", justifyContent: "center" }}>
+            <Select
+              id="services_channels_select"
+              title={text_maker("select_period")}
+              selected={active_year}
+              options={_.map(report_years, (year) => ({
+                id: year,
+                display: formats.year_to_fiscal_year_raw(year),
+              }))}
+              onSelect={(year) => set_active_year(year)}
+            />
+          </div>
+          <WrappedNivoPie
+            data={channel_pct_data}
+            is_money={false}
+            display_horizontal={true}
+          />
+        </div>
         //</HeightClippedGraph>
       )}
     </div>

--- a/client/src/panels/panel_declarations/services/services_channels.js
+++ b/client/src/panels/panel_declarations/services/services_channels.js
@@ -217,7 +217,7 @@ const ServicesChannelsPanel = ({ subject }) => {
           }}
         />
       ) : (
-        <HeightClippedGraph clipHeight={300}>
+        //<HeightClippedGraph clipHeight={300}>
           <div style={{ marginTop: "50px" }} className="col-12 col-lg-12">
             <div style={{ textAlign: "center" }}>
               <TM
@@ -244,7 +244,7 @@ const ServicesChannelsPanel = ({ subject }) => {
               display_horizontal={true}
             />
           </div>
-        </HeightClippedGraph>
+        //</HeightClippedGraph>
       )}
     </div>
   );

--- a/client/src/panels/panel_declarations/services/services_channels.js
+++ b/client/src/panels/panel_declarations/services/services_channels.js
@@ -1,7 +1,6 @@
 import _ from "lodash";
 import React, { useEffect, useState } from "react";
-
-import { HeightClippedGraph } from "src/panels/panel_declarations/common_panel_components";
+//import {HeightClippedGraph}
 import { InfographicPanel } from "src/panels/panel_declarations/InfographicPanel";
 import { declare_panel } from "src/panels/PanelRegistry";
 

--- a/client/src/panels/panel_declarations/services/single_service_panels/service_standards.js
+++ b/client/src/panels/panel_declarations/services/single_service_panels/service_standards.js
@@ -10,7 +10,6 @@ import {
   DisplayTable,
   create_text_maker_component,
   VisibilityControl,
-  HeightClipper,
   TabsStateful,
 } from "src/components/index";
 
@@ -179,12 +178,10 @@ export class ServiceStandards extends React.Component {
                 }
               />
             )}
-            <HeightClipper clipHeight={500}>
-              <DisplayTable
-                data={filtered_data}
-                column_configs={column_configs}
-              />
-            </HeightClipper>
+            <DisplayTable
+              data={filtered_data}
+              column_configs={column_configs}
+            />
           </Fragment>
         ) : (
           <TM className="medium-panel-text" k="no_service_standards_text" />

--- a/client/src/panels/panel_declarations/services/subject_offering_services.js
+++ b/client/src/panels/panel_declarations/services/subject_offering_services.js
@@ -1,7 +1,6 @@
 import _ from "lodash";
 import React from "react";
 
-import { HeightClippedGraph } from "src/panels/panel_declarations/common_panel_components";
 import { InfographicPanel } from "src/panels/panel_declarations/InfographicPanel";
 import { declare_panel } from "src/panels/PanelRegistry";
 
@@ -76,7 +75,7 @@ const OrgsOfferingServicesPanel = ({ subject }) => {
     }),
   };
   return (
-    <HeightClippedGraph clipHeight={600}>
+    <div>
       {!is_gov && (
         <TM
           className="medium-panel-text"
@@ -98,8 +97,9 @@ const OrgsOfferingServicesPanel = ({ subject }) => {
         unsorted_initial={true}
         data={cleaned_data}
         column_configs={column_configs}
+        page_size_increment={15}
       />
-    </HeightClippedGraph>
+    </div>
   );
 };
 


### PR DESCRIPTION
Fixed defaultProp page_size_increment issue and assigned lower page_size_increments to smaller graphs, removed heightclipper where it was seemingly not needed. If I got rid of it in a place that I shouldn't have, or missed a spot where I should have removed it just let me know. I also chose 15 as a page_size_increment_value on instinct and how it looked on the page, if that value should change to something lower or higher just let me know.