### PR TITLE
In year vote new visuals

### DIFF
--- a/client/src/panels/panel_declarations/finances/vote_stat/in_year_vote_stat_split.js
+++ b/client/src/panels/panel_declarations/finances/vote_stat/in_year_vote_stat_split.js
@@ -55,7 +55,7 @@ const render_w_options =
                         "e1"
                     ) + "e-1"
                   )}
-                  %){" "}
+                  %)
                 </tspan>
               )}
               isInteractive={false}

--- a/client/src/panels/panel_declarations/finances/vote_stat/in_year_vote_stat_split.js
+++ b/client/src/panels/panel_declarations/finances/vote_stat/in_year_vote_stat_split.js
@@ -8,9 +8,9 @@ import { declare_panel } from "src/panels/PanelRegistry";
 
 import { infobase_colors } from "src/core/color_schemes";
 
-import { is_a11y_mode } from "src/core/injected_build_constants";
-
 import { formats } from "src/core/format";
+
+import { is_a11y_mode } from "src/core/injected_build_constants";
 
 import { WrappedNivoBar } from "src/charts/wrapped_nivo/index";
 

--- a/client/src/panels/panel_declarations/finances/vote_stat/in_year_vote_stat_split.js
+++ b/client/src/panels/panel_declarations/finances/vote_stat/in_year_vote_stat_split.js
@@ -6,13 +6,18 @@ import { declare_panel } from "src/panels/PanelRegistry";
 
 import { is_a11y_mode } from "src/core/injected_build_constants";
 
-import { WrappedNivoPie } from "src/charts/wrapped_nivo/index";
+import { WrappedNivoBar } from "src/charts/wrapped_nivo/index";
 
 import { text_maker, TM } from "./vote_stat_text_provider";
+
+import { infobase_colors } from "src/core/color_schemes";
+
+import { textColor } from "src/style_constants/index";
 
 const voted = text_maker("voted");
 const stat = text_maker("stat");
 const main_col = "{{est_in_year}}_estimates";
+const colors = infobase_colors();
 
 const render_w_options =
   ({ graph_col, text_col, text_key }) =>
@@ -31,7 +36,39 @@ const render_w_options =
         </Col>
         {!is_a11y_mode && (
           <Col isGraph size={graph_col}>
-            <WrappedNivoPie data={data} />
+            <WrappedNivoBar
+              data={data}
+              keys={["value"]}
+              indexBy={"id"}
+              colors={(d) => colors(d.id)}
+              margin={{
+                top: 50,
+                right: 40,
+                bottom: 120,
+                left: 40,
+              }}
+              bttm_axis={{
+                format: (d) =>
+                  _.words(d).length > 3 ? d.substring(0, 20) + "..." : d,
+                tickSize: 3,
+                tickRotation: -45,
+                tickPadding: 10,
+              }}
+              graph_height="450px"
+              enableGridX={false}
+              remove_left_axis={true}
+              theme={{
+                axis: {
+                  ticks: {
+                    text: {
+                      fontSize: 12,
+                      fill: textColor,
+                      fontWeight: "550",
+                    },
+                  },
+                },
+              }}
+            />
           </Col>
         )}
       </StdPanel>

--- a/client/src/panels/panel_declarations/finances/vote_stat/in_year_vote_stat_split.js
+++ b/client/src/panels/panel_declarations/finances/vote_stat/in_year_vote_stat_split.js
@@ -44,7 +44,7 @@ const render_w_options =
               data={data}
               keys={["value"]}
               label={(d) => (
-                <tspan y={-10}>{formats.compact2_raw(d.formattedValue)}</tspan>
+                <tspan y={-10}>{formats.compact2_raw(d.formattedValue)} ({Number(Math.round(((d.formattedValue/(vote_stat_est_in_year[0].value + vote_stat_est_in_year[1].value))*100)+'e1')+'e-1')}%) </tspan>
               )}
               isInteractive={false}
               enableLabel={true}

--- a/client/src/panels/panel_declarations/finances/vote_stat/in_year_vote_stat_split.js
+++ b/client/src/panels/panel_declarations/finances/vote_stat/in_year_vote_stat_split.js
@@ -10,6 +10,8 @@ import { infobase_colors } from "src/core/color_schemes";
 
 import { is_a11y_mode } from "src/core/injected_build_constants";
 
