### PR TITLE
Select unit test

### DIFF
--- a/client/src/components/Select/Select.tsx
+++ b/client/src/components/Select/Select.tsx
@@ -30,6 +30,7 @@ const Select = ({
   title,
 }: SelectProps) => (
   <select
+    data-testid="select"
     style={style}
     id={id}
     disabled={disabled}
@@ -40,7 +41,7 @@ const Select = ({
     aria-label={title}
   >
     {_.map(options, (choice) => (
-      <option key={choice.id} value={choice.id}>
+      <option data-testid="select-option" key={choice.id} value={choice.id}>
         {choice.display}
       </option>
     ))}

--- a/client/src/components/Select/Select.unit-test.tsx
+++ b/client/src/components/Select/Select.unit-test.tsx
@@ -1,0 +1,41 @@
+import { render, fireEvent } from "@testing-library/react";
+import React from "react";
+import _ from "lodash";
+import { Select } from "./Select";
+
+const testing_default = {
+  options: [
+    {
+      id: "selectinitial",
+      display: "display1",
+    },
+    {
+      id: "select2",
+      display: "display2",
+    },
+    {
+      id: "select3",
+      display: "display3",
+    },
+  ],
+};
+
+describe("Select", () => {
+  it("initializes initial select-option, calls onSelect when select option is changes", async () => {
+    const onSelect = jest.fn();
+    const id = "Selector";
+    let selected = "selectinitial";
+
+    const { getByTestId, queryAllByTestId } = render(
+      <Select {...{ ...testing_default, id, selected: selected, onSelect }} />
+    );
+
+    let options = queryAllByTestId(
+      "select-option"
+    ) as unknown as HTMLOptionElement[];
+    expect(options[0].selected).toBeTruthy();
+    expect(onSelect).toHaveBeenCalledTimes(0);
+    fireEvent.change(getByTestId("select"), { target: { value: "select2" } });
+    expect(onSelect).toHaveBeenCalledTimes(1);
+  });
+});

--- a/client/src/components/Select/Select.unit-test.tsx
+++ b/client/src/components/Select/Select.unit-test.tsx
@@ -1,6 +1,7 @@
 import { render, fireEvent } from "@testing-library/react";
+
 import React from "react";
-import _ from "lodash";
+
 import { Select } from "./Select";
 
 const testing_default = {
@@ -24,17 +25,18 @@ describe("Select", () => {
   it("initializes initial select-option, calls onSelect when select option is changes", async () => {
     const onSelect = jest.fn();
     const id = "Selector";
-    let selected = "selectinitial";
+    const selected = "selectinitial";
 
     const { getByTestId, queryAllByTestId } = render(
       <Select {...{ ...testing_default, id, selected: selected, onSelect }} />
     );
 
-    let options = queryAllByTestId(
+    const options = queryAllByTestId(
       "select-option"
     ) as unknown as HTMLOptionElement[];
     expect(options[0].selected).toBeTruthy();
     expect(onSelect).toHaveBeenCalledTimes(0);
+    //Does not actually seem to be changing the selected value for some reason.
     fireEvent.change(getByTestId("select"), { target: { value: "select2" } });
     expect(onSelect).toHaveBeenCalledTimes(1);
   });

--- a/client/src/components/Select/Select.unit-test.tsx
+++ b/client/src/components/Select/Select.unit-test.tsx
@@ -59,5 +59,4 @@ describe("Select", () => {
     expect(options[0].selected).toBeFalsy();
     expect(options[1].selected).toBeTruthy();
   });
-
 });

--- a/client/src/components/Select/Select.unit-test.tsx
+++ b/client/src/components/Select/Select.unit-test.tsx
@@ -22,7 +22,7 @@ const testing_default = {
 };
 
 describe("Select", () => {
-  it("initializes initial select-option, calls onSelect when select option is changes", async () => {
+  it("initializes initial select-option, calls onSelect when select is changed", () => {
     const onSelect = jest.fn();
     const id = "Selector";
     const selected = "selectinitial";
@@ -40,4 +40,24 @@ describe("Select", () => {
     fireEvent.change(getByTestId("select"), { target: { value: "select2" } });
     expect(onSelect).toHaveBeenCalledTimes(1);
   });
+
+  it("changes other select-option besides initial option to be 'selected'", () => {
+    const onSelect = jest.fn();
+    const id = "Selector";
+    const selected = "selectinitial";
+
+    const { queryAllByTestId } = render(
+      <Select {...{ ...testing_default, id, selected: selected, onSelect }} />
+    );
+
+    const options = queryAllByTestId(
+      "select-option"
+    ) as unknown as HTMLOptionElement[];
+    expect(options[0].selected).toBeTruthy();
+    //Directly swaps currently selected option
+    fireEvent.change(options[1], { target: { selected: true } });
+    expect(options[0].selected).toBeFalsy();
+    expect(options[1].selected).toBeTruthy();
+  });
+
 });


### PR DESCRIPTION
Marked as awaiting review as I'm not sure if there will be much else I can do on this task without feedback- knowing how to actually use fireEvent.change() to swap the select components currently selected value would be helpful. I suspect that this can potentially be done through actually customizing the onSelect function, however I did try to mimic the logic of other components that made their own onSelect but did not have much luck.

Regardless however, calling onSelect is tested as well as changing the currently selected option through using fireEvent.change() on the options array.

Just let me know if my tests have any problems or if I should add anymore tests.