### PR TITLE
Add more eslint lodash preferences

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -21,6 +21,7 @@
     "lodash/prefer-immutable-method": ["warn"],
     "lodash/prefer-lodash-chain": ["warn"],
     "lodash/no-extra-args": ["warn"],
+    "lodash/prefer-times": ["warn"],
     "import/order": [
       "warn",
       {

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -20,7 +20,6 @@
     "lodash/prefer-includes": ["warn"],
     "lodash/prefer-immutable-method": ["warn"],
     "lodash/prefer-lodash-chain": ["warn"],
-    "lodash/prefer-invoke-map": ["warn"],
     "lodash/no-extra-args": ["warn"],
     "import/order": [
       "warn",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -21,6 +21,7 @@
     "lodash/prefer-immutable-method": ["warn"],
     "lodash/prefer-lodash-chain": ["warn"],
     "lodash/prefer-invoke-map": ["warn"],
+    "lodash/no-extra-args": ["warn"],
     "import/order": [
       "warn",
       {

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -17,6 +17,10 @@
     "lodash/no-double-unwrap": ["error"],
     "lodash/no-unbound-this": ["error"],
     "lodash/unwrap": ["error"],
+    "lodash/prefer-includes": ["warn"],
+    "lodash/prefer-immutable-method": ["warn"],
+    "lodash/chaining": ["warn"],
+    "lodash/prefer-invoke-map": ["warn"],
     "import/order": [
       "warn",
       {

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -19,7 +19,7 @@
     "lodash/unwrap": ["error"],
     "lodash/prefer-includes": ["warn"],
     "lodash/prefer-immutable-method": ["warn"],
-    "lodash/chaining": ["warn"],
+    "lodash/prefer-lodash-chain": ["warn"],
     "lodash/prefer-invoke-map": ["warn"],
     "import/order": [
       "warn",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -22,6 +22,7 @@
     "lodash/prefer-lodash-chain": ["warn"],
     "lodash/no-extra-args": ["warn"],
     "lodash/prefer-find": ["warn"],
+    "lodash/prefer-reject": ["warn"],
     "import/order": [
       "warn",
       {

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -21,7 +21,7 @@
     "lodash/prefer-immutable-method": ["warn"],
     "lodash/prefer-lodash-chain": ["warn"],
     "lodash/no-extra-args": ["warn"],
-    "lodash/prefer-times": ["warn"],
+    "lodash/prefer-find": ["warn"],
     "import/order": [
       "warn",
       {

--- a/client/build_code/copy_static_assets.js
+++ b/client/build_code/copy_static_assets.js
@@ -123,7 +123,7 @@ function get_index_pages() {
 
   const en_lang_lookups = _.mapValues(index_lang_lookups, "en");
   const fr_lang_lookups = _.mapValues(index_lang_lookups, "fr");
-  _.each(
+  _.forEach(
     [en_lang_lookups, fr_lang_lookups],
     (lookups) => (lookups.CDN_URL = CDN_URL)
   );
@@ -174,7 +174,7 @@ function build_proj(PROJ) {
   const footnotes_dir = `${dir}/footnotes`;
   const well_known_dir = `${dir}/.well-known`;
 
-  _.each([build_dir_name, dir, app_dir, footnotes_dir], (name) =>
+  _.forEach([build_dir_name, dir, app_dir, footnotes_dir], (name) =>
     make_dir_if_exists(name)
   );
 
@@ -195,7 +195,7 @@ function build_proj(PROJ) {
 
   write_gitsha_file(dir);
 
-  _.each(["en", "fr"], (lang) => {
+  _.forEach(["en", "fr"], (lang) => {
     const {
       depts: dept_footnotes,
       tags: tag_footnotes,
@@ -204,7 +204,7 @@ function build_proj(PROJ) {
       estimates: estimate_footnotes,
     } = get_footnote_file_defs(parsed_bilingual_models, lang);
 
-    _.each(_.merge(dept_footnotes, tag_footnotes), (file_str, subj_id) => {
+    _.forEach(_.merge(dept_footnotes, tag_footnotes), (file_str, subj_id) => {
       // reminder: the funky .json.js exstension is to ensure that Cloudflare caches these, as it usually won't cache .json
       fs.writeFileSync(
         `${footnotes_dir}/fn_${lang}_${subj_id}.json.js`,
@@ -252,7 +252,7 @@ function build_proj(PROJ) {
   );
   PROJ.other.forEach((f_name) => copy_file_to_target_dir(f_name, dir));
 
-  _.each(get_index_pages(), ({ file_prefix, en, fr }) => {
+  _.forEach(get_index_pages(), ({ file_prefix, en, fr }) => {
     fs.writeFileSync(`${dir}/${file_prefix}-eng.html`, en);
     fs.writeFileSync(`${dir}/${file_prefix}-fra.html`, fr);
   });

--- a/client/build_code/loaders/sass-interop-loader.js
+++ b/client/build_code/loaders/sass-interop-loader.js
@@ -20,9 +20,9 @@ const get_top_level_variable_names = (content) =>
     .value();
 
 const test_variable_type_cases = (scss_module_path, variable_names) => {
-  const non_camel_case_names = _.filter(
+  const non_camel_case_names = _.reject(
     variable_names,
-    (name) => _.camelCase(name) !== name
+    (name) => _.camelCase(name) === name
   );
 
   if (!_.isEmpty(non_camel_case_names)) {

--- a/client/build_code/loaders/sass-interop-loader.js
+++ b/client/build_code/loaders/sass-interop-loader.js
@@ -16,7 +16,7 @@ const get_top_level_variable_names = (content) =>
   _.chain(content)
     .split("\n")
     .filter((line) => sass_variable_pattern.test(line))
-    .invokeMap((export_line) => export_line.replace(sass_variable_pattern, "$1"))
+    .map((export_line) => export_line.replace(sass_variable_pattern, "$1"))
     .value();
 
 const test_variable_type_cases = (scss_module_path, variable_names) => {

--- a/client/build_code/loaders/sass-interop-loader.js
+++ b/client/build_code/loaders/sass-interop-loader.js
@@ -16,7 +16,7 @@ const get_top_level_variable_names = (content) =>
   _.chain(content)
     .split("\n")
     .filter((line) => sass_variable_pattern.test(line))
-    .map((export_line) => export_line.replace(sass_variable_pattern, "$1"))
+    .invokeMap((export_line) => export_line.replace(sass_variable_pattern, "$1"))
     .value();
 
 const test_variable_type_cases = (scss_module_path, variable_names) => {

--- a/client/build_code/loaders/yaml-lang-loader.js
+++ b/client/build_code/loaders/yaml-lang-loader.js
@@ -11,7 +11,7 @@ module.exports = function (src) {
   var lang = this.query.lang;
 
   var obj = yaml.load(src);
-  _.each(obj, function (val, key) {
+  _.forEach(obj, function (val, key) {
     if (!_.isObject(val)) {
       return [key, val];
     }

--- a/client/build_code/write_footnote_bundles.js
+++ b/client/build_code/write_footnote_bundles.js
@@ -32,16 +32,16 @@ function populate_stores(parsed_models) {
     footnotes,
   } = parsed_models;
 
-  _.each(crsos, ({ id, dept_code }) => {
+  _.forEach(crsos, ({ id, dept_code }) => {
     crso_deptcodes[id] = dept_code;
   });
 
-  _.each(programs, ({ dept_code, activity_code }) => {
+  _.forEach(programs, ({ dept_code, activity_code }) => {
     const prog_id = `${dept_code}-${activity_code}`;
     program_deptcodes[prog_id] = dept_code;
   });
 
-  _.each(tag_prog_links, ({ program_id, tag_id }) => {
+  _.forEach(tag_prog_links, ({ program_id, tag_id }) => {
     if (!program_tag_ids[program_id]) {
       program_tag_ids[program_id] = [];
     }
@@ -62,7 +62,7 @@ function populate_stores(parsed_models) {
     .fromPairs()
     .value();
 
-  _.each(footnotes, (obj) => {
+  _.forEach(footnotes, (obj) => {
     //FIXME: once pipeline starts including unique IDs for each footnote, we can stop using index.
     //"id","subject_class","subject_id","fyear1","fyear2","keys","footnote_en","footnote_fr"
     all_footnotes.push(obj);
@@ -90,7 +90,7 @@ function populate_stores(parsed_models) {
           footnotes_by_deptcode[dept_code].push(obj);
 
           const tag_ids = program_tag_ids[subject_id];
-          _.each(tag_ids, (tag_id) => {
+          _.forEach(tag_ids, (tag_id) => {
             footnotes_by_tag_id[tag_id].push(obj);
           });
 

--- a/client/cypress/integration/InfoBase/route_tests.spec.js
+++ b/client/cypress/integration/InfoBase/route_tests.spec.js
@@ -385,5 +385,5 @@ describe("Route tests", () => {
     }
   })();
 
-  _.each(route_configs_to_test, run_tests_from_config);
+  _.forEach(route_configs_to_test, run_tests_from_config);
 });

--- a/client/scripts/typescript_progress/generate_typescript_progress_stats.js
+++ b/client/scripts/typescript_progress/generate_typescript_progress_stats.js
@@ -49,7 +49,7 @@ json.modules.forEach((node) => {
     return;
   }
   node.dependencies = node.dependencies
-    .filter((dep) => !dep.resolved.match(excludedRe))
+    .reject((dep) => dep.resolved.match(excludedRe))
     .map((dep) => ({ ...dep, source: dep.resolved }));
 
   recordsByName[node.source] = node;

--- a/client/src/EstimatesComparison/scheme.js
+++ b/client/src/EstimatesComparison/scheme.js
@@ -359,7 +359,7 @@ function get_data_by_item_types() {
         }
       }
 
-      const is_voted = _.isNumber(_.first(rows).votenum);
+      const is_voted = _.isNumber(_.head(rows).votenum);
 
       const is_single_item =
         _.chain(rows).map(row_identifier_func).uniq().value().length === 1;

--- a/client/src/IgocExplorer/hierarchies.js
+++ b/client/src/IgocExplorer/hierarchies.js
@@ -90,7 +90,7 @@ const grouping_options = {
             }))
             .value(),
         }))
-        .each((parent_form_node) => {
+        .forEach((parent_form_node) => {
           if (parent_form_node.children.length === 1) {
             //if an inst form grouping just contains a single inst form, 'skip' the level
             const { children } = parent_form_node.children[0];

--- a/client/src/InfoBase/bootstrapper.js
+++ b/client/src/InfoBase/bootstrapper.js
@@ -77,7 +77,7 @@ function bootstrapper(App, done) {
   wake_up_graphql_cloud_function();
 
   populate_initial_stores_from_lookups().then(() => {
-    _.each(table_defs, (table_def) =>
+    _.forEach(table_defs, (table_def) =>
       Table.store.create_and_register(table_def)
     );
 

--- a/client/src/TagExplorer/resource_scheme.js
+++ b/client/src/TagExplorer/resource_scheme.js
@@ -83,15 +83,15 @@ function create_resource_hierarchy({ hierarchy_scheme, year }) {
                   },
                   subject.is_m2m &&
                     !_.isEmpty(
-                      _.filter(
+                      _.reject(
                         prog.tags_by_scheme[subject.root.id],
-                        (tag) => tag.id !== subject.id
+                        (tag) => tag.id === subject.id
                       )
                     ) &&
                     related_tags_row(
-                      _.filter(
+                      _.reject(
                         prog.tags_by_scheme[subject.root.id],
-                        (tag) => tag.id !== subject.id
+                        (tag) => tag.id === subject.id
                       ),
                       "program"
                     ),

--- a/client/src/TagExplorer/utils.js
+++ b/client/src/TagExplorer/utils.js
@@ -10,7 +10,7 @@ const { text_maker, TM } = create_text_maker_component(text);
 
 const { std_years, planning_years } = year_templates;
 const actual_year = _.last(std_years);
-const planning_year = _.first(planning_years);
+const planning_year = _.head(planning_years);
 
 const route_arg_to_year_map = {
   actual: actual_year,

--- a/client/src/charts/wrapped_nivo/NivoLineBarToggle/NivoLineBarToggle.js
+++ b/client/src/charts/wrapped_nivo/NivoLineBarToggle/NivoLineBarToggle.js
@@ -60,7 +60,7 @@ export class NivoLineBarToggle extends React.Component {
     // so this ensures that the mapping will be the same for
     // each sub-graph
     const set_graph_colors = (items) =>
-      _.each(items, (item) => colors(item.label));
+      _.forEach(items, (item) => colors(item.label));
     set_graph_colors(props.data);
 
     this.state = {

--- a/client/src/components/DisplayTable/DisplayTable.tsx
+++ b/client/src/components/DisplayTable/DisplayTable.tsx
@@ -170,7 +170,7 @@ const get_default_state_from_props = (props: _DisplayTableProps) => {
     : _.chain(col_configs_with_defaults)
         .pickBy((col) => col.is_sortable)
         .keys()
-        .first()
+        .head()
         .value();
 
   const searches = _.chain(col_configs_with_defaults)
@@ -418,7 +418,7 @@ export class _DisplayTable extends React.Component<
 
     const all_ordered_col_keys = _.chain(col_configs_with_defaults)
       .map(({ index }, key) => [index, key])
-      .sortBy(_.first)
+      .sortBy(_.head)
       .map(_.last)
       .value() as string[];
     const visible_ordered_col_keys = _.intersection(

--- a/client/src/components/DisplayTable/DisplayTableUtils.js
+++ b/client/src/components/DisplayTable/DisplayTableUtils.js
@@ -199,34 +199,34 @@ export const SelectPage = ({
     }
   };
   const extend_options_left = (option_range, page_count, current_page) => {
-    if (_.first(option_range) === 1) {
+    if (_.head(option_range) === 1) {
       //option range sees page 1, add 2 to the end
       return [
         ...option_range,
         _.last(option_range) + 1,
         _.last(option_range) + 2,
       ];
-    } else if (_.first(option_range) === 2) {
+    } else if (_.head(option_range) === 2) {
       //option range sees page 2 (page 1 is not visible so manually add it)
       return [1, ...option_range, _.last(option_range) + 1];
-    } else if (_.first(option_range) === 3) {
+    } else if (_.head(option_range) === 3) {
       //option range sees page 3 (page 1 and 2 not visible, manually add it)
       return [1, 2, ...option_range];
     } else if (current_page === page_count - 3) {
       //being on the forth last page manages to be short 1 option
       return [
         1,
-        _.first(option_range) - 2,
-        _.first(option_range) - 1,
+        _.head(option_range) - 2,
+        _.head(option_range) - 1,
         ...option_range,
       ];
     } else if (current_page > page_count - 3) {
       //being in the last 3 pages manages to be short 2 options
       return [
         1,
-        _.first(option_range) - 3,
-        _.first(option_range) - 2,
-        _.first(option_range) - 1,
+        _.head(option_range) - 3,
+        _.head(option_range) - 2,
+        _.head(option_range) - 1,
         ...option_range,
       ];
     } else {
@@ -276,7 +276,7 @@ export const SelectPage = ({
         //we are missing 4 options (2 ellipses and 2 extremeties)
         return [
           1,
-          _.first(raw_page_options) - 1,
+          _.head(raw_page_options) - 1,
           ...raw_page_options,
           _.last(raw_page_options) + 1,
           page_count,
@@ -285,7 +285,7 @@ export const SelectPage = ({
         //handling cases for being in the extremities
         if (!_.includes(raw_page_options, 1)) {
           //if we are close to the very front, we must manually add the ellipsis value and the very last value
-          return [1, _.first(raw_page_options) - 1, ...raw_page_options];
+          return [1, _.head(raw_page_options) - 1, ...raw_page_options];
         } else if (!_.includes(raw_page_options, page_count)) {
           //same thing here except we are close to the very end
           return [

--- a/client/src/components/DisplayTable/DisplayTableUtils.js
+++ b/client/src/components/DisplayTable/DisplayTableUtils.js
@@ -357,8 +357,7 @@ export const SelectPageSize = ({
       : _.ceil(num_items / page_size_increment);
 
   const options = _.chain(num_options + 1)
-    .range()
-    .map((_, ix) => {
+    .times((_, ix) => {
       if (ix === num_options) {
         return { value: num_items, label: text_maker("show_all") };
       } else {

--- a/client/src/components/HeaderNotification/HeaderNotification.unit-test.tsx
+++ b/client/src/components/HeaderNotification/HeaderNotification.unit-test.tsx
@@ -23,7 +23,7 @@ describe("HeaderNotification", () => {
       />
     );
 
-    _.each(list_of_text, (text) => {
+    _.forEach(list_of_text, (text) => {
       expect(screen.getByText(text)).toBeInTheDocument();
     });
   });

--- a/client/src/components/HeightClipper/HeightClipper.tsx
+++ b/client/src/components/HeightClipper/HeightClipper.tsx
@@ -21,7 +21,7 @@ interface HeightClipperProps {
 interface HeightClipperState {
   exceedsHeight: boolean;
   shouldClip: boolean;
-} 
+}
 
 export const HeightClipper = (props: HeightClipperProps) =>
   is_a11y_mode ? props.children : <_HeightClipper {...props} />;

--- a/client/src/components/HeightClipper/HeightClipper.tsx
+++ b/client/src/components/HeightClipper/HeightClipper.tsx
@@ -21,7 +21,7 @@ interface HeightClipperProps {
 interface HeightClipperState {
   exceedsHeight: boolean;
   shouldClip: boolean;
-}
+} 
 
 export const HeightClipper = (props: HeightClipperProps) =>
   is_a11y_mode ? props.children : <_HeightClipper {...props} />;
@@ -88,12 +88,12 @@ class _HeightClipper extends React.Component<
       _.map<Element, HTMLElement>(
         height_clipper_node.querySelectorAll('[tabindex="-999"]'),
         _.identity
-      ).forEach((node: HTMLElement) => node.removeAttribute("tabindex"));
+      ).flatMap((node: HTMLElement) => node.removeAttribute("tabindex"));
 
       _.map<Element, HTMLElement>(
         height_clipper_node.querySelectorAll("[prev-tabindex]"),
         _.identity
-      ).forEach((node: HTMLElement) => {
+      ).flatMap((node: HTMLElement) => {
         const temp = node.getAttribute("prev-tabidnex");
         if (temp !== null) {
           const previous_tabindex = temp;
@@ -105,7 +105,7 @@ class _HeightClipper extends React.Component<
       _.map<Element, HTMLElement>(
         height_clipper_node.querySelectorAll("svg"),
         _.identity
-      ).forEach((node: HTMLElement) => node.removeAttribute("focusable"));
+      ).flatMap((node: HTMLElement) => node.removeAttribute("focusable"));
     }
   }
 
@@ -113,7 +113,7 @@ class _HeightClipper extends React.Component<
     _.map<Element, HTMLElement>(
       untabbable_children_node.querySelectorAll("*"),
       _.identity
-    ).forEach((node: HTMLElement) => {
+    ).flatMap((node: HTMLElement) => {
       if (
         !_.isUndefined(node.tabIndex) &&
         !_.isNull(node.tabIndex) &&
@@ -131,7 +131,7 @@ class _HeightClipper extends React.Component<
     _.map<Element, HTMLElement>(
       untabbable_children_node.querySelectorAll("svg"),
       _.identity
-    ).forEach((node: HTMLElement) => {
+    ).flatMap((node: HTMLElement) => {
       node.setAttribute("focusable", "false");
     });
   }

--- a/client/src/components/LeafSpinner/LeafSpinner.tsx
+++ b/client/src/components/LeafSpinner/LeafSpinner.tsx
@@ -76,7 +76,7 @@ export const LeafSpinner = ({
   config_name,
   use_light_colors = false,
 }: LeafSpinnerProps) => {
-  const default_config_name = _.chain(spinner_configs).keys().first().value();
+  const default_config_name = _.chain(spinner_configs).keys().head().value();
 
   const { outer_positioning_style, spinner_container_style } =
     spinner_configs[config_name || default_config_name];

--- a/client/src/components/Tabs/Tabs.tsx
+++ b/client/src/components/Tabs/Tabs.tsx
@@ -136,7 +136,7 @@ export const TabsStateful = <
   TabKey extends keyof Tabs
 >({
   tabs,
-  default_tab_key = _.chain(tabs).keys().first().value() as TabKey,
+  default_tab_key = _.chain(tabs).keys().head().value() as TabKey,
 }: {
   tabs: Tabs;
   default_tab_key?: TabKey;

--- a/client/src/components/Tabs/Tabs.unit-test.tsx
+++ b/client/src/components/Tabs/Tabs.unit-test.tsx
@@ -31,7 +31,7 @@ describe("Tabs", () => {
     const tablist_node = screen.getByRole("tablist");
 
     const tab_nodes = getAllByRole(tablist_node, "tab");
-    _.each(tab_nodes, (tab_node, index) => {
+    _.forEach(tab_nodes, (tab_node, index) => {
       expect(tab_node).toContainElement(
         getByText(tablist_node, tabs[_.keys(tabs)[index]])
       );

--- a/client/src/core/NavComponents.js
+++ b/client/src/core/NavComponents.js
@@ -390,7 +390,7 @@ const synchronize_link = (target_el_selector, link_modifier_func) => {
   newHash = newHash.split("#")[1] || "";
 
   if (_.get(el_to_update, "href")) {
-    const link = _.first(el_to_update.href.split("#"));
+    const link = _.head(el_to_update.href.split("#"));
     if (link) {
       el_to_update.href = `${link}#${newHash}`;
     }

--- a/client/src/core/ensure_loaded.js
+++ b/client/src/core/ensure_loaded.js
@@ -22,7 +22,7 @@ const load_tables = (table_set) =>
   Promise.all(
     _.chain(table_set)
       .reject(_.property("loaded"))
-      .invokeMap((table) => table.load())
+      .map((table) => table.load())
       .value()
   );
 

--- a/client/src/core/ensure_loaded.js
+++ b/client/src/core/ensure_loaded.js
@@ -22,7 +22,7 @@ const load_tables = (table_set) =>
   Promise.all(
     _.chain(table_set)
       .reject(_.property("loaded"))
-      .map((table) => table.load())
+      .invokeMap((table) => table.load())
       .value()
   );
 

--- a/client/src/core/format.ts
+++ b/client/src/core/format.ts
@@ -122,9 +122,8 @@ const compact = (
         }
       });
 
-      const defined_compacted = _.reject(
-        compacted,
-        (pair) => _.isUndefined(pair)
+      const defined_compacted = _.reject(compacted, (pair) =>
+        _.isUndefined(pair)
       );
       const defined_compact_val = defined_compacted[0];
 

--- a/client/src/core/format.ts
+++ b/client/src/core/format.ts
@@ -122,9 +122,9 @@ const compact = (
         }
       });
 
-      const defined_compacted = _.filter(
+      const defined_compacted = _.reject(
         compacted,
-        (pair) => !_.isUndefined(pair)
+        (pair) => _.isUndefined(pair)
       );
       const defined_compact_val = defined_compacted[0];
 
@@ -184,8 +184,8 @@ const compact_written = (
         }
       });
 
-      const defined_compacted = _.filter(compacted, (pair) => {
-        return !_.isUndefined(pair);
+      const defined_compacted = _.reject(compacted, (pair) => {
+        return _.isUndefined(pair);
       });
 
       // ... this code is a real pile of crap. Refactor a TODO, in the meantime just wanted to note that the pre-TS code assumed

--- a/client/src/explorer_common/hierarchy_tools.js
+++ b/client/src/explorer_common/hierarchy_tools.js
@@ -15,7 +15,7 @@ function flat_descendants(node) {
   let currentWave = [node];
   const flat_nodes = [];
   while (_.some(currentWave, (node) => !_.isEmpty(node.children))) {
-    _.each(currentWave, (node) => {
+    _.forEach(currentWave, (node) => {
       if (!_.isEmpty(node.children)) {
         flat_nodes.push(...node.children);
       }
@@ -31,7 +31,7 @@ function flat_descendants(node) {
 
 function _create_children_links(node, nodes_by_parent_id) {
   node.children = nodes_by_parent_id[node.id] || null;
-  _.each(node.children, (child) =>
+  _.forEach(node.children, (child) =>
     _create_children_links(child, nodes_by_parent_id)
   );
 }
@@ -76,7 +76,7 @@ function filter_hierarchy(
     .value();
 
   //add in ancestors of all the current nodes
-  _.each(positive_search_results, (node) => {
+  _.forEach(positive_search_results, (node) => {
     let current = node;
     let done = false;
     while (!done) {
@@ -111,7 +111,7 @@ function ensureVisibility(nodes, shouldNodeBeVisible) {
 
   const nodes_to_ensure_visibility = _.filter(nodes, shouldNodeBeVisible);
 
-  _.each(nodes_to_ensure_visibility, (node) => {
+  _.forEach(nodes_to_ensure_visibility, (node) => {
     let current = node.parent_id && nodes_by_id[node.parent_id];
     while (current) {
       current.is_expanded = true;
@@ -204,7 +204,7 @@ function convert_d3_hierarchy_to_explorer_hierarchy(root) {
   const new_nodes_by_parent_id = _.groupBy(new_nodes, (node) => node.parent_id);
 
   //finally, attach the children links.
-  _.each(new_nodes, (node) => {
+  _.forEach(new_nodes, (node) => {
     node.children = new_nodes_by_parent_id[node.id];
   });
 
@@ -246,7 +246,7 @@ function simplify_hierarchy(flat_nodes, is_simple_parent, bottom_layer_filter) {
     .value();
 
   const ancestors_by_id = {};
-  _.each(simple_parents, (node) => {
+  _.forEach(simple_parents, (node) => {
     let current = node;
     let done = false;
     while (!done) {

--- a/client/src/explorer_common/resource_explorer_common.js
+++ b/client/src/explorer_common/resource_explorer_common.js
@@ -46,7 +46,7 @@ const get_rows_for_subject_from_table = _.memoize(
     } else if (!_.isEmpty(subject.children_tags)) {
       return _.chain(subject.children_tags)
         .flatMap((tag) => get_rows_for_subject_from_table(tag, type, year))
-        .flatten(true)
+        .flatten()
         .uniqBy()
         .compact()
         .value();

--- a/client/src/explorer_common/resource_explorer_common.js
+++ b/client/src/explorer_common/resource_explorer_common.js
@@ -40,13 +40,12 @@ const get_rows_for_subject_from_table = _.memoize(
         .value();
     } else if (subject.subject_type === "ministry") {
       return _.chain(subject.orgs)
-        .map((org) => get_rows_for_subject_from_table(org, type, year))
-        .flatten(true)
+        .flatMap((org) => get_rows_for_subject_from_table(org, type, year))
         .compact()
         .value();
     } else if (!_.isEmpty(subject.children_tags)) {
       return _.chain(subject.children_tags)
-        .map((tag) => get_rows_for_subject_from_table(tag, type, year))
+        .flatMap((tag) => get_rows_for_subject_from_table(tag, type, year))
         .flatten(true)
         .uniqBy()
         .compact()

--- a/client/src/handlebars/register_helpers.side-effects.js
+++ b/client/src/handlebars/register_helpers.side-effects.js
@@ -14,7 +14,7 @@ import { lang } from "src/core/injected_build_constants";
 
 import { infographic_href_template, glossary_href } from "src/link_utils";
 
-_.each(formats, (format, key) => {
+_.forEach(formats, (format, key) => {
   HandlebarsWithPrototypeAccess.registerHelper(
     "fmt_" + key,
     (amount) => new HandlebarsWithPrototypeAccess.SafeString(format(amount))

--- a/client/src/infographic/Infographic.js
+++ b/client/src/infographic/Infographic.js
@@ -248,7 +248,7 @@ class Infographic extends React.Component {
               .map((panel_key) =>
                 PanelRegistry.lookup(panel_key, subject.subject_type)
               )
-              .filter((panel) => !panel.is_meta_panel)
+              .reject((panel) => panel.is_meta_panel)
               .map((panel) => [panel.key, panel.get_title(subject)])
               .fromPairs()
               .value()}

--- a/client/src/infographic/Infographic.js
+++ b/client/src/infographic/Infographic.js
@@ -313,7 +313,7 @@ class Infographic extends React.Component {
 
         if (!_.has(subject_panels_by_bubble_id, active_bubble_id)) {
           const fallback_bubble_for_subject =
-            _.chain(subject_panels_by_bubble_id).keys().first().value() || null;
+            _.chain(subject_panels_by_bubble_id).keys().head().value() || null;
 
           this.props.url_replace(
             infographic_href_template(

--- a/client/src/models/covid/populate.js
+++ b/client/src/models/covid/populate.js
@@ -81,7 +81,7 @@ export const api_load_all_covid_measures = () => {
   }
 
   return promisedAllCovidMeasures().then((covid_measures) => {
-    _.each(covid_measures, (covid_measure) =>
+    _.forEach(covid_measures, (covid_measure) =>
       CovidMeasureStore.create_and_register(covid_measure)
     );
 

--- a/client/src/models/covid/queries/GovCovidSummary/GovCovidSummary.ts
+++ b/client/src/models/covid/queries/GovCovidSummary/GovCovidSummary.ts
@@ -16,5 +16,5 @@ export const {
   query_name: "GovCovidSummary",
   query: GovCovidSummaryDocument,
   resolver: (response: GovCovidSummaryQuery) =>
-    _.first(response?.root?.gov?.covid_summary),
+    _.head(response?.root?.gov?.covid_summary),
 });

--- a/client/src/models/covid/queries/OrgCovidSummary/OrgCovidSummary.ts
+++ b/client/src/models/covid/queries/OrgCovidSummary/OrgCovidSummary.ts
@@ -16,5 +16,5 @@ export const {
   query_name: "OrgCovidSummary",
   query: OrgCovidSummaryDocument,
   resolver: (response: OrgCovidSummaryQuery) =>
-    _.first(response?.root?.org?.covid_summary),
+    _.head(response?.root?.org?.covid_summary),
 });

--- a/client/src/models/covid/queries/TopCovidSpending/TopCovidSpending.ts
+++ b/client/src/models/covid/queries/TopCovidSpending/TopCovidSpending.ts
@@ -17,14 +17,14 @@ export const {
   query: TopCovidSpendingDocument,
   resolver: (response: TopCovidSpendingQuery) =>
     _.chain(response?.root?.gov?.covid_summary)
-      .first()
+      .head()
       .thru(({ top_spending_orgs, top_spending_measures }) => ({
         top_spending_orgs: _.map(
           _.compact(top_spending_orgs),
           ({ name, covid_summary }) => ({
             name,
             spending: _.chain(covid_summary)
-              .first()
+              .head()
               .get("covid_expenditures")
               .thru(({ vote, stat }) => (vote || 0) + (stat || 0))
               .value(),
@@ -35,7 +35,7 @@ export const {
           ({ name, covid_data }) => ({
             name,
             spending: _.chain(covid_data)
-              .first()
+              .head()
               .get("covid_expenditures")
               .compact()
               .reduce(

--- a/client/src/models/faq/populate_faq.ts
+++ b/client/src/models/faq/populate_faq.ts
@@ -10,7 +10,7 @@ import { sanitized_marked } from "src/general_utils";
 import { faqStore } from "./faq";
 
 export const populate_faq = (faq: ParsedCsvWithUndefineds) =>
-  _.each(faq, (faq) => {
+  _.forEach(faq, (faq) => {
     faqStore.create_and_register({
       ...enforced_required_fields({
         id: faq.id,

--- a/client/src/models/footnotes/dynamic_footnotes.ts
+++ b/client/src/models/footnotes/dynamic_footnotes.ts
@@ -106,9 +106,9 @@ export const get_dynamic_footnote_definitions = (): FootNoteDef[] => {
           doc_type,
           year,
         }))
-        .filter(
+        .reject(
           ({ late_orgs }) =>
-            !_.chain(late_orgs).intersection(EXEMPT_ORGS).isEmpty().value()
+            _.chain(late_orgs).intersection(EXEMPT_ORGS).isEmpty().value()
         )
         .value();
       if (!_.isEmpty(docs_with_late_expempt_orgs)) {

--- a/client/src/models/footnotes/dynamic_footnotes.ts
+++ b/client/src/models/footnotes/dynamic_footnotes.ts
@@ -106,9 +106,8 @@ export const get_dynamic_footnote_definitions = (): FootNoteDef[] => {
           doc_type,
           year,
         }))
-        .reject(
-          ({ late_orgs }) =>
-            _.chain(late_orgs).intersection(EXEMPT_ORGS).isEmpty().value()
+        .reject(({ late_orgs }) =>
+          _.chain(late_orgs).intersection(EXEMPT_ORGS).isEmpty().value()
         )
         .value();
       if (!_.isEmpty(docs_with_late_expempt_orgs)) {

--- a/client/src/models/footnotes/populate_footnotes.ts
+++ b/client/src/models/footnotes/populate_footnotes.ts
@@ -31,7 +31,7 @@ function populate_footnotes(csv_str: string) {
     _.mapValues(row, (item) => _.trim(item))
   );
 
-  _.each(rows, (obj) => {
+  _.forEach(rows, (obj) => {
     const {
       id,
       subject_class,
@@ -132,7 +132,7 @@ function load_footnotes_bundle(
 function populate_global_footnotes(csv_str: string) {
   populate_footnotes(csv_str);
 
-  _.each(get_dynamic_footnote_definitions(), function (footnote_config) {
+  _.forEach(get_dynamic_footnote_definitions(), function (footnote_config) {
     footNoteStore.create_and_register(footnote_config);
   });
 }

--- a/client/src/models/glossary/populate_glossary.ts
+++ b/client/src/models/glossary/populate_glossary.ts
@@ -8,7 +8,7 @@ import { lang } from "src/core/injected_build_constants";
 import { glossaryEntryStore } from "./glossary";
 
 export const populate_glossary = (glossary: ParsedCsvWithUndefineds) =>
-  _.each(glossary, ({ id, name_en, name_fr, def_en, def_fr }) => {
+  _.forEach(glossary, ({ id, name_en, name_fr, def_en, def_fr }) => {
     const raw_definition = lang === "en" ? def_en : def_fr;
 
     raw_definition &&

--- a/client/src/models/results/populate_results.js
+++ b/client/src/models/results/populate_results.js
@@ -242,8 +242,8 @@ function extract_flat_data_from_results_hierarchies(
     pi_dr_links = [];
 
   const crawl_hierachy_level = (subject_node) =>
-    _.each(subject_node, (subject) => {
-      _.each(
+    _.forEach(subject_node, (subject) => {
+      _.forEach(
         _.chain(subject)
           .pickBy((value, key) => /(drr|dp)[0-9][0-9]_results/.test(key))
           .reduce((memo, doc_results) => [...memo, ...doc_results], [])
@@ -256,18 +256,18 @@ function extract_flat_data_from_results_hierarchies(
             doc: result.doc,
           });
 
-          _.each(result.indicators, (indicator) => {
+          _.forEach(result.indicators, (indicator) => {
             indicators.push(_.omit(indicator, "__typename"));
           });
         }
       );
 
       if (!_.isEmpty(subject.pidrlinks)) {
-        _.each(subject.pidrlinks, (pidrlink) => pi_dr_links.push(pidrlink));
+        _.forEach(subject.pidrlinks, (pidrlink) => pi_dr_links.push(pidrlink));
       }
     });
 
-  _.each(hierarchical_response_data, (response) => {
+  _.forEach(hierarchical_response_data, (response) => {
     switch (response.__typename) {
       case "Program":
         crawl_hierachy_level([response]);
@@ -380,16 +380,16 @@ export function api_load_results_bundle(subject, result_docs) {
       const { results, indicators, pi_dr_links } =
         extract_flat_data_from_results_hierarchies(hierarchical_response_data);
 
-      _.each(results, (obj) => Result.create_and_register(obj));
-      _.each(
+      _.forEach(results, (obj) => Result.create_and_register(obj));
+      _.forEach(
         indicators,
         (obj) => Indicator.lookup(obj.id) || Indicator.create_and_register(obj)
       );
-      _.each(pi_dr_links, ({ program_id, result_id }) =>
+      _.forEach(pi_dr_links, ({ program_id, result_id }) =>
         PI_DR_Links.add(program_id, result_id)
       );
 
-      _.each(
+      _.forEach(
         docs_to_load,
         // Need to use _.setWith and pass Object as the customizer function to account for keys that may be numbers (e.g. dept id's)
         // Just using _.set makes large empty arrays when using a number as an accessor in the target string, bleh
@@ -511,16 +511,16 @@ export function api_load_single_indicator(subject, result_docs) {
       const { results, indicators, pi_dr_links } =
         extract_flat_data_from_results_hierarchies(hierarchical_response_data);
 
-      _.each(results, (obj) => Result.create_and_register(obj));
-      _.each(
+      _.forEach(results, (obj) => Result.create_and_register(obj));
+      _.forEach(
         indicators,
         (obj) => Indicator.lookup(obj.id) || Indicator.create_and_register(obj)
       );
-      _.each(pi_dr_links, ({ program_id, result_id }) =>
+      _.forEach(pi_dr_links, ({ program_id, result_id }) =>
         PI_DR_Links.add(program_id, result_id)
       );
 
-      _.each(
+      _.forEach(
         docs_to_load,
         // Need to use _.setWith and pass Object as the customizer function to account for keys that may be numbers (e.g. dept id's)
         // Just using _.set makes large empty arrays when using a number as an accessor in the target string, bleh
@@ -672,7 +672,7 @@ export function api_load_results_counts(level = "summary") {
         }
 
         // if it's in the results count set, it has results data
-        _.each(mapped_rows, ({ id }) => (_subject_has_results[id] = true)); // side effect
+        _.forEach(mapped_rows, ({ id }) => (_subject_has_results[id] = true)); // side effect
 
         return Promise.resolve();
       })

--- a/client/src/models/results/results.js
+++ b/client/src/models/results/results.js
@@ -327,7 +327,7 @@ const build_doc_info_objects = (doc_type, docs) =>
 
       const primary_resource_year = is_drr
         ? _.last(resource_years)
-        : _.first(resource_years);
+        : _.head(resource_years);
 
       return {
         doc_type,

--- a/client/src/models/subjects/Dept.ts
+++ b/client/src/models/subjects/Dept.ts
@@ -127,7 +127,7 @@ export class Dept extends BaseSubjectFactory<DeptDef, typeof dept_subject_type>(
     return _.filter(Dept.store.get_all(), (dept) => dept.has_table_data);
   }
   static depts_without_table_data() {
-    return _.filter(Dept.store.get_all(), (dept) => !dept.has_table_data);
+    return _.reject(Dept.store.get_all(), (dept) => dept.has_table_data);
   }
   get has_table_data() {
     return !_.isEmpty(this.table_ids);

--- a/client/src/models/subjects/populate_subjects.ts
+++ b/client/src/models/subjects/populate_subjects.ts
@@ -21,7 +21,7 @@ export const populate_depts = (
   dept_code_to_csv_name: ParsedCsvWithUndefineds,
   crso: ParsedCsvWithUndefineds
 ) => {
-  _.each(ministries, ({ id, name_en, name_fr }) => {
+  _.forEach(ministries, ({ id, name_en, name_fr }) => {
     Dept.ministryStore.create_and_register({
       ...enforced_required_fields({
         id,
@@ -30,7 +30,7 @@ export const populate_depts = (
     });
   });
 
-  _.each(ministers, ({ id, name_en, name_fr }) => {
+  _.forEach(ministers, ({ id, name_en, name_fr }) => {
     Dept.ministerStore.create_and_register({
       ...enforced_required_fields({
         id,
@@ -39,7 +39,7 @@ export const populate_depts = (
     });
   });
 
-  _.each(inst_forms, ({ id, parent_id, name_en, name_fr }) => {
+  _.forEach(inst_forms, ({ id, parent_id, name_en, name_fr }) => {
     Dept.instFormStore.create_and_register({
       ...enforced_required_fields({
         id,
@@ -54,7 +54,7 @@ export const populate_depts = (
     const url_row = _.find(url_lookups, ({ id }) => id === url_key);
     return url_row?.[`url_${lang}`] || "";
   };
-  _.each(
+  _.forEach(
     igoc,
     ({
       org_id: id,
@@ -146,7 +146,7 @@ export const populate_crsos = (
   igoc: ParsedCsvWithUndefineds,
   program: ParsedCsvWithUndefineds
 ) =>
-  _.each(
+  _.forEach(
     crso,
     ({ id, dept_code, name, desc, is_active, is_drf, is_internal_service }) => {
       CRSO.store.create_and_register({
@@ -181,7 +181,7 @@ export const populate_programs_and_tags = (
   program_tags: ParsedCsvWithUndefineds,
   tags_to_programs: ParsedCsvWithUndefineds
 ) => {
-  _.each(
+  _.forEach(
     program,
     ({
       dept_code,
@@ -230,7 +230,7 @@ export const populate_programs_and_tags = (
       });
     }
   );
-  _.each(
+  _.forEach(
     program_tag_types,
     ({ id, type: cardinality, name_en, name_fr, desc_en, desc_fr }) => {
       ProgramTag.store.create_and_register({
@@ -250,7 +250,7 @@ export const populate_programs_and_tags = (
       });
     }
   );
-  _.each(
+  _.forEach(
     program_tags,
     ({
       tag_id: id,

--- a/client/src/models/text.js
+++ b/client/src/models/text.js
@@ -154,7 +154,7 @@ const text_bundles_by_filename = {};
 const add_text_bundle = (text_bundle) => {
   const { __file_name__ } = text_bundle;
   const to_add = {};
-  _.each(_.omit(text_bundle, "__file_name__"), (text_obj, key) => {
+  _.forEach(_.omit(text_bundle, "__file_name__"), (text_obj, key) => {
     if (text_obj.handlebars_partial) {
       HandlebarsWithPrototypeAccess.registerPartial(key, text_obj.text);
       return;
@@ -223,7 +223,7 @@ const _create_text_maker =
     }
 
     let rtn = text_obj.text;
-    _.each(text_obj.transform, (transform) => {
+    _.forEach(text_obj.transform, (transform) => {
       if (transform === "handlebars") {
         if (!text_obj.handlebars_compiled) {
           text_obj.text = HandlebarsWithPrototypeAccess.compile(rtn);

--- a/client/src/models/text.js
+++ b/client/src/models/text.js
@@ -241,7 +241,7 @@ const _create_text_maker =
           temp_dom_node.querySelectorAll(".embeded-markdown");
 
         if (embedded_markdown_nodes.length) {
-          _.map(embedded_markdown_nodes, _.identity).forEach(
+          _.map(embedded_markdown_nodes, _.identity).flatMap(
             (node) =>
               (node.innerHTML = marked(node.innerHTML, {
                 sanitize: false,

--- a/client/src/models/text.js
+++ b/client/src/models/text.js
@@ -115,7 +115,7 @@ const run_template = function (s, extra_args = {}) {
   }
   // build common arguments object which will be passed
   // to all templates
-  const args = _.extend({}, extra_args, full_template_globals); //FIXME: extra_args should take precedence over template globals. Don't have time to test this right now.
+  const args = _.assignIn({}, extra_args, full_template_globals); //FIXME: extra_args should take precedence over template globals. Don't have time to test this right now.
   // combine the `extra_args` with the common arguments
   if (s) {
     let _template;
@@ -174,7 +174,7 @@ const add_text_bundle = (text_bundle) => {
       text_obj.handlebars_compiled = true;
     }
   });
-  _.extend(template_store, to_add);
+  _.assignIn(template_store, to_add);
 
   text_bundles_by_filename[__file_name__] = to_add;
 };
@@ -272,7 +272,7 @@ const create_text_maker = (bundles) => {
   }
 
   const combined = combine_bundles(bundles);
-  _.extend(combined, combined_global_bundle);
+  _.assignIn(combined, combined_global_bundle);
   const func = _create_text_maker(combined);
   combined.__text_maker_func__ = func;
 

--- a/client/src/models/text.js
+++ b/client/src/models/text.js
@@ -241,7 +241,7 @@ const _create_text_maker =
           temp_dom_node.querySelectorAll(".embeded-markdown");
 
         if (embedded_markdown_nodes.length) {
-          _.map(embedded_markdown_nodes, _.idenity).forEach(
+          _.map(embedded_markdown_nodes, _.identity).forEach(
             (node) =>
               (node.innerHTML = marked(node.innerHTML, {
                 sanitize: false,

--- a/client/src/models/utils/populate_utils.ts
+++ b/client/src/models/utils/populate_utils.ts
@@ -6,7 +6,7 @@ export const enforced_required_fields = <
 >(
   enforced_required_fields: RequiredFields
 ) => {
-  _.each(enforced_required_fields, (cell, key) => {
+  _.forEach(enforced_required_fields, (cell, key) => {
     if (typeof cell === "undefined") {
       throw new Error(`Required field "${key}" has an empty cell`);
     }

--- a/client/src/models/years.js
+++ b/client/src/models/years.js
@@ -71,12 +71,7 @@ const actual_to_planned_gap_year = _.chain(year_templates)
     _.head(planning_years),
   ])
   .map((fiscal_year) =>
-    _.chain(fiscal_year)
-      .thru(run_template)
-      .split("-")
-      .head()
-      .parseInt()
-      .value()
+    _.chain(fiscal_year).thru(run_template).split("-").head().parseInt().value()
   )
   .thru(([last_pa_year, first_planning_year]) => {
     if (first_planning_year - last_pa_year == 2) {

--- a/client/src/models/years.js
+++ b/client/src/models/years.js
@@ -5,7 +5,7 @@ import { lang } from "src/core/injected_build_constants";
 import { run_template } from "./text";
 
 const fiscal_year_to_year = (fy_string) =>
-  _.chain(fy_string).split("-").first().toNumber().value() || null;
+  _.chain(fy_string).split("-").head().toNumber().value() || null;
 
 const year_to_fiscal_year = (year) => {
   if (year) {
@@ -68,13 +68,13 @@ const year_templates = {
 const actual_to_planned_gap_year = _.chain(year_templates)
   .thru(({ std_years, planning_years }) => [
     _.last(std_years),
-    _.first(planning_years),
+    _.head(planning_years),
   ])
   .map((fiscal_year) =>
     _.chain(fiscal_year)
       .thru(run_template)
       .split("-")
-      .first()
+      .head()
       .parseInt()
       .value()
   )

--- a/client/src/panels/panel_declarations/covid/covid_common_utils.js
+++ b/client/src/panels/panel_declarations/covid/covid_common_utils.js
@@ -88,7 +88,7 @@ const get_est_doc_list_plain_text = (est_docs) =>
 const summable_data_keys = ["stat", "vote"];
 const row_group_reducer = (group) => {
   const keys_to_sum_over = _.chain(group)
-    .first()
+    .head()
     .keys()
     .intersection(summable_data_keys)
     .value();
@@ -112,7 +112,7 @@ const roll_up_flat_measure_data_by_property = (
       // since the key value will have been converted to a string (happens with fiscal_year below, but we
       // know that should be an int so can just covert back ourselves)
       const roll_up_value = _.chain(roll_up_group)
-        .first()
+        .head()
         .get(roll_up_property)
         .value();
 

--- a/client/src/panels/panel_declarations/covid/covid_estimates.js
+++ b/client/src/panels/panel_declarations/covid/covid_estimates.js
@@ -478,7 +478,7 @@ class SummaryTabComponent extends React.Component {
       .value();
 
     this.graph_keys = _.chain(this.graph_data)
-      .first()
+      .head()
       .omit(this.graph_index_key)
       .keys()
       .value();

--- a/client/src/panels/panel_declarations/covid/covid_expenditures.js
+++ b/client/src/panels/panel_declarations/covid/covid_expenditures.js
@@ -45,11 +45,11 @@ const SummaryTab = ({ args: { calculations }, data }) => {
   const { top_spending_orgs, top_spending_measures } = data;
 
   const { name: top_spending_org_name, spending: top_spending_org_amount } =
-    _.first(top_spending_orgs);
+    _.head(top_spending_orgs);
   const {
     name: top_spending_measure_name,
     spending: top_spending_measure_amount,
-  } = _.first(top_spending_measures);
+  } = _.head(top_spending_measures);
   const text_args = {
     ...calculations,
     top_spending_org_name,

--- a/client/src/panels/panel_declarations/finances/detailed_program_spending_split/detailed_program_spending_split.js
+++ b/client/src/panels/panel_declarations/finances/detailed_program_spending_split/detailed_program_spending_split.js
@@ -286,7 +286,7 @@ class DetailedProgramSplit extends React.Component {
       )
       .groupBy((row) => row.program.name)
       .map((group) => ({
-        label: _.first(group).program.name,
+        label: _.head(group).program.name,
 
         ..._.chain(group)
           .groupBy("so_label")

--- a/client/src/panels/panel_declarations/finances/drr_dp_resources/crso_by_prog.js
+++ b/client/src/panels/panel_declarations/finances/drr_dp_resources/crso_by_prog.js
@@ -53,7 +53,7 @@ const render_resource_type =
     //use hacky side-effects to create colors for all programs, so that these colours are consitent accross the fte/$ panel
     const all_program_names = _.chain(exp_data).map("label").uniq().value();
     const colors = infobase_colors();
-    _.each(all_program_names, (name) => colors(name));
+    _.forEach(all_program_names, (name) => colors(name));
 
     const first_year_program_count = _.chain(exp_data)
       .zip(fte_data)
@@ -233,7 +233,7 @@ const get_calculate_func =
       _.chain(data)
         .reduce(
           (sum_by_year, row) => {
-            _.each(years, (year) => {
+            _.forEach(years, (year) => {
               sum_by_year[year] = sum_by_year[year] + row[year];
             });
             return sum_by_year;

--- a/client/src/panels/panel_declarations/finances/drr_dp_resources/spending_in_perspective.js
+++ b/client/src/panels/panel_declarations/finances/drr_dp_resources/spending_in_perspective.js
@@ -122,7 +122,7 @@ export const declare_spending_in_tag_perspective_panel = () =>
         }
         const { programSpending } = tables;
         //analysis: as of writing this (oct 2016) the max number of tags encountered is 13.
-        const prog_row = _.first(programSpending.programs.get(subject));
+        const prog_row = _.head(programSpending.programs.get(subject));
 
         if (!prog_row || !(prog_row[col] > 0)) {
           return false;

--- a/client/src/panels/panel_declarations/finances/sobj/personel_spend.js
+++ b/client/src/panels/panel_declarations/finances/sobj/personel_spend.js
@@ -38,7 +38,7 @@ export const declare_personnel_spend_panel = () =>
         const sorted_pairs = _.sortBy(year_value_pairs, _.last);
 
         const [max_year, max_spend] = _.last(sorted_pairs);
-        const [min_year, min_spend] = _.first(sorted_pairs);
+        const [min_year, min_spend] = _.head(sorted_pairs);
         const text_calculations = {
           five_year_avg,
           max_spend,

--- a/client/src/panels/panel_declarations/finances/sobj/spend_by_so_hist.js
+++ b/client/src/panels/panel_declarations/finances/sobj/spend_by_so_hist.js
@@ -72,7 +72,7 @@ class SobjLine extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      active_sobjs: [_.first(props.data).label],
+      active_sobjs: [_.head(props.data).label],
     };
     this.colors = scaleOrdinal().range(
       _.concat(newIBLightCategoryColors, newIBDarkCategoryColors)

--- a/client/src/panels/panel_declarations/finances/transfer_payments/historical_g_and_c.js
+++ b/client/src/panels/panel_declarations/finances/transfer_payments/historical_g_and_c.js
@@ -134,7 +134,7 @@ class DetailedHistTPItems extends React.Component {
     const { rows } = props;
     this.state = {
       active_indices: [0],
-      active_type: _.first(rows, "type_id").type_id,
+      active_type: _.head(rows, "type_id").type_id,
     };
 
     this.color_scale = infobase_colors();

--- a/client/src/panels/panel_declarations/finances/transfer_payments/historical_g_and_c.js
+++ b/client/src/panels/panel_declarations/finances/transfer_payments/historical_g_and_c.js
@@ -134,7 +134,7 @@ class DetailedHistTPItems extends React.Component {
     const { rows } = props;
     this.state = {
       active_indices: [0],
-      active_type: _.head(rows, "type_id").type_id,
+      active_type: _.first(rows, "type_id").type_id,
     };
 
     this.color_scale = infobase_colors();

--- a/client/src/panels/panel_declarations/finances/vote_stat/in_year_estimates_split.js
+++ b/client/src/panels/panel_declarations/finances/vote_stat/in_year_estimates_split.js
@@ -38,7 +38,7 @@ const estimates_split_calculate = ({ subject, tables }) => {
       const est_amnt = sum(_.map(est_doc_lines[1], est_in_year_col));
       return [est_doc_lines[0], est_amnt];
     })
-    .filter((row) => row[1] !== 0)
+    .reject((row) => row[1] === 0)
     .value();
 
   const calculations = {

--- a/client/src/panels/panel_declarations/finances/welcome_mat/welcome_mat.js
+++ b/client/src/panels/panel_declarations/finances/welcome_mat/welcome_mat.js
@@ -838,7 +838,7 @@ function get_calcs(subject, q6, q12) {
     matched_data = matched_data
       ? matched_data
       : {
-          year: reverse ? _.last(years) : _.first(years),
+          year: reverse ? _.last(years) : _.head(years),
           value: 0,
         };
     return matched_data;
@@ -855,7 +855,7 @@ function get_calcs(subject, q6, q12) {
   );
 
   const spend_latest_year = latest_hist_spend_data.value;
-  const spend_plan_1 = _.first(planned_spend_data);
+  const spend_plan_1 = _.head(planned_spend_data);
   const spend_plan_3 = _.last(planned_spend_data);
 
   const latest_year_hist_spend_diff =
@@ -882,7 +882,7 @@ function get_calcs(subject, q6, q12) {
   );
 
   const fte_latest_year = latest_hist_fte_data.value;
-  const fte_plan_1 = _.first(planned_fte_data);
+  const fte_plan_1 = _.head(planned_fte_data);
   const fte_plan_3 = _.last(planned_fte_data);
 
   const latest_year_hist_fte_diff =

--- a/client/src/panels/panel_declarations/finances/welcome_mat/welcome_mat_exp_program_spending.js
+++ b/client/src/panels/panel_declarations/finances/welcome_mat/welcome_mat_exp_program_spending.js
@@ -96,13 +96,13 @@ export const format_and_get_exp_program_spending = (type, subject) => {
 
   const shouldTickRender = (tick) => {
     if (type === "hist" || type === "hist_estimates") {
-      return tick === _.first(history_ticks) || tick === _.last(history_ticks);
+      return tick === _.head(history_ticks) || tick === _.last(history_ticks);
     } else if (type === "planned") {
-      return tick === _.first(plan_ticks) || tick === _.last(plan_ticks);
+      return tick === _.head(plan_ticks) || tick === _.last(plan_ticks);
     } else {
       return (
         tick === gap_year ||
-        tick === _.first(history_ticks) ||
+        tick === _.head(history_ticks) ||
         tick === _.last(plan_ticks)
       );
     }

--- a/client/src/panels/panel_declarations/finances/welcome_mat/welcome_mat_fte.js
+++ b/client/src/panels/panel_declarations/finances/welcome_mat/welcome_mat_fte.js
@@ -74,14 +74,14 @@ export const format_and_get_fte = (type, subject) => {
   const shouldTickRender = (tick) => {
     if (type === "hist" || type === "hist_estimates") {
       return (
-        tick === _.first(historical_ticks) || tick === _.last(historical_ticks)
+        tick === _.head(historical_ticks) || tick === _.last(historical_ticks)
       );
     } else if (type === "planned") {
-      return tick === _.first(planned_ticks) || tick === _.last(planned_ticks);
+      return tick === _.head(planned_ticks) || tick === _.last(planned_ticks);
     } else {
       return (
         tick === gap_year ||
-        tick === _.first(historical_ticks) ||
+        tick === _.head(historical_ticks) ||
         tick === _.last(planned_ticks)
       );
     }

--- a/client/src/panels/panel_declarations/misc/hierarchy_component.js
+++ b/client/src/panels/panel_declarations/misc/hierarchy_component.js
@@ -210,7 +210,7 @@ export const org_internal_hierarchy = ({
       href: crso.is_cr && href_generator(crso),
       dead: !crso.is_active,
       children: _.chain(crso.programs)
-        .filter((program) => !program.is_fake)
+        .reject((program) => program.is_fake)
         .map((prog) => ({
           name: prog.name,
           href: href_generator(prog),
@@ -252,7 +252,7 @@ export const program_hierarchy = ({
             show_cousins || is_parent(crso)
               ? _.chain(crso.programs)
                   .filter(show_siblings ? _.constant(true) : is_subject)
-                  .filter((program) => !program.is_fake)
+                  .reject((program) => program.is_fake)
                   .map((prog) => ({
                     name: prog.name,
                     current_subject: is_subject(prog),
@@ -305,7 +305,7 @@ export const tag_hierarchy = ({
         showChildren &&
         is_subject(tag) &&
         _.chain(tag.programs)
-          .filter((program) => !program.is_fake)
+          .reject((program) => program.is_fake)
           .map((prog) => ({
             name: prog.name,
             href: href_generator(prog),
@@ -368,7 +368,7 @@ export const crso_hierarchy = ({ subject, href_generator }) => {
                 dead: !crso.is_active,
                 //program
                 children: _.chain(crso.programs)
-                  .filter((program) => !program.is_fake)
+                  .reject((program) => program.is_fake)
                   .map((prg) => ({
                     level: prg.subject_type,
                     name: prg.name,
@@ -413,7 +413,7 @@ export const crso_pi_hierarchy = ({ subject, href_generator }) => ({
               href: href_generator(subject),
               // program
               children: _.chain(subject.programs)
-                .filter((program) => !program.is_fake)
+                .reject((program) => program.is_fake)
                 .map((prg) => ({
                   level: prg.subject_type,
                   name: prg.name,

--- a/client/src/panels/panel_declarations/misc/resource_structure/utils.js
+++ b/client/src/panels/panel_declarations/misc/resource_structure/utils.js
@@ -11,6 +11,6 @@ const { text_maker, TM } = create_text_maker_component(text);
 const { std_years, planning_years } = year_templates;
 
 const actual_year = _.last(std_years);
-const planning_year = _.first(planning_years);
+const planning_year = _.head(planning_years);
 
 export { text_maker, TM, actual_year, planning_year };

--- a/client/src/panels/panel_declarations/misc/tags_related_to_subject_panels.js
+++ b/client/src/panels/panel_declarations/misc/tags_related_to_subject_panels.js
@@ -56,7 +56,7 @@ function get_related_tag_list_args(subject) {
       tags_by_root_id = _.chain(subject.programs)
         .map("tags")
         .flatten()
-        .uniq("id")
+        .uniqBy("id")
         .groupBy("root.id")
         .value();
 

--- a/client/src/panels/panel_declarations/misc/tags_related_to_subject_panels.js
+++ b/client/src/panels/panel_declarations/misc/tags_related_to_subject_panels.js
@@ -174,9 +174,9 @@ export const declare_related_tags_panel = () =>
           .reject({ id: subject.id })
           .groupBy((tag) => tag.id)
           .map((group) => ({
-            tag: _.first(group),
+            tag: _.head(group),
             count: group.length,
-            type: _.first(group).root.id,
+            type: _.head(group).root.id,
           }))
           .filter("count")
           .groupBy("type")

--- a/client/src/panels/panel_declarations/misc/warning_panels.js
+++ b/client/src/panels/panel_declarations/misc/warning_panels.js
@@ -337,8 +337,7 @@ const get_declare_late_resources_panel = (planned_or_actual, late_orgs) => () =>
   });
 
 const depts_with_late_actual_resources = _.chain(result_docs_in_tabling_order)
-  .filter(({ doc_type }) => doc_type === "drr")
-  .last()
+  .findLast(({ doc_type }) => doc_type === "drr")
   .get("late_resources_orgs")
   .concat(PRE_DRR_PUBLIC_ACCOUNTS_LATE_FTE_MOCK_DOC.late_resources_orgs)
   .uniq()
@@ -347,8 +346,7 @@ export const declare_late_actual_resources_panel =
   get_declare_late_resources_panel("actual", depts_with_late_actual_resources);
 
 const depts_with_late_planned_resources = _.chain(result_docs_in_tabling_order)
-  .filter(({ doc_type }) => doc_type === "dp")
-  .last()
+  .findLast(({ doc_type }) => doc_type === "dp")
   .get("late_resources_orgs")
   .value();
 export const declare_late_planned_resources_panel =

--- a/client/src/panels/panel_declarations/people/calculate_common_text_args.js
+++ b/client/src/panels/panel_declarations/people/calculate_common_text_args.js
@@ -37,7 +37,7 @@ export const calculate_common_text_args = (
     .value();
 
   const [top_avg_group, top_avg_group_share] = _.last(group_avg_shares);
-  const [bottom_avg_group, bottom_avg_group_share] = _.first(group_avg_shares);
+  const [bottom_avg_group, bottom_avg_group_share] = _.head(group_avg_shares);
 
   return {
     first_active_year_index,

--- a/client/src/panels/panel_declarations/people/employee_age.js
+++ b/client/src/panels/panel_declarations/people/employee_age.js
@@ -123,10 +123,10 @@ export const declare_employee_age_panel = () =>
         const { avg_age, age_group } = calculations;
 
         const dept_avg_first_active_year =
-          avg_age.length > 1 ? _.first(avg_age[1].data) : null;
+          avg_age.length > 1 ? _.head(avg_age[1].data) : null;
         const dept_avg_last_active_year =
           avg_age.length > 1 ? _.last(avg_age[1].data) : null;
-        const gov_avgage_last_year_5 = _.first(avg_age[0].data);
+        const gov_avgage_last_year_5 = _.head(avg_age[0].data);
         const gov_avgage_last_year = _.last(avg_age[0].data);
 
         const common_text_args = calculate_common_text_args(age_group);

--- a/client/src/panels/panel_declarations/people/employee_executive_level.js
+++ b/client/src/panels/panel_declarations/people/employee_executive_level.js
@@ -113,7 +113,7 @@ export const declare_employee_executive_level_panel = () =>
               ...calculate_common_text_args(series),
               subject,
               avg_num_non_ex: _.chain(series)
-                .head(({ label }) => label === "Non-EX")
+                .first(({ label }) => label === "Non-EX")
                 .thru(({ data }) => _.mean(data))
                 .value(),
             };

--- a/client/src/panels/panel_declarations/people/employee_executive_level.js
+++ b/client/src/panels/panel_declarations/people/employee_executive_level.js
@@ -113,7 +113,7 @@ export const declare_employee_executive_level_panel = () =>
               ...calculate_common_text_args(series),
               subject,
               avg_num_non_ex: _.chain(series)
-                .first(({ label }) => label === "Non-EX")
+                .head(({ label }) => label === "Non-EX")
                 .thru(({ data }) => _.mean(data))
                 .value(),
             };

--- a/client/src/panels/panel_declarations/results/CommonDrrSummary.js
+++ b/client/src/panels/panel_declarations/results/CommonDrrSummary.js
@@ -190,7 +190,7 @@ class PercentageViz extends React.Component {
     const all_ids = _.keys(counts);
     const present_ids = _.chain(counts)
       .toPairs()
-      .filter((count) => count[1] !== 0)
+      .reject((count) => count[1] === 0)
       .fromPairs()
       .value();
 

--- a/client/src/panels/panel_declarations/results/CommonDrrSummary.js
+++ b/client/src/panels/panel_declarations/results/CommonDrrSummary.js
@@ -112,7 +112,7 @@ const StatusGrid = ({ met, not_met, not_available, future, drr_key }) => {
   const viz_data = _.chain(data)
     .sortBy(({ status_key }) => icon_order[status_key])
     .flatMap(({ viz_count, status_key }) => {
-      return _.range(0, viz_count).map(() => ({ status_key }));
+      return _.times(viz_count, () => ({ status_key }));
     })
     .value();
 

--- a/client/src/panels/panel_declarations/results/drr_summary.js
+++ b/client/src/panels/panel_declarations/results/drr_summary.js
@@ -92,7 +92,7 @@ export const declare_drr_summary_panel = () =>
         return (
           !_.isEmpty(drr_keys) &&
           text_maker("drr_summary_title", {
-            first_year: get_year_for_doc_key(_.first(drr_keys)),
+            first_year: get_year_for_doc_key(_.head(drr_keys)),
             last_year:
               drr_keys.length > 1 && get_year_for_doc_key(_.last(drr_keys)),
           })

--- a/client/src/panels/panel_declarations/results/drr_table/result_flat_table.js
+++ b/client/src/panels/panel_declarations/results/drr_table/result_flat_table.js
@@ -422,7 +422,7 @@ export const declare_results_table_panel = () =>
         const drr_keys_with_data = get_drr_keys_with_data(subject);
 
         return text_maker("result_flat_table_title", {
-          first_year: get_year_for_doc_key(_.first(drr_keys_with_data)),
+          first_year: get_year_for_doc_key(_.head(drr_keys_with_data)),
           last_year:
             drr_keys_with_data.length > 1 &&
             get_year_for_doc_key(_.last(drr_keys_with_data)),

--- a/client/src/panels/panel_declarations/results/gov_dp.js
+++ b/client/src/panels/panel_declarations/results/gov_dp.js
@@ -153,7 +153,7 @@ export const declare_gov_dp_panel = () =>
       legacy_non_table_dependencies: ["requires_result_counts"],
       get_title: () =>
         text_maker("gov_dp_summary_title", {
-          first_year: get_year_for_doc_key(_.first(dp_keys)),
+          first_year: get_year_for_doc_key(_.head(dp_keys)),
           last_year:
             dp_keys.length > 1 && get_year_for_doc_key(_.last(dp_keys)),
         }),

--- a/client/src/panels/panel_declarations/results/gov_drr.js
+++ b/client/src/panels/panel_declarations/results/gov_drr.js
@@ -170,7 +170,7 @@ export const declare_gov_drr_panel = () =>
       legacy_non_table_dependencies: ["requires_result_counts"],
       get_title: () =>
         text_maker("gov_drr_summary_title", {
-          first_year: get_year_for_doc_key(_.first(drr_keys)),
+          first_year: get_year_for_doc_key(_.head(drr_keys)),
           last_year:
             drr_keys.length > 1 && get_year_for_doc_key(_.last(drr_keys)),
         }),

--- a/client/src/panels/panel_declarations/results/result_components.js
+++ b/client/src/panels/panel_declarations/results/result_components.js
@@ -373,9 +373,9 @@ function indicators_period_span_str(indicators) {
     .sortBy() //sort by year (no arg needed)
     .thru((nums) => {
       if (nums.length > 1) {
-        return `${_.first(nums)} - ${_.last(nums)}`;
+        return `${_.head(nums)} - ${_.last(nums)}`;
       } else if (nums.length === 1) {
-        return _.first(nums);
+        return _.head(nums);
       } else {
         return "";
       }

--- a/client/src/panels/panel_declarations/results/result_components.js
+++ b/client/src/panels/panel_declarations/results/result_components.js
@@ -322,8 +322,7 @@ const StatusIconTable = ({ icon_counts, onIconClick, active_list }) => (
     <VisibilityControl
       items={_.map(ordered_status_keys, (status_key) => ({
         key: status_key,
-        active:
-          active_list.length === 0 || _.includes(active_list, status_key),
+        active: active_list.length === 0 || _.includes(active_list, status_key),
         count: icon_counts[status_key] || 0,
         text: text_maker(status_key),
         icon: large_status_icons[status_key],

--- a/client/src/panels/panel_declarations/results/result_components.js
+++ b/client/src/panels/panel_declarations/results/result_components.js
@@ -323,7 +323,7 @@ const StatusIconTable = ({ icon_counts, onIconClick, active_list }) => (
       items={_.map(ordered_status_keys, (status_key) => ({
         key: status_key,
         active:
-          active_list.length === 0 || _.indexOf(active_list, status_key) !== -1,
+          active_list.length === 0 || _.includes(active_list, status_key),
         count: icon_counts[status_key] || 0,
         text: text_maker(status_key),
         icon: large_status_icons[status_key],

--- a/client/src/panels/panel_declarations/services/services_intro.js
+++ b/client/src/panels/panel_declarations/services/services_intro.js
@@ -57,7 +57,7 @@ const ServicesIntroPanel = ({ subject }) => {
         args={{
           subject,
           from_year: _.last(report_years),
-          to_year: _.first(report_years),
+          to_year: _.head(report_years),
           ...(subject.subject_type === "gov"
             ? { num_of_subject_offering_services }
             : { num_of_programs_offering_services }),

--- a/client/src/panels/panel_declarations/services/single_service_panels/service_standards.js
+++ b/client/src/panels/panel_declarations/services/single_service_panels/service_standards.js
@@ -164,7 +164,7 @@ export class ServiceStandards extends React.Component {
                   count: _.countBy(data, "is_target_met")[status_key] || 0,
                   active:
                     active_statuses.length === standard_statuses.length ||
-                    _.indexOf(active_statuses, status_key) !== -1,
+                    _.includes(active_statuses, status_key),
                   text: text_maker(status_key),
                   icon: status_icons[status_key],
                 }))}

--- a/client/src/rpb/rpb_link.js
+++ b/client/src/rpb/rpb_link.js
@@ -14,7 +14,7 @@ const rpb_link = (naive_state, first_character = "#") =>
         table: table && table.is_table ? table.id : table,
         subject: subject && subject.subject_type ? subject.guid : subject,
         columns:
-          _.first(columns) && _.first(columns).nick
+          _.head(columns) && _.head(columns).nick
             ? _.map(columns, "nick")
             : columns,
       };

--- a/client/src/search/SearchConfigTypeahead.js
+++ b/client/src/search/SearchConfigTypeahead.js
@@ -27,7 +27,7 @@ export class SearchConfigTypeahead extends React.Component {
     const { search_phrase } = this.state;
 
     if (search_phrase !== "") {
-      _.each(search_configs, (search_config) => {
+      _.forEach(search_configs, (search_config) => {
         const { config_name, query } = search_config;
 
         const is_not_loading_or_loaded = _.isUndefined(

--- a/client/src/tables/TableClass.js
+++ b/client/src/tables/TableClass.js
@@ -525,7 +525,7 @@ export class Table {
       var mapped_row = mapper.map(row);
       // turn the array of data into an object with keys based on the defined columns
       var row_obj = _.zipObject(this.unique_headers, mapped_row);
-      _.toPairs(row_obj).forEach((pair) => {
+      _.toPairs(row_obj).flatMap((pair) => {
         const [key, val] = pair;
         const type = this.col_from_nick(key).type;
         // in case we have numbers represented as string, we'll convert them to integers
@@ -572,7 +572,7 @@ export class Table {
           row_obj[key] = 0;
         }
       });
-      _.toPairs(row_obj).forEach(([key, _val]) => {
+      _.toPairs(row_obj).flatMap(([key, _val]) => {
         const col = this.col_from_nick(key);
         if (col.formula && _.isUndefined(col.formula.default)) {
           row_obj[key] = col.formula(row_obj);

--- a/client/src/tables/TableClass.js
+++ b/client/src/tables/TableClass.js
@@ -362,12 +362,10 @@ export class Table {
 
     return (
       _.chain(cols)
-        .filter((col) => col.nick === grouping)
-        .head()
+        .find((col) => col.nick === grouping)
         .value() ||
       _.chain(cols)
-        .filter((col) => _.has(col, `custom_groupings.${grouping}`))
-        .head()
+        .find((col) => _.has(col, `custom_groupings.${grouping}`))
         .value() || { nick: "default" }
     );
   }

--- a/client/src/tables/TableClass.js
+++ b/client/src/tables/TableClass.js
@@ -24,7 +24,7 @@ function add_child(x) {
   if (!_.isArray(x)) {
     x = [x];
   }
-  _.each(x, (col) => {
+  _.forEach(x, (col) => {
     if (_.isString(col)) {
       col = { header: { en: col, fr: col } };
     }
@@ -117,7 +117,7 @@ class Queries {
       .reduce(reducer, initial);
 
     // deal with percentage columns
-    _.each(cols, (col, i) => {
+    _.forEach(cols, (col, i) => {
       var type = this.table.col_from_nick(col).type;
       if (type === "percentage") {
         total[i] = total[i] / total.length;
@@ -144,7 +144,7 @@ class Queries {
     }
     var vals = this.sum_cols(data, cols);
     if (format) {
-      _.each(cols, (col) => {
+      _.forEach(cols, (col) => {
         var type = this.table.col_from_nick(col).type;
         vals[col] = _.get(formats, type, _.identity)(vals[col]);
       });
@@ -259,7 +259,7 @@ export class Table {
 
     to_chain
       .filter((col) => !_.isUndefined(col.formula))
-      .each((col) => {
+      .forEach((col) => {
         var formula = col.formula;
         col.formula = (data) => formula(this, data);
       })
@@ -274,7 +274,7 @@ export class Table {
           _.isUndefined(col.formula)
         );
       })
-      .each(function (col) {
+      .forEach(function (col) {
         col.formula = function (data) {
           if (_.isArray(data)) {
             const to_sum = _.map(data, col.nick || col.wcag);
@@ -498,7 +498,7 @@ export class Table {
     data = _.chain(parsed_data)
       .tail()
       .map(row_transf)
-      .each((row) => this.process_mapped_row(row))
+      .forEach((row) => this.process_mapped_row(row))
       .groupBy((row) => row.dept === "ZGOC")
       .value();
     this.csv_headers = _.head(parsed_data);
@@ -507,7 +507,7 @@ export class Table {
 
     this.depts = {};
 
-    _.each(this.data, (row) => {
+    _.forEach(this.data, (row) => {
       if (!this.depts[row.dept]) {
         this.depts[row.dept] = [row];
       } else {

--- a/client/src/tables/TableClass.js
+++ b/client/src/tables/TableClass.js
@@ -96,7 +96,7 @@ class Queries {
     this.dept = subject && subject.subject_type === "dept" && subject.id;
     this.subject = subject;
     this.data = data;
-    _.extend(this, table.queries);
+    _.assignIn(this, table.queries);
   }
 
   sum_cols(rows, cols) {

--- a/client/src/tables/orgEmployeeAgeGroup.js
+++ b/client/src/tables/orgEmployeeAgeGroup.js
@@ -37,7 +37,7 @@ export default {
       },
       can_group_by: true,
     });
-    _.each(people_years, (header, ix) => {
+    _.forEach(people_years, (header, ix) => {
       this.add_col({
         type: "big_int",
         nick: header,

--- a/client/src/tables/orgEmployeeAvgAge.js
+++ b/client/src/tables/orgEmployeeAvgAge.js
@@ -29,7 +29,7 @@ export default {
       nick: "avgage",
       header: trivial_text_maker("avgage"),
     });
-    _.each(people_years, (header, ix) => {
+    _.forEach(people_years, (header, ix) => {
       this.add_col({
         type: "decimal1",
         nick: header,

--- a/client/src/tables/orgEmployeeExLvl.js
+++ b/client/src/tables/orgEmployeeExLvl.js
@@ -34,7 +34,7 @@ export default {
       header: trivial_text_maker("ex_level"),
       can_group_by: true,
     });
-    _.each(people_years, (header, ix) => {
+    _.forEach(people_years, (header, ix) => {
       this.add_col({
         type: "big_int",
         nick: header,

--- a/client/src/tables/orgEmployeeFol.js
+++ b/client/src/tables/orgEmployeeFol.js
@@ -34,7 +34,7 @@ export default {
       header: trivial_text_maker("FOL"),
       can_group_by: true,
     });
-    _.each(people_years, (header, ix) => {
+    _.forEach(people_years, (header, ix) => {
       this.add_col({
         type: "big_int",
         nick: header,

--- a/client/src/tables/orgEmployeeGender.js
+++ b/client/src/tables/orgEmployeeGender.js
@@ -34,7 +34,7 @@ export default {
       header: trivial_text_maker("employee_gender"),
       can_group_by: true,
     });
-    _.each(people_years, (header, ix) => {
+    _.forEach(people_years, (header, ix) => {
       this.add_col({
         type: "big_int",
         nick: header,

--- a/client/src/tables/orgEmployeeRegion.js
+++ b/client/src/tables/orgEmployeeRegion.js
@@ -45,7 +45,7 @@ export default {
       },
       can_group_by: true,
     });
-    _.each(people_years, (header, ix) => {
+    _.forEach(people_years, (header, ix) => {
       this.add_col({
         type: "big_int",
         nick: header,

--- a/client/src/tables/orgEmployeeType.js
+++ b/client/src/tables/orgEmployeeType.js
@@ -37,7 +37,7 @@ export default {
       },
       can_group_by: true,
     });
-    _.each(people_years, (header, ix) => {
+    _.forEach(people_years, (header, ix) => {
       this.add_col({
         type: "big_int",
         nick: header,

--- a/client/src/tables/orgSobjs.js
+++ b/client/src/tables/orgSobjs.js
@@ -44,7 +44,7 @@ export default {
       },
       can_group_by: true,
     });
-    _.each(std_years, (header) => {
+    _.forEach(std_years, (header) => {
       this.add_col({
         type: "dollar",
         nick: header,

--- a/client/src/tables/orgTransferPayments.js
+++ b/client/src/tables/orgTransferPayments.js
@@ -72,7 +72,7 @@ export default {
         },
       },
     ]);
-    _.each(std_years, (header) => {
+    _.forEach(std_years, (header) => {
       this.add_col(header).add_child([
         {
           type: "big_int",

--- a/client/src/tables/orgVoteStatEstimates.js
+++ b/client/src/tables/orgVoteStatEstimates.js
@@ -85,7 +85,7 @@ export default {
       },
       can_group_by: true,
     });
-    _.each(estimates_years, (yr) => {
+    _.forEach(estimates_years, (yr) => {
       this.add_col({
         type: "dollar",
         nick: yr + "_estimates",

--- a/client/src/tables/orgVoteStatPa.js
+++ b/client/src/tables/orgVoteStatPa.js
@@ -69,7 +69,7 @@ export default {
         },
       },
     ]);
-    _.each(std_years, (header) => {
+    _.forEach(std_years, (header) => {
       this.add_col(header).add_child([
         {
           type: "big_int",

--- a/client/src/tables/people_five_year_percentage_formula.js
+++ b/client/src/tables/people_five_year_percentage_formula.js
@@ -42,8 +42,8 @@ function people_five_year_percentage_formula(
             return d[col_name] === cats[0];
           }).length === row.length;
       }
-      _.each(col_names_to_be_averaged, function (year, i) {
-        _.each(table.data, function (d) {
+      _.forEach(col_names_to_be_averaged, function (year, i) {
+        _.forEach(table.data, function (d) {
           // scenario 2
           if (all_cat_lines) {
             total_totals[i] = total_totals[i] + d[year] || d[year];

--- a/client/src/tables/programFtes.js
+++ b/client/src/tables/programFtes.js
@@ -50,7 +50,7 @@ export default {
       },
       can_group_by: true,
     });
-    _.each(std_years, (header) => {
+    _.forEach(std_years, (header) => {
       this.add_col({
         type: "decimal2",
         nick: header,
@@ -81,7 +81,7 @@ export default {
         fr: `Correspond au nombre total d'équivalents temps plein (ETP) prévus pour l'exercice {{pa_last_year_planned}}`,
       },
     });
-    _.each(planning_years, (header) => {
+    _.forEach(planning_years, (header) => {
       this.add_col({
         type: "decimal2",
         nick: header,

--- a/client/src/tables/programSpending.js
+++ b/client/src/tables/programSpending.js
@@ -51,7 +51,7 @@ export default {
         can_group_by: true,
       },
     ]);
-    _.each(std_years, (header) => {
+    _.forEach(std_years, (header) => {
       //TODO: the col definitions here are copied from orgVoteStatPa, either change them or make it DRY
       this.add_col(header).add_child([
         {
@@ -83,7 +83,7 @@ export default {
         fr: `Correspondent au total des dépenses prévues pour l'exercice {{pa_last_year_planned}}, y compris les fonds approuvés par le Conseil du Trésor.`,
       },
     });
-    _.each(planning_years, (header) => {
+    _.forEach(planning_years, (header) => {
       this.add_col(header).add_child([
         {
           type: "big_int",

--- a/docs/getting-started/js-tips-style-guide.md
+++ b/docs/getting-started/js-tips-style-guide.md
@@ -53,7 +53,7 @@ Our (un)official (and somewhat incomplete) rules for code style:
       - `const [ name_ix, text_ix, year_ix] = d3.range(0,3); const name = line[name_ix];`
 - Iterating structures : Don't use that for loop!
   - the **only** case for for loops: iterating over hundreds of items (at least) _when_ you can optimize by exiting early with a `break`. Even then, a lodash method like `_.find` that already exists early is usually good enough and more elegant.
-  - `_.each(structure, func(val,key_or_index) )` and `arr.forEach(func(val,index))` are better than for loops, but it's better not to use them, since they can only do useful work through _side-effects_, which are to be avoided
+  - `_.forEach(structure, func(val,key_or_index) )` and `arr.forEach(func(val,index))` are better than for loops, but it's better not to use them, since they can only do useful work through _side-effects_, which are to be avoided
   - Instead, if you're processing data into a new variable, better to use lodash helpers for functionally creating new data structures
 - Identifier names
   - HTML ID or class: `lower-case-separated-by-dashes`. When styling DOM for a cohesive element, use [BEM](http://getbem.com/) naming conventions

--- a/form_backend/src/template_utils/get_templates.js
+++ b/form_backend/src/template_utils/get_templates.js
@@ -10,7 +10,7 @@ const get_templates = () => {
 
   const json_template_names = _.chain(readdirSync(templates_path))
     .filter((file_name) => /\.json$/.test(file_name))
-    .map((file_name) => file_name.replace(/\.json$/, ""))
+    _.invokeMap((file_name) => file_name.replace(/\.json$/, ""))
     .value();
 
   const template_name_content_pairs = _.map(

--- a/form_backend/src/template_utils/get_templates.js
+++ b/form_backend/src/template_utils/get_templates.js
@@ -10,7 +10,7 @@ const get_templates = () => {
 
   const json_template_names = _.chain(readdirSync(templates_path))
     .filter((file_name) => /\.json$/.test(file_name))
-    .invokeMap((file_name) => file_name.replace(/\.json$/, ""))
+    .map((file_name) => file_name.replace(/\.json$/, ""))
     .value();
 
   const template_name_content_pairs = _.map(

--- a/form_backend/src/template_utils/get_templates.js
+++ b/form_backend/src/template_utils/get_templates.js
@@ -13,7 +13,7 @@ const get_templates = () => {
     .map((file_name) => file_name.replace(/\.json$/, ""))
     .value();
 
-  const template_name_content_pairs = _.invokeMap(
+  const template_name_content_pairs = _.map(
     json_template_names,
     (json_template_name) => [
       json_template_name,

--- a/form_backend/src/template_utils/get_templates.js
+++ b/form_backend/src/template_utils/get_templates.js
@@ -10,10 +10,10 @@ const get_templates = () => {
 
   const json_template_names = _.chain(readdirSync(templates_path))
     .filter((file_name) => /\.json$/.test(file_name))
-    .invokeMap((file_name) => file_name.replace(/\.json$/, ""))
+    .map((file_name) => file_name.replace(/\.json$/, ""))
     .value();
 
-  const template_name_content_pairs = _.map(
+  const template_name_content_pairs = _.invokeMap(
     json_template_names,
     (json_template_name) => [
       json_template_name,

--- a/form_backend/src/template_utils/get_templates.js
+++ b/form_backend/src/template_utils/get_templates.js
@@ -10,7 +10,7 @@ const get_templates = () => {
 
   const json_template_names = _.chain(readdirSync(templates_path))
     .filter((file_name) => /\.json$/.test(file_name))
-    _.invokeMap((file_name) => file_name.replace(/\.json$/, ""))
+    .invokeMap((file_name) => file_name.replace(/\.json$/, ""))
     .value();
 
   const template_name_content_pairs = _.map(

--- a/server/src/models/core_subject/models.js
+++ b/server/src/models/core_subject/models.js
@@ -176,7 +176,7 @@ export default function define_core_subjects(model_singleton) {
     ),
     crso_id_loader: create_resource_by_id_attr_dataloader(Crso, "crso_id"),
   };
-  _.each(loaders, (val, key) => model_singleton.define_loader(key, val));
+  _.forEach(loaders, (val, key) => model_singleton.define_loader(key, val));
 
   const search_orgs = create_searcher(Org);
   const search_programs = create_searcher(Program);

--- a/server/src/models/covid/models.js
+++ b/server/src/models/covid/models.js
@@ -120,5 +120,5 @@ export default function (model_singleton) {
       "org_id"
     ),
   };
-  _.each(loaders, (val, key) => model_singleton.define_loader(key, val));
+  _.forEach(loaders, (val, key) => model_singleton.define_loader(key, val));
 }

--- a/server/src/models/covid/populate.js
+++ b/server/src/models/covid/populate.js
@@ -38,7 +38,7 @@ export default async function ({ models }) {
       _.join([org_id, fiscal_year, covid_measure_id], "__")
     )
     .map((rolled_up_rows) => ({
-      ..._.first(rolled_up_rows),
+      ..._.head(rolled_up_rows),
       ..._.reduce(
         rolled_up_rows,
         (memo, row) => ({
@@ -65,7 +65,7 @@ export default async function ({ models }) {
               `covid_expenditures.csv contains more than one uniqe calendar_month (${calendar_month}) for ${fiscal_year}`
             );
           } else {
-            return _.first(calendar_month);
+            return _.head(calendar_month);
           }
         })
         .value()

--- a/server/src/models/covid/schema.js
+++ b/server/src/models/covid/schema.js
@@ -116,7 +116,7 @@ export default function ({ models, loaders }) {
   const years_with_covid_data_resolver = (subject_id) =>
     years_with_covid_data_loader.load(subject_id).then(
       (years_with_covid_data) =>
-        _.first(years_with_covid_data) || {
+        _.head(years_with_covid_data) || {
           years_with_estimates: [],
           years_with_expenditures: [],
         }

--- a/server/src/models/finances/models.js
+++ b/server/src/models/finances/models.js
@@ -159,5 +159,5 @@ export default function (model_singleton) {
       "program_id"
     ),
   };
-  _.each(loaders, (val, key) => model_singleton.define_loader(key, val));
+  _.forEach(loaders, (val, key) => model_singleton.define_loader(key, val));
 }

--- a/server/src/models/index.js
+++ b/server/src/models/index.js
@@ -32,7 +32,7 @@ const sub_module_defs = _.compact([
 ]);
 
 export function create_models() {
-  _.each(
+  _.forEach(
     sub_module_defs,
     ({ define_models }) =>
       _.isFunction(define_models) && define_models(model_singleton)
@@ -54,7 +54,7 @@ export function get_schema_deps() {
   const schema_strings = [root_schema.schema];
   const resolver_objs = [root_schema.resolvers];
 
-  _.each(sub_module_defs, ({ define_schema }) => {
+  _.forEach(sub_module_defs, ({ define_schema }) => {
     if (_.isFunction(define_schema)) {
       const { schema, resolvers } = define_schema(model_singleton);
 

--- a/server/src/models/people/models.js
+++ b/server/src/models/people/models.js
@@ -73,5 +73,5 @@ export default function (model_singleton) {
     ),
   };
 
-  _.each(loaders, (val, key) => model_singleton.define_loader(key, val));
+  _.forEach(loaders, (val, key) => model_singleton.define_loader(key, val));
 }

--- a/server/src/models/people/populate.js
+++ b/server/src/models/people/populate.js
@@ -7,7 +7,7 @@ import { headcount_types } from "./utils.js";
 const headcount_non_year_headers = ["dept_code", "dimension", "avg_share"];
 const validate_headcount_headers = (csv_name, csv) =>
   _.chain(csv)
-    .first()
+    .head()
     .keys()
     .thru((headers) => {
       const has_expected_non_year_headers = _.chain(headers)

--- a/server/src/models/results/models.js
+++ b/server/src/models/results/models.js
@@ -109,7 +109,7 @@ export default function (model_singleton) {
     Indicator,
     "indicator_id"
   );
-  _.each(
+  _.forEach(
     {
       result_by_subj_loader,
       indicator_by_result_loader,

--- a/server/src/models/results/populate.js
+++ b/server/src/models/results/populate.js
@@ -26,7 +26,7 @@ const counts_from_indicators = (indicators) =>
       return _.chain(indicator_count_fragments)
         .reduce(
           (memo, count_fragment) => {
-            _.each(count_fragment, (value, key) =>
+            _.forEach(count_fragment, (value, key) =>
               _.isArray(memo[key]) ? memo[key].push(value) : memo[key]++
             );
             return memo;

--- a/server/src/models/search_utils.js
+++ b/server/src/models/search_utils.js
@@ -33,7 +33,7 @@ const flatten_to_string = (searchable_content) => {
 const add_derived_search_terms_to_doc = (doc, searchable_keys_by_lang) =>
   _.chain(search_terms_def)
     .keys()
-    .each((search_terms_field_key) => {
+    .forEach((search_terms_field_key) => {
       const search_field_lang = /.*_(.*?)$/.exec(search_terms_field_key)?.[1];
 
       const searchable_fields = (() => {
@@ -94,7 +94,7 @@ export const make_schema_with_search_terms = (
 
   // insertMany operations do not call save middleware, needs its own
   schema.pre("insertMany", function (next, docs) {
-    _.each(docs, (doc) =>
+    _.forEach(docs, (doc) =>
       add_derived_search_terms_to_doc(doc, searchable_keys_by_lang)
     );
 

--- a/server/src/models/services/models.js
+++ b/server/src/models/services/models.js
@@ -207,5 +207,5 @@ export default function (model_singleton) {
       "id"
     ),
   };
-  _.each(loaders, (val, key) => model_singleton.define_loader(key, val));
+  _.forEach(loaders, (val, key) => model_singleton.define_loader(key, val));
 }

--- a/server/src/models/services/populate.js
+++ b/server/src/models/services/populate.js
@@ -327,7 +327,7 @@ export default async function ({ models }) {
         .value()
     )
     // only valid under above logic, will need to rework active status deterination in multi-year refactor
-    .each((service) => {
+    .forEach((service) => {
       service.is_active =
         service.submission_year === absolute_most_recent_submission_year;
     })

--- a/server/src/models/services/schema.js
+++ b/server/src/models/services/schema.js
@@ -184,7 +184,7 @@ export default function ({ models, loaders }) {
 
   const resolvers = {
     Root: {
-      service: (_x, { id }) => service_loader.load(id).then(_.first),
+      service: (_x, { id }) => service_loader.load(id).then(_.head),
       search_services: get_search_terms_resolver(Service),
     },
     Gov: {

--- a/server/src/models/standard_objects/models.js
+++ b/server/src/models/standard_objects/models.js
@@ -13,7 +13,7 @@ function flatten_so_records(records, years_to_include) {
         amount: row[year],
       }))
     )
-    .compact("amount")
+    .compact()
     .value();
 }
 

--- a/server/src/models/standard_objects/populate.js
+++ b/server/src/models/standard_objects/populate.js
@@ -23,16 +23,16 @@ export default function ({ models }) {
     })
   );
 
-  _.each(org_records, (record) => {
-    _.each(
+  _.forEach(org_records, (record) => {
+    _.forEach(
       public_account_years,
       (col) => (record[col] = record[col] && parseFloat(record[col]))
     );
   });
 
   const prog_sobj_cols = _.takeRight(public_account_years, 2);
-  _.each(prog_records, (record) => {
-    _.each(
+  _.forEach(prog_records, (record) => {
+    _.forEach(
       prog_sobj_cols,
       (col) => (record[col] = record[col] && parseFloat(record[col]))
     );
@@ -40,6 +40,6 @@ export default function ({ models }) {
 
   const { OrgSobj, ProgSobj } = models;
 
-  _.each(org_records, (rec) => OrgSobj.register(rec));
-  _.each(prog_records, (rec) => ProgSobj.register(rec));
+  _.forEach(org_records, (rec) => OrgSobj.register(rec));
+  _.forEach(prog_records, (rec) => ProgSobj.register(rec));
 }

--- a/server/src/models/transfer_payments/populate.js
+++ b/server/src/models/transfer_payments/populate.js
@@ -6,8 +6,8 @@ import { get_standard_csv_file_rows } from "../load_utils.js";
 export default function ({ models }) {
   const records = get_standard_csv_file_rows("transfer_payments.csv");
 
-  _.each(records, (record) => {
-    _.each(
+  _.forEach(records, (record) => {
+    _.forEach(
       public_account_years_auth_exp,
       (col) => (record[col] = record[col] && parseFloat(record[col]))
     );
@@ -15,5 +15,5 @@ export default function ({ models }) {
 
   const { TransferPayments } = models;
 
-  _.each(records, (rec) => TransferPayments.register(rec));
+  _.forEach(records, (rec) => TransferPayments.register(rec));
 }

--- a/server/src/models/vote_stat/models.js
+++ b/server/src/models/vote_stat/models.js
@@ -50,7 +50,7 @@ function flatten_program_records(records, years_to_include = program_years) {
         exp: row[year],
       }))
     )
-    .compact("exp")
+    .compact()
     .value();
 }
 

--- a/server/src/models/vote_stat/populate.js
+++ b/server/src/models/vote_stat/populate.js
@@ -23,28 +23,28 @@ export default function ({ models }) {
   );
 
   const prog_years = _.takeRight(public_account_years, 2);
-  _.each(program_vs_records, (obj) => {
+  _.forEach(program_vs_records, (obj) => {
     obj.program_id = create_program_id(obj);
-    _.each(prog_years, (col) => {
+    _.forEach(prog_years, (col) => {
       obj[col] = obj[col] && parseFloat(obj[col]);
     });
   });
 
-  _.each(pa_records, (record) => {
-    _.each(
+  _.forEach(pa_records, (record) => {
+    _.forEach(
       public_account_years_auth_exp,
       (col) => (record[col] = record[col] && parseFloat(record[col]))
     );
   });
 
-  _.each(estimates_records, (record) => {
-    _.each(
+  _.forEach(estimates_records, (record) => {
+    _.forEach(
       estimates_years,
       (col) => (record[col] = record[col] && parseFloat(record[col]))
     );
   });
 
-  _.each(pa_records, (record) => PAVoteStat.register(record));
-  _.each(estimates_records, (record) => EstimatesVoteStat.register(record));
-  _.each(program_vs_records, (record) => ProgramVoteStat.register(record));
+  _.forEach(pa_records, (record) => PAVoteStat.register(record));
+  _.forEach(estimates_records, (record) => EstimatesVoteStat.register(record));
+  _.forEach(program_vs_records, (record) => ProgramVoteStat.register(record));
 }


### PR DESCRIPTION
Based on issue https://github.com/TBS-EACPD/infobase/issues/783

Unsure of these listed reccomendations and thus did not implement them: 
"pipe: custom implementation of lodash -> replace with thru (manual fix)",
"do not use chain for one method: remove the chain() and value() (manual)",
"map: use lodash instead",
"mapping to obtain object values: use values() instead",
"nested methods: use chain() instead"