+import { formats } from "src/core/format";
+
 import { WrappedNivoBar } from "src/charts/wrapped_nivo/index";
 
 import { textColor } from "src/style_constants/index";
@@ -41,6 +43,11 @@ const render_w_options =
             <WrappedNivoBar
               data={data}
               keys={["value"]}
+              label={(d) => (
+                <tspan y={-10}>{formats.compact2_raw(d.formattedValue)}</tspan>
+              )}
+              isInteractive={false}
+              enableLabel={true}
               indexBy={"id"}
               colors={(d) => colors(d.id)}
               margin={{

--- a/client/src/panels/panel_declarations/finances/vote_stat/in_year_vote_stat_split.js
+++ b/client/src/panels/panel_declarations/finances/vote_stat/in_year_vote_stat_split.js
@@ -44,7 +44,19 @@ const render_w_options =
               data={data}
               keys={["value"]}
               label={(d) => (
-                <tspan y={-10}>{formats.compact2_raw(d.formattedValue)} ({Number(Math.round(((d.formattedValue/(vote_stat_est_in_year[0].value + vote_stat_est_in_year[1].value))*100)+'e1')+'e-1')}%) </tspan>
+                <tspan y={-10}>
+                  {formats.compact2_raw(d.formattedValue)} (
+                  {Number(
+                    Math.round(
+                      (d.formattedValue /
+                        (vote_stat_est_in_year[0].value +
+                          vote_stat_est_in_year[1].value)) *
+                        100 +
+                        "e1"
+                    ) + "e-1"
+                  )}
+                  %){" "}
+                </tspan>
               )}
               isInteractive={false}
               enableLabel={true}

--- a/client/src/panels/panel_declarations/finances/vote_stat/in_year_vote_stat_split.js
+++ b/client/src/panels/panel_declarations/finances/vote_stat/in_year_vote_stat_split.js
@@ -1,18 +1,20 @@
 import _ from "lodash";
+
 import React from "react";
 
 import { StdPanel, Col } from "src/panels/panel_declarations/InfographicPanel";
+
 import { declare_panel } from "src/panels/PanelRegistry";
+
+import { infobase_colors } from "src/core/color_schemes";
 
 import { is_a11y_mode } from "src/core/injected_build_constants";
 
 import { WrappedNivoBar } from "src/charts/wrapped_nivo/index";
 
-import { text_maker, TM } from "./vote_stat_text_provider";
-
-import { infobase_colors } from "src/core/color_schemes";
-
 import { textColor } from "src/style_constants/index";
+
+import { text_maker, TM } from "./vote_stat_text_provider";
 
 const voted = text_maker("voted");
 const stat = text_maker("stat");

--- a/client/src/panels/panel_declarations/finances/vote_stat/last_year_vote_stat_split.js
+++ b/client/src/panels/panel_declarations/finances/vote_stat/last_year_vote_stat_split.js
@@ -8,9 +8,9 @@ import { year_templates } from "src/models/years";
 
 import { infobase_colors } from "src/core/color_schemes";
 
-import { is_a11y_mode } from "src/core/injected_build_constants";
-
 import { formats } from "src/core/format";
+
+import { is_a11y_mode } from "src/core/injected_build_constants";
 
 import { WrappedNivoBar } from "src/charts/wrapped_nivo/index";
 
@@ -31,6 +31,8 @@ const render_w_options =
       id: data_set.label,
     }));
 
