### PR TITLE
Redesign table of contents

### DIFF
--- a/client/src/infographic/Infographic.scss
+++ b/client/src/infographic/Infographic.scss
@@ -77,3 +77,13 @@ of the advanced search for mobile */
     overflow-x: visible;
   }
 }
+
+.toc_link {
+  font-size: 11px;
+}
+
+.toc_link.active {
+  font-size: 15px;
+  font-weight: bold;
+  text-decoration: underline;
+}

--- a/client/src/infographic/TableOfContents.js
+++ b/client/src/infographic/TableOfContents.js
@@ -38,7 +38,6 @@ export default class TableOfContents extends React.Component {
           if (href) {
             if (entry.intersectionRatio > 0.4) {
               href.classList.add("active");
-              console.log(this.state.active_href);
               const temp = this.state.active_href;
               this.setState({
                 active_href: href,
@@ -57,7 +56,7 @@ export default class TableOfContents extends React.Component {
       for (const el of panels) {
         observer.observe(el);
       }
-    }, 750);
+    }, 2500);
   }
 
   componentDidMount() {
@@ -88,6 +87,7 @@ export default class TableOfContents extends React.Component {
           </div>
         }
         content={
+          
         <div
           aria-label="Table of contents"
           style={{
@@ -115,7 +115,7 @@ export default class TableOfContents extends React.Component {
               fontWeight: "500",
             }}
           >
-            Table of Contents
+            <TM k="table_of_contents" />{" "}
           </h2>
           <UnlabeledTombstone
             items={_.map(panel_titles_by_key, (panel_title, panel_key) => (
@@ -145,4 +145,3 @@ export default class TableOfContents extends React.Component {
     );
   }
 }
-

--- a/client/src/infographic/TableOfContents.js
+++ b/client/src/infographic/TableOfContents.js
@@ -11,96 +11,14 @@ export default class TableOfContents extends React.Component {
     super(props);
     this.state = {
       is_open: false,
-      //active_page: null,
+      active_page: null,
       previous_href: null,
       active_href: null,
     };
   }
-  /* activeId = useState();
-  setActiveId = useState();
-  nestedHeadings = useHeadingsData();
-  useIntersectionObserver(setActiveId);
 
-   useHeadingsData = () => {
-    const [nestedHeadings, setNestedHeadings] = useState([]);
-  
-    useEffect(() => {
-      const headingElements = Array.from(
-        document.querySelectorAll("h2")
-      );
-  
-      const newNestedHeadings = getNestedHeadings(headingElements);
-      setNestedHeadings(newNestedHeadings);
-    }, []);
-  
-    return { nestedHeadings };
-  };
-
-  getNestedHeadings = (headingElements) => {
-    const nestedHeadings = [];
-  
-    headingElements.forEach((heading, index) => {
-      const { innerText: title, id } = heading;
-  
-      if (heading.nodeName === "H2") {
-        nestedHeadings.push({ id, title, items: [] });
-      } else if (heading.nodeName === "H3" && nestedHeadings.length > 0) {
-        nestedHeadings[nestedHeadings.length - 1].items.push({
-          id,
-          title,
-        });
-      }
-    });
-  
-    return nestedHeadings;
-  };
-
-  useIntersectionObserver = (setActiveId) => {
-    const headingElementsRef = useRef({});
-    useEffect(() => {
-      const callback = (headings) => {
-        headingElementsRef.current = headings.reduce((map, headingElement) => {
-          map[headingElement.target.id] = headingElement;
-          return map;
-        }, headingElementsRef.current);
-  
-        const visibleHeadings = [];
-        Object.keys(headingElementsRef.current).forEach((key) => {
-          const headingElement = headingElementsRef.current[key];
-          if (headingElement.isIntersecting) visibleHeadings.push(headingElement);
-        });
-  
-        const getIndexFromId = (id) =>
-          headingElements.findIndex((heading) => heading.id === id);
-  
-        if (visibleHeadings.length === 1) {
-          setActiveId(visibleHeadings[0].target.id);
-        } else if (visibleHeadings.length > 1) {
-          const sortedVisibleHeadings = visibleHeadings.sort(
-            (a, b) => getIndexFromId(a.target.id) > getIndexFromId(b.target.id)
-          );
-          setActiveId(sortedVisibleHeadings[0].target.id);
-        }
-      };
-  
-      const observer = new IntersectionObserver(callback, {
-        rootMargin: "0px 0px -40% 0px"
-      });
-  
-      const headingElements = Array.from(document.querySelectorAll("h2, h3"));
-  
-      headingElements.forEach((element) => observer.observe(element));
-  
-      return () => observer.disconnect();
-    }, [setActiveId]);
-  };
-  */
-
-  componentDidMount() {
+  updateTableofContents() {
     const { subject, active_bubble_id } = this.props;
-    /*const { active_page } = this.state;
-    this.getUpdate(active_page);
-    */
 
     const observer = new IntersectionObserver(
       (entries) => {
@@ -138,17 +56,18 @@ export default class TableOfContents extends React.Component {
     }, 3000);
   }
 
-  /* componentDidUpdate () {
-    if(!window.location.href.includes(this.props.active_bubble_id)){
-      const { active_page } = this.state;
-      this.getUpdate(active_page);
-    }
+  componentDidMount() {
+    this.setState({ active_page: this.props.active_bubble_id });
+    this.updateTableofContents();
   }
 
-  getUpdate = () => {
-    this.setState({active_page: window.location.href});
-};
-*/
+  componentDidUpdate() {
+    if (this.props.active_bubble_id != this.state.active_page) {
+      console.log("true!");
+      this.setState({ active_page: this.props.active_bubble_id });
+      this.updateTableofContents();
+    }
+  }
 
   on_click = () => this.setState({ is_open: !this.state.is_open });
   render() {
@@ -196,46 +115,6 @@ export default class TableOfContents extends React.Component {
             ))}
           />
         </div>
-
-        /* <StatelessDetails
-          summary_content={
-            <div>
-              <TM k="table_of_contents" />{" "}
-              <TM className="panel-status-text" k="skip_to_panel" />
-            </div>
-          }
-          content={
-            <div
-              style={{
-                border: "1px solid",
-                borderColor: separatorColor,
-                position: "fixed",
-                left: "5px",
-                top: "150px",
-                backgroundColor: "white",
-                zIndex: "999",
-                boxShadow: "0 1px 2px rgb(43 59 93 / 29%)",
-                font: "10px"
-              }}
-            >
-              <UnlabeledTombstone
-                items={_.map(panel_titles_by_key, (panel_title, panel_key) => (
-                  <a
-                    key={panel_key}
-                    href={infographic_href_template(subject, active_bubble_id, {
-                      panel_key,
-                    })}
-                  >
-                    {panel_title}
-                  </a>
-                ))}
-              />
-            </div>
-          }
-          on_click={this.on_click}
-          is_open={is_open}
-        />
-        */
       )
     );
   }

--- a/client/src/infographic/TableOfContents.js
+++ b/client/src/infographic/TableOfContents.js
@@ -35,7 +35,9 @@ export default class TableOfContents extends React.Component {
             maxHeight: "580px",
           }}
         >
-          <h2 style={{backgroundColor: "blue", color: "white"}}>Table of Contents</h2>
+          <h2 style={{ backgroundColor: "blue", color: "white" }}>
+            Table of Contents
+          </h2>
           <UnlabeledTombstone
             items={_.map(panel_titles_by_key, (panel_title, panel_key) => (
               <a

--- a/client/src/infographic/TableOfContents.js
+++ b/client/src/infographic/TableOfContents.js
@@ -7,8 +7,6 @@ import {
   UnlabeledTombstone,
 } from "src/components/index";
 
-import { separatorColor } from "src/style_constants/index";
-
 import { infographic_href_template } from "./infographic_href_template";
 
 import text from "./TableOfContents.yaml";
@@ -30,7 +28,36 @@ export default class TableOfContents extends React.Component {
 
     return (
       !_.isEmpty(panel_titles_by_key) && (
-        <StatelessDetails
+        <div
+          aria-label="Table of contents"
+          style={{
+            border: "1px solid",
+            position: "fixed",
+            display: "inline-block",
+            left: "5px",
+            top: "150px",
+            backgroundColor: "transparent",
+            zIndex: "999",
+            boxShadow: "0 1px 2px rgb(43 59 93 / 29%)",
+            font: "8px",
+            overflow: "auto",
+          }}
+        >
+          <UnlabeledTombstone
+            items={_.map(panel_titles_by_key, (panel_title, panel_key) => (
+              <a
+                key={panel_key}
+                href={infographic_href_template(subject, active_bubble_id, {
+                  panel_key,
+                })}
+              >
+                {panel_title}
+              </a>
+            ))}
+          />
+        </div>
+
+        /* <StatelessDetails
           summary_content={
             <div>
               <TM k="table_of_contents" />{" "}
@@ -42,7 +69,13 @@ export default class TableOfContents extends React.Component {
               style={{
                 border: "1px solid",
                 borderColor: separatorColor,
-                borderRadius: "5px",
+                position: "fixed",
+                left: "5px",
+                top: "150px",
+                backgroundColor: "white",
+                zIndex: "999",
+                boxShadow: "0 1px 2px rgb(43 59 93 / 29%)",
+                font: "10px"
               }}
             >
               <UnlabeledTombstone
@@ -62,6 +95,7 @@ export default class TableOfContents extends React.Component {
           on_click={this.on_click}
           is_open={is_open}
         />
+        */
       )
     );
   }

--- a/client/src/infographic/TableOfContents.js
+++ b/client/src/infographic/TableOfContents.js
@@ -91,7 +91,16 @@ export default class TableOfContents extends React.Component {
             maxHeight: "580px",
           }}
         >
-          <h2 style={{ backgroundColor: "rgb(44, 112, 201)", color: "white", display: "flex", textAlign: "center", fontSize: "1.2em", fontWeight: "500" }}>
+          <h2
+            style={{
+              backgroundColor: "rgb(44, 112, 201)",
+              color: "white",
+              display: "flex",
+              textAlign: "center",
+              fontSize: "1.2em",
+              fontWeight: "500",
+            }}
+          >
             Table of Contents
           </h2>
           <UnlabeledTombstone

--- a/client/src/infographic/TableOfContents.js
+++ b/client/src/infographic/TableOfContents.js
@@ -80,7 +80,6 @@ export default class TableOfContents extends React.Component {
     const { subject, active_bubble_id, panel_titles_by_key } = this.props;
 
     const { is_open } = this.state;
-
     return (
       !_.isEmpty(panel_titles_by_key) && (
         <StatelessDetails
@@ -118,6 +117,9 @@ export default class TableOfContents extends React.Component {
                   fontWeight: "500",
                 }}
               >
+                <button onClick={this.on_click} style={{ textAlign: "left" }}>
+                  x
+                </button>
                 <TM k="table_of_contents" />{" "}
               </h2>
               <UnlabeledTombstone

--- a/client/src/infographic/TableOfContents.js
+++ b/client/src/infographic/TableOfContents.js
@@ -53,7 +53,7 @@ export default class TableOfContents extends React.Component {
       for (const el of panels) {
         observer.observe(el);
       }
-    }, 3000);
+    }, 1500);
   }
 
   componentDidMount() {
@@ -63,7 +63,6 @@ export default class TableOfContents extends React.Component {
 
   componentDidUpdate() {
     if (this.props.active_bubble_id != this.state.active_page) {
-      console.log("true!");
       this.setState({ active_page: this.props.active_bubble_id });
       this.updateTableofContents();
     }

--- a/client/src/infographic/TableOfContents.js
+++ b/client/src/infographic/TableOfContents.js
@@ -32,7 +32,7 @@ export default class TableOfContents extends React.Component {
 
           const href = document.querySelector(query);
           if (href) {
-            if (entry.intersectionRatio > 0.5) {
+            if (entry.intersectionRatio > 0.4) {
               href.classList.add("active");
               console.log(this.state.active_href);
               const temp = this.state.active_href;
@@ -45,7 +45,7 @@ export default class TableOfContents extends React.Component {
           }
         });
       },
-      { threshold: [0, 0.5] }
+      { threshold: [0, 0.4] }
     );
 
     setTimeout(() => {
@@ -53,7 +53,7 @@ export default class TableOfContents extends React.Component {
       for (const el of panels) {
         observer.observe(el);
       }
-    }, 1500);
+    }, 750);
   }
 
   componentDidMount() {
@@ -91,7 +91,7 @@ export default class TableOfContents extends React.Component {
             maxHeight: "580px",
           }}
         >
-          <h2 style={{ backgroundColor: "blue", color: "white" }}>
+          <h2 style={{ backgroundColor: "rgb(44, 112, 201)", color: "white", display: "flex", textAlign: "center", fontSize: "1.2em", fontWeight: "500" }}>
             Table of Contents
           </h2>
           <UnlabeledTombstone

--- a/client/src/infographic/TableOfContents.js
+++ b/client/src/infographic/TableOfContents.js
@@ -2,7 +2,11 @@ import _ from "lodash";
 
 import React from "react";
 
-import { UnlabeledTombstone, StatelessDetails, create_text_maker_component} from "src/components/index";
+import {
+  UnlabeledTombstone,
+  StatelessDetails,
+  create_text_maker_component,
+} from "src/components/index";
 
 import { infographic_href_template } from "./infographic_href_template";
 
@@ -80,66 +84,65 @@ export default class TableOfContents extends React.Component {
     return (
       !_.isEmpty(panel_titles_by_key) && (
         <StatelessDetails
-        summary_content={
-          <div>
-            <TM k="table_of_contents" />{" "}
-            <TM className="panel-status-text" k="skip_to_panel" />
-          </div>
-        }
-        content={
-          
-        <div
-          aria-label="Table of contents"
-          style={{
-            border: "1px solid",
-            position: "fixed",
-            display: "inline-block",
-            left: "5px",
-            top: "110px",
-            backgroundColor: "white",
-            zIndex: "999",
-            boxShadow: "0 1px 2px rgb(43 59 93 / 29%)",
-            font: "3px",
-            overflow: "auto",
-            maxWidth: "150px",
-            maxHeight: "580px",
-          }}
-        >
-          <h2
-            style={{
-              backgroundColor: "rgb(44, 112, 201)",
-              color: "white",
-              display: "flex",
-              textAlign: "center",
-              fontSize: "1.2em",
-              fontWeight: "500",
-            }}
-          >
-            <TM k="table_of_contents" />{" "}
-          </h2>
-          <UnlabeledTombstone
-            items={_.map(panel_titles_by_key, (panel_title, panel_key) => (
-              <a
-                className={"toc_link"}
-                key={panel_key}
-                href={infographic_href_template(subject, active_bubble_id, {
-                  panel_key,
-                })}
-                onClick={(e) => {
-                  e.preventDefault();
-                  document.getElementById(panel_key).scrollIntoView({
-                    behavior: "smooth",
-                  });
+          summary_content={
+            <div>
+              <TM k="table_of_contents" />{" "}
+              <TM className="panel-status-text" k="skip_to_panel" />
+            </div>
+          }
+          content={
+            <div
+              aria-label="Table of contents"
+              style={{
+                border: "1px solid",
+                position: "fixed",
+                display: "inline-block",
+                left: "5px",
+                top: "110px",
+                backgroundColor: "white",
+                zIndex: "999",
+                boxShadow: "0 1px 2px rgb(43 59 93 / 29%)",
+                font: "3px",
+                overflow: "auto",
+                maxWidth: "150px",
+                maxHeight: "580px",
+              }}
+            >
+              <h2
+                style={{
+                  backgroundColor: "rgb(44, 112, 201)",
+                  color: "white",
+                  display: "flex",
+                  textAlign: "center",
+                  fontSize: "1.2em",
+                  fontWeight: "500",
                 }}
               >
-                {panel_title}
-              </a>
-            ))}
-          />
-        </div>
-        }
-        on_click={this.on_click}
-        is_open={is_open}
+                <TM k="table_of_contents" />{" "}
+              </h2>
+              <UnlabeledTombstone
+                items={_.map(panel_titles_by_key, (panel_title, panel_key) => (
+                  <a
+                    className={"toc_link"}
+                    key={panel_key}
+                    href={infographic_href_template(subject, active_bubble_id, {
+                      panel_key,
+                    })}
+                    onClick={(e) => {
+                      e.preventDefault();
+                      document.getElementById(panel_key).scrollIntoView({
+                        behavior: "smooth",
+                      });
+                    }}
+                  >
+                    {panel_title}
+                  </a>
+                ))}
+              />
+            </div>
+          }
+          on_click={this.on_click}
+          is_open={is_open}
         />
       )
     );

--- a/client/src/infographic/TableOfContents.js
+++ b/client/src/infographic/TableOfContents.js
@@ -1,17 +1,9 @@
 import _ from "lodash";
 import React from "react";
 
-import {
-  StatelessDetails,
-  create_text_maker_component,
-  UnlabeledTombstone,
-} from "src/components/index";
+import { UnlabeledTombstone } from "src/components/index";
 
 import { infographic_href_template } from "./infographic_href_template";
-
-import text from "./TableOfContents.yaml";
-
-const { TM } = create_text_maker_component(text);
 
 export default class TableOfContents extends React.Component {
   constructor(props) {
@@ -24,8 +16,6 @@ export default class TableOfContents extends React.Component {
   render() {
     const { subject, active_bubble_id, panel_titles_by_key } = this.props;
 
-    const { is_open } = this.state;
-
     return (
       !_.isEmpty(panel_titles_by_key) && (
         <div
@@ -35,12 +25,14 @@ export default class TableOfContents extends React.Component {
             position: "fixed",
             display: "inline-block",
             left: "5px",
-            top: "150px",
+            top: "110px",
             backgroundColor: "transparent",
             zIndex: "999",
             boxShadow: "0 1px 2px rgb(43 59 93 / 29%)",
-            font: "8px",
+            font: "3px",
             overflow: "auto",
+            maxWidth: "150px",
+            maxHeight: "580px",
           }}
         >
           <UnlabeledTombstone

--- a/client/src/infographic/TableOfContents.js
+++ b/client/src/infographic/TableOfContents.js
@@ -1,4 +1,5 @@
 import _ from "lodash";
+
 import React from "react";
 
 import { UnlabeledTombstone } from "src/components/index";
@@ -10,8 +11,145 @@ export default class TableOfContents extends React.Component {
     super(props);
     this.state = {
       is_open: false,
+      //active_page: null,
+      previous_href: null,
+      active_href: null,
     };
   }
+  /* activeId = useState();
+  setActiveId = useState();
+  nestedHeadings = useHeadingsData();
+  useIntersectionObserver(setActiveId);
+
+   useHeadingsData = () => {
+    const [nestedHeadings, setNestedHeadings] = useState([]);
+  
+    useEffect(() => {
+      const headingElements = Array.from(
+        document.querySelectorAll("h2")
+      );
+  
+      const newNestedHeadings = getNestedHeadings(headingElements);
+      setNestedHeadings(newNestedHeadings);
+    }, []);
+  
+    return { nestedHeadings };
+  };
+
+  getNestedHeadings = (headingElements) => {
+    const nestedHeadings = [];
+  
+    headingElements.forEach((heading, index) => {
+      const { innerText: title, id } = heading;
+  
+      if (heading.nodeName === "H2") {
+        nestedHeadings.push({ id, title, items: [] });
+      } else if (heading.nodeName === "H3" && nestedHeadings.length > 0) {
+        nestedHeadings[nestedHeadings.length - 1].items.push({
+          id,
+          title,
+        });
+      }
+    });
+  
+    return nestedHeadings;
+  };
+
+  useIntersectionObserver = (setActiveId) => {
+    const headingElementsRef = useRef({});
+    useEffect(() => {
+      const callback = (headings) => {
+        headingElementsRef.current = headings.reduce((map, headingElement) => {
+          map[headingElement.target.id] = headingElement;
+          return map;
+        }, headingElementsRef.current);
+  
+        const visibleHeadings = [];
+        Object.keys(headingElementsRef.current).forEach((key) => {
+          const headingElement = headingElementsRef.current[key];
+          if (headingElement.isIntersecting) visibleHeadings.push(headingElement);
+        });
+  
+        const getIndexFromId = (id) =>
+          headingElements.findIndex((heading) => heading.id === id);
+  
+        if (visibleHeadings.length === 1) {
+          setActiveId(visibleHeadings[0].target.id);
+        } else if (visibleHeadings.length > 1) {
+          const sortedVisibleHeadings = visibleHeadings.sort(
+            (a, b) => getIndexFromId(a.target.id) > getIndexFromId(b.target.id)
+          );
+          setActiveId(sortedVisibleHeadings[0].target.id);
+        }
+      };
+  
+      const observer = new IntersectionObserver(callback, {
+        rootMargin: "0px 0px -40% 0px"
+      });
+  
+      const headingElements = Array.from(document.querySelectorAll("h2, h3"));
+  
+      headingElements.forEach((element) => observer.observe(element));
+  
+      return () => observer.disconnect();
+    }, [setActiveId]);
+  };
+  */
+
+  componentDidMount() {
+    const { subject, active_bubble_id } = this.props;
+    /*const { active_page } = this.state;
+    this.getUpdate(active_page);
+    */
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          const panel_key = entry.target.parentElement.getAttribute("id");
+          const query = `a[href="${infographic_href_template(
+            subject,
+            active_bubble_id,
+            { panel_key }
+          )}"]`;
+
+          const href = document.querySelector(query);
+          if (href) {
+            if (entry.intersectionRatio > 0.5) {
+              href.classList.add("active");
+              console.log(this.state.active_href);
+              const temp = this.state.active_href;
+              this.setState({
+                active_href: href,
+                previous_href: temp,
+              });
+              this.state.previous_href?.classList.remove("active");
+            }
+          }
+        });
+      },
+      { threshold: [0, 0.5] }
+    );
+
+    setTimeout(() => {
+      const panels = document.getElementsByClassName("panel");
+      for (const el of panels) {
+        observer.observe(el);
+      }
+    }, 3000);
+  }
+
+  /* componentDidUpdate () {
+    if(!window.location.href.includes(this.props.active_bubble_id)){
+      const { active_page } = this.state;
+      this.getUpdate(active_page);
+    }
+  }
+
+  getUpdate = () => {
+    this.setState({active_page: window.location.href});
+};
+*/
+
   on_click = () => this.setState({ is_open: !this.state.is_open });
   render() {
     const { subject, active_bubble_id, panel_titles_by_key } = this.props;
@@ -41,10 +179,17 @@ export default class TableOfContents extends React.Component {
           <UnlabeledTombstone
             items={_.map(panel_titles_by_key, (panel_title, panel_key) => (
               <a
+                className={"toc_link"}
                 key={panel_key}
                 href={infographic_href_template(subject, active_bubble_id, {
                   panel_key,
                 })}
+                onClick={(e) => {
+                  e.preventDefault();
+                  document.getElementById(panel_key).scrollIntoView({
+                    behavior: "smooth",
+                  });
+                }}
               >
                 {panel_title}
               </a>

--- a/client/src/infographic/TableOfContents.js
+++ b/client/src/infographic/TableOfContents.js
@@ -26,7 +26,7 @@ export default class TableOfContents extends React.Component {
             display: "inline-block",
             left: "5px",
             top: "110px",
-            backgroundColor: "transparent",
+            backgroundColor: "white",
             zIndex: "999",
             boxShadow: "0 1px 2px rgb(43 59 93 / 29%)",
             font: "3px",
@@ -35,6 +35,7 @@ export default class TableOfContents extends React.Component {
             maxHeight: "580px",
           }}
         >
+          <h2 style={{backgroundColor: "blue", color: "white"}}>Table of Contents</h2>
           <UnlabeledTombstone
             items={_.map(panel_titles_by_key, (panel_title, panel_key) => (
               <a

--- a/client/src/infographic/TableOfContents.js
+++ b/client/src/infographic/TableOfContents.js
@@ -2,15 +2,19 @@ import _ from "lodash";
 
 import React from "react";
 
-import { UnlabeledTombstone } from "src/components/index";
+import { UnlabeledTombstone, StatelessDetails, create_text_maker_component} from "src/components/index";
 
 import { infographic_href_template } from "./infographic_href_template";
+
+import text from "./TableOfContents.yaml";
+
+const { TM } = create_text_maker_component(text);
 
 export default class TableOfContents extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      is_open: false,
+      is_open: true,
       active_page: null,
       previous_href: null,
       active_href: null,
@@ -72,8 +76,18 @@ export default class TableOfContents extends React.Component {
   render() {
     const { subject, active_bubble_id, panel_titles_by_key } = this.props;
 
+    const { is_open } = this.state;
+
     return (
       !_.isEmpty(panel_titles_by_key) && (
+        <StatelessDetails
+        summary_content={
+          <div>
+            <TM k="table_of_contents" />{" "}
+            <TM className="panel-status-text" k="skip_to_panel" />
+          </div>
+        }
+        content={
         <div
           aria-label="Table of contents"
           style={{
@@ -123,7 +137,12 @@ export default class TableOfContents extends React.Component {
             ))}
           />
         </div>
+        }
+        on_click={this.on_click}
+        is_open={is_open}
+        />
       )
     );
   }
 }
+


### PR DESCRIPTION
In progress, the logic of highlighting the currently visible panel seems to work- but the only concern is it takes a few seconds for the functionality to work upon changing the subject due to the timeout call. Unfortunately seems like it can't afford to be removed, but perhaps a replacement for it could work and make things faster.