### PR TITLE
Notice for Sunsetting Covid Reporting

### DIFF
--- a/client/src/panels/panel_declarations/covid/covid_intro.js
+++ b/client/src/panels/panel_declarations/covid/covid_intro.js
@@ -110,6 +110,7 @@ class CovidIntroPanelDyanmicText extends React.Component {
                 }}
               />
             )}
+          <TM k={"covid_intro_notice"} />
         </YearSelectionTabs>
       );
     }

--- a/client/src/panels/panel_declarations/covid/covid_intro.yaml
+++ b/client/src/panels/panel_declarations/covid/covid_intro.yaml
@@ -29,8 +29,9 @@ covid_intro_exp:
 covid_intro_notice:
   transform: [handlebars,markdown]
   en: |
-    **Important:** As a result of the sunsetting of the Government of Canada’s COVID-19 Economic Response Plan authorities in fiscal year **2022-23**, please note that the Treasury
-    Board Secretariat **has ceased collecting data on COVID Expenditures as of March 31, 2023**.
+    **Important:** As a result of the sunsetting of the Government of Canada’s COVID-19 Economic Response Plan authorities in fiscal year **2022-23**, please 
+    note that the Treasury Board Secretariat **has ceased collecting data on COVID Expenditures as of March 31, 2023**.
   fr: |
-    **Important:** Étant donné l’élimination progressive des autorités du Plan d'intervention économique du Canada pour répondre à la COVID-19 au cours de l’exercice financier 
-    **2022-23**, veuillez noter que le Secrétariat du Conseil du Trésor **a cessé de recueillir des données sur les dépenses au titre de la COVID-19 en date du 31 mars 2023**.
+    **Important:** Étant donné l’élimination progressive des autorités du Plan d'intervention économique du Canada pour répondre à la COVID-19 au cours de 
+    l’exercice financier **2022-23**, veuillez noter que le Secrétariat du Conseil du Trésor **a cessé de recueillir des données sur les dépenses au titre 
+    de la COVID-19 en date du 31 mars 2023**.

--- a/client/src/panels/panel_declarations/covid/covid_intro.yaml
+++ b/client/src/panels/panel_declarations/covid/covid_intro.yaml
@@ -29,8 +29,8 @@ covid_intro_exp:
 covid_intro_notice:
   transform: [handlebars,markdown]
   en: |
-    **Important:** As a result of the sunsetting of the Government of Canada’s COVID-19 Economic Response Plan authorities in fiscal year 2022-23, please note that the Treasury
-    Board Secretariat has ceased collecting data on COVID Expenditures as of March 31, 2023.
+    **Important:** As a result of the sunsetting of the Government of Canada’s COVID-19 Economic Response Plan authorities in fiscal year **2022-23**, please note that the Treasury
+    Board Secretariat **has ceased collecting data on COVID Expenditures as of March 31, 2023**.
   fr: |
     **Important:** Étant donné l’élimination progressive des autorités du Plan d'intervention économique du Canada pour répondre à la COVID-19 au cours de l’exercice financier 
-    2022-23, veuillez noter que le Secrétariat du Conseil du Trésor a cessé de recueillir des données sur les dépenses au titre de la COVID-19 en date du 31 mars 2023.
+    **2022-23**, veuillez noter que le Secrétariat du Conseil du Trésor **a cessé de recueillir des données sur les dépenses au titre de la COVID-19 en date du 31 mars 2023**.

--- a/client/src/panels/panel_declarations/covid/covid_intro.yaml
+++ b/client/src/panels/panel_declarations/covid/covid_intro.yaml
@@ -25,3 +25,12 @@ covid_intro_exp:
   fr: |
     En date du **{{date_last_updated_text}}**, les organisations fédérales ont **estimé à {{fmt_compact1_written gov_covid_expenditures_in_year}}
     le total des dépenses** au titre des mesures du PIE pour **{{fmt_year_to_fiscal_year selected_year}}**.
+
+covid_intro_notice:
+  transform: [handlebars,markdown]
+  en: |
+    **Important:** As a result of the sunsetting of the Government of Canada’s COVID-19 Economic Response Plan authorities in fiscal year 2022-23, please note that the Treasury
+    Board Secretariat has ceased collecting data on COVID Expenditures as of March 31, 2023.
+  fr: |
+    **Important:** Étant donné l’élimination progressive des autorités du Plan d'intervention économique du Canada pour répondre à la COVID-19 au cours de l’exercice financier 
+    2022-23, veuillez noter que le Secrétariat du Conseil du Trésor a cessé de recueillir des données sur les dépenses au titre de la COVID-19 en date du 31 mars 2023.


### PR DESCRIPTION
Added a note at the bottom of the COVID-19 intro panel that explains that TBS has stopped collecting covid data as of March 31, 2023.