+    
+
     return (
       <StdPanel {...{ title, footnotes, sources, datasets, glossary_keys }}>
         <Col isText size={text_col}>
@@ -47,7 +49,7 @@ const render_w_options =
               isInteractive={false}
               enableLabel={true}
               indexBy={"id"}
-              colors={["red", "blue"]}
+              colors={(d) => colors(d.id)}
               margin={{
                 top: 50,
                 right: 40,

--- a/client/src/panels/panel_declarations/finances/vote_stat/last_year_vote_stat_split.js
+++ b/client/src/panels/panel_declarations/finances/vote_stat/last_year_vote_stat_split.js
@@ -6,13 +6,20 @@ import { declare_panel } from "src/panels/PanelRegistry";
 
 import { year_templates } from "src/models/years";
 
+import { infobase_colors } from "src/core/color_schemes";
+
 import { is_a11y_mode } from "src/core/injected_build_constants";
 
-import { WrappedNivoPie } from "src/charts/wrapped_nivo/index";
+import { formats } from "src/core/format";
+
+import { WrappedNivoBar } from "src/charts/wrapped_nivo/index";
+
+import { textColor } from "src/style_constants/index";
 
 import { text_maker, TM } from "./vote_stat_text_provider";
 
 const { std_years } = year_templates;
+const colors = infobase_colors();
 
 const render_w_options =
   ({ text_key, graph_col, text_col }) =>
@@ -31,7 +38,44 @@ const render_w_options =
         </Col>
         {!is_a11y_mode && (
           <Col isGraph size={graph_col}>
-            <WrappedNivoPie data={data} />
+            <WrappedNivoBar
+              data={data}
+              keys={["value"]}
+              label={(d) => (
+                <tspan y={-10}>{formats.compact2_raw(d.formattedValue)}</tspan>
+              )}
+              isInteractive={false}
+              enableLabel={true}
+              indexBy={"id"}
+              colors={["red", "blue"]}
+              margin={{
+                top: 50,
+                right: 40,
+                bottom: 120,
+                left: 40,
+              }}
+              bttm_axis={{
+                format: (d) =>
+                  _.words(d).length > 3 ? d.substring(0, 20) + "..." : d,
+                tickSize: 3,
+                tickRotation: -45,
+                tickPadding: 10,
+              }}
+              graph_height="450px"
+              enableGridX={false}
+              remove_left_axis={true}
+              theme={{
+                axis: {
+                  ticks: {
+                    text: {
+                      fontSize: 12,
+                      fill: textColor,
+                      fontWeight: "550",
+                    },
+                  },
+                },
+              }}
+            />
           </Col>
         )}
       </StdPanel>

--- a/client/src/panels/panel_declarations/finances/vote_stat/last_year_vote_stat_split.js
+++ b/client/src/panels/panel_declarations/finances/vote_stat/last_year_vote_stat_split.js
@@ -42,7 +42,18 @@ const render_w_options =
               data={data}
               keys={["value"]}
               label={(d) => (
-                <tspan y={-10}>{formats.compact2_raw(d.formattedValue)} ({Number(Math.round(((d.formattedValue/(vote_stat[0].value + vote_stat[1].value))*100)+'e1')+'e-1')}%)</tspan>
+                <tspan y={-10}>
+                  {formats.compact2_raw(d.formattedValue)} (
+                  {Number(
+                    Math.round(
+                      (d.formattedValue /
+                        (vote_stat[0].value + vote_stat[1].value)) *
+                        100 +
+                        "e1"
+                    ) + "e-1"
+                  )}
+                  %)
+                </tspan>
               )}
               isInteractive={false}
               enableLabel={true}

--- a/client/src/panels/panel_declarations/finances/vote_stat/last_year_vote_stat_split.js
+++ b/client/src/panels/panel_declarations/finances/vote_stat/last_year_vote_stat_split.js
@@ -31,8 +31,6 @@ const render_w_options =
       id: data_set.label,
     }));
 
-    
-
     return (
       <StdPanel {...{ title, footnotes, sources, datasets, glossary_keys }}>
         <Col isText size={text_col}>

--- a/client/src/panels/panel_declarations/finances/vote_stat/last_year_vote_stat_split.js
+++ b/client/src/panels/panel_declarations/finances/vote_stat/last_year_vote_stat_split.js
@@ -42,7 +42,7 @@ const render_w_options =
               data={data}
               keys={["value"]}
               label={(d) => (
-                <tspan y={-10}>{formats.compact2_raw(d.formattedValue)}</tspan>
+                <tspan y={-10}>{formats.compact2_raw(d.formattedValue)} ({Number(Math.round(((d.formattedValue/(vote_stat[0].value + vote_stat[1].value))*100)+'e1')+'e-1')}%)</tspan>
               )}
               isInteractive={false}
               enableLabel={true}


### PR DESCRIPTION
(Stemmed from https://github.com/TBS-EACPD/infobase/issues/512 , unsure of why I can't tag it on development.)

Separated the votes and statutory items into two bars. Percentage values are on labels, but not functioning on the graphs table version yet. Also the original issue seemed as though more discussion may have been needed on how to format the data, so if my solution here needs to be changed (which is fairly likely I assume) just let me know.