### PR TITLE
Separate FTE and Spending on Welcome Mat

### DIFF
--- a/client/src/panels/panel_declarations/finances/welcome_mat/welcome_mat.js
+++ b/client/src/panels/panel_declarations/finances/welcome_mat/welcome_mat.js
@@ -976,7 +976,6 @@ const common_program_crso_calculate = ({ subject, tables }) => {
 const common_panel_config = {
   legacy_table_dependencies: ["programSpending", "programFtes"],
   get_dataset_keys: () => ["program_spending", "program_ftes"],
-  get_title: () => text_maker("welcome_mat_title"),
   get_title: ({ calculations }) => {
     const has_fte_data = calculations.calcs.has_fte;
     if (has_fte_data) {

--- a/client/src/panels/panel_declarations/finances/welcome_mat/welcome_mat.js
+++ b/client/src/panels/panel_declarations/finances/welcome_mat/welcome_mat.js
@@ -64,6 +64,9 @@ const WelcomeMatShell = ({ header_row, spend_row, fte_row, text_row }) => (
       {header_row}
     </div>
     <div className="mat-grid__row">{spend_row}</div>
+    <div className="mat-grid__row mat-grid__row--sm-hide" aria-hidden>
+      {header_row}
+    </div>
     {fte_row && <div className="mat-grid__row">{fte_row}</div>}
     {text_row && <div className="mat-grid__row">{text_row}</div>}
   </div>

--- a/client/src/panels/panel_declarations/finances/welcome_mat/welcome_mat.js
+++ b/client/src/panels/panel_declarations/finances/welcome_mat/welcome_mat.js
@@ -62,38 +62,48 @@ const PaneItem = ({ children, textSize, hide_lg }) => (
   </div>
 );
 
-const WelcomeMatShell = ({ header_row, spend_row, fte_row, text_row }) => (
-  <TabsStateful
-    tabs={{
-      spending: {
-        label: text_maker("spending"),
-        content: (
-          <div className="mat-grid">
-            <div className="mat-grid__row mat-grid__row--sm-hide" aria-hidden>
-              {header_row}
-            </div>
-            <div className="mat-grid__row">{spend_row}</div>
-            {text_row && <div className="mat-grid__row">{text_row[0]}</div>}
-          </div>
-        ),
-      },
-      ...(fte_row && {
-        employment: {
-          label: text_maker("employment"),
-          content: (
-            <div className="mat-grid">
-              <div className="mat-grid__row mat-grid__row--sm-hide" aria-hidden>
-                {header_row}
-              </div>
-              <div className="mat-grid__row">{fte_row}</div>
-              {text_row && <div className="mat-grid__row">{text_row[1]}</div>}
-            </div>
-          ),
-        },
-      }),
-    }}
-  />
-);
+const WelcomeMatShell = ({ header_row, spend_row, fte_row, text_row }) => {
+  const spending_tab_content = (
+    <div className="mat-grid">
+      <div className="mat-grid__row mat-grid__row--sm-hide" aria-hidden>
+        {header_row}
+      </div>
+      <div className="mat-grid__row">{spend_row}</div>
+      {text_row && <div className="mat-grid__row">{text_row[0]}</div>}
+    </div>
+  );
+
+  const employment_tab_content = (
+    <div className="mat-grid">
+      <div className="mat-grid__row mat-grid__row--sm-hide" aria-hidden>
+        {header_row}
+      </div>
+      <div className="mat-grid__row">{fte_row}</div>
+      {text_row && <div className="mat-grid__row">{text_row[1]}</div>}
+    </div>
+  );
+
+  if (fte_row) {
+    return (
+      <TabsStateful
+        tabs={{
+          spending: {
+            label: text_maker("spending"),
+            content: spending_tab_content,
+          },
+          ...(fte_row && {
+            employment: {
+              label: text_maker("employment"),
+              content: employment_tab_content,
+            },
+          }),
+        }}
+      />
+    );
+  } else {
+    return spending_tab_content;
+  }
+};
 
 /*
   markup:

--- a/client/src/panels/panel_declarations/finances/welcome_mat/welcome_mat.js
+++ b/client/src/panels/panel_declarations/finances/welcome_mat/welcome_mat.js
@@ -977,6 +977,14 @@ const common_panel_config = {
   legacy_table_dependencies: ["programSpending", "programFtes"],
   get_dataset_keys: () => ["program_spending", "program_ftes"],
   get_title: () => text_maker("welcome_mat_title"),
+  get_title: ({ calculations }) => {
+    const has_fte_data = calculations.calcs.has_fte;
+    if (has_fte_data) {
+      return text_maker("welcome_mat_title");
+    } else {
+      return text_maker("welcome_mat_spending_title");
+    }
+  },
 };
 
 export const declare_welcome_mat_panel = () =>

--- a/client/src/panels/panel_declarations/finances/welcome_mat/welcome_mat.js
+++ b/client/src/panels/panel_declarations/finances/welcome_mat/welcome_mat.js
@@ -5,7 +5,11 @@ import React, { Fragment } from "react";
 import { InfographicPanel } from "src/panels/panel_declarations/InfographicPanel";
 import { declare_panel } from "src/panels/PanelRegistry";
 
-import { create_text_maker_component, Format } from "src/components/index";
+import {
+  create_text_maker_component,
+  Format,
+  TabsStateful,
+} from "src/components/index";
 
 import { run_template } from "src/models/text";
 
@@ -59,20 +63,36 @@ const PaneItem = ({ children, textSize, hide_lg }) => (
 );
 
 const WelcomeMatShell = ({ header_row, spend_row, fte_row, text_row }) => (
-  <div className="mat-grid">
-    <div className="mat-grid__row mat-grid__row--sm-hide" aria-hidden>
-      {header_row}
-    </div>
-    <div className="mat-grid__row">{spend_row}</div>
-    {text_row && <div className="mat-grid__row">{text_row[0]}</div>}
-    {fte_row && (
-      <div className="mat-grid__row mat-grid__row--sm-hide" aria-hidden>
-        {header_row}
-      </div>
-    )}
-    {fte_row && <div className="mat-grid__row">{fte_row}</div>}
-    {text_row && <div className="mat-grid__row">{text_row[1]}</div>}
-  </div>
+  <TabsStateful
+    tabs={{
+      spending: {
+        label: text_maker("spending"),
+        content: (
+          <div className="mat-grid">
+            <div className="mat-grid__row mat-grid__row--sm-hide" aria-hidden>
+              {header_row}
+            </div>
+            <div className="mat-grid__row">{spend_row}</div>
+            {text_row && <div className="mat-grid__row">{text_row[0]}</div>}
+          </div>
+        ),
+      },
+      ...(fte_row && {
+        employment: {
+          label: text_maker("employment"),
+          content: (
+            <div className="mat-grid">
+              <div className="mat-grid__row mat-grid__row--sm-hide" aria-hidden>
+                {header_row}
+              </div>
+              <div className="mat-grid__row">{fte_row}</div>
+              {text_row && <div className="mat-grid__row">{text_row[1]}</div>}
+            </div>
+          ),
+        },
+      }),
+    }}
+  />
 );
 
 /*

--- a/client/src/panels/panel_declarations/finances/welcome_mat/welcome_mat.js
+++ b/client/src/panels/panel_declarations/finances/welcome_mat/welcome_mat.js
@@ -91,12 +91,10 @@ const WelcomeMatShell = ({ header_row, spend_row, fte_row, text_row }) => {
             label: text_maker("spending"),
             content: spending_tab_content,
           },
-          ...(fte_row && {
-            employment: {
-              label: text_maker("employment"),
-              content: employment_tab_content,
-            },
-          }),
+          employment: {
+            label: text_maker("employment"),
+            content: employment_tab_content,
+          },
         }}
       />
     );

--- a/client/src/panels/panel_declarations/finances/welcome_mat/welcome_mat.js
+++ b/client/src/panels/panel_declarations/finances/welcome_mat/welcome_mat.js
@@ -64,11 +64,14 @@ const WelcomeMatShell = ({ header_row, spend_row, fte_row, text_row }) => (
       {header_row}
     </div>
     <div className="mat-grid__row">{spend_row}</div>
-    <div className="mat-grid__row mat-grid__row--sm-hide" aria-hidden>
-      {header_row}
-    </div>
+    {text_row && <div className="mat-grid__row">{text_row[0]}</div>}
+    {fte_row && (
+      <div className="mat-grid__row mat-grid__row--sm-hide" aria-hidden>
+        {header_row}
+      </div>
+    )}
     {fte_row && <div className="mat-grid__row">{fte_row}</div>}
-    {text_row && <div className="mat-grid__row">{text_row}</div>}
+    {text_row && <div className="mat-grid__row">{text_row[1]}</div>}
   </div>
 );
 
@@ -716,7 +719,7 @@ const WelcomeMat = (props) => {
         }
         text_row={[
           spend_summary_key && (
-            <Pane key="a" size={45}>
+            <Pane key="a" size={100}>
               <PaneItem textSize="small">
                 <TM
                   k={spend_summary_key}
@@ -733,7 +736,7 @@ const WelcomeMat = (props) => {
             </Pane>
           ),
           fte_summary_key && (
-            <Pane key="b" size={55}>
+            <Pane key="b" size={100}>
               <PaneItem textSize="small">
                 <TM
                   k={fte_summary_key}

--- a/client/src/panels/panel_declarations/finances/welcome_mat/welcome_mat.js
+++ b/client/src/panels/panel_declarations/finances/welcome_mat/welcome_mat.js
@@ -954,6 +954,7 @@ export const declare_welcome_mat_panel = () =>
         case "gov":
           return {
             ...common_panel_config,
+            get_dataset_keys: () => ["program_spending"],
 
             calculate: ({ subject, tables }) => {
               const { programSpending, programFtes } = tables;

--- a/client/src/panels/panel_declarations/finances/welcome_mat/welcome_mat.js
+++ b/client/src/panels/panel_declarations/finances/welcome_mat/welcome_mat.js
@@ -996,6 +996,7 @@ export const declare_welcome_mat_panel = () =>
         case "gov":
           return {
             ...common_panel_config,
+            get_title: () => text_maker("welcome_mat_spending_title"),
             get_dataset_keys: () => ["program_spending"],
 
             calculate: ({ subject, tables }) => {

--- a/client/src/panels/panel_declarations/finances/welcome_mat/welcome_mat.js
+++ b/client/src/panels/panel_declarations/finances/welcome_mat/welcome_mat.js
@@ -567,7 +567,7 @@ const WelcomeMat = (props) => {
     if (!_.includes(["crso", "program"], subject_type)) {
       if (subject_type === "gov") {
         spend_summary_key = "gov_welcome_mat_spending_summary";
-        fte_summary_key = "welcome_mat_fte_summary";
+        fte_summary_key = false;
       } else if (subject_type === "dept") {
         spend_summary_key = "dept1_welcome_mat_spending_summary";
         fte_summary_key = "welcome_mat_fte_summary";
@@ -652,6 +652,7 @@ const WelcomeMat = (props) => {
           ]
         }
         fte_row={
+          subject_type !== "gov" &&
           has_fte && [
             !latest_equals_oldest_hist && (
               <Pane key="a" size={15}>

--- a/client/src/panels/panel_declarations/finances/welcome_mat/welcome_mat.yaml
+++ b/client/src/panels/panel_declarations/finances/welcome_mat/welcome_mat.yaml
@@ -3,6 +3,11 @@ welcome_mat_title:
   en: Spending and Employment Trend
   fr: Tendance des dépenses et de l'emploi
 
+welcome_mat_spending_title:
+  transform: [handlebars]
+  en: Spending Trend
+  fr: Tendance des dépenses
+
 no_wrap_year:
   transform: [handlebars]
   handlebars_partial : true

--- a/client/src/panels/panel_declarations/finances/welcome_mat/welcome_mat.yaml
+++ b/client/src/panels/panel_declarations/finances/welcome_mat/welcome_mat.yaml
@@ -294,3 +294,11 @@ CR_exp_ftes_fte_summary:
    Au cours des 3 prochaines années, le total des dépenses {{fr_will_change_by  exp_calcs.exp_plan_change "m" "s" "fmt_percentage1"}} et 
    le nombre d'[équivalents temps plein (ETPs)]{{gl "FTE"}} {{fr_will_change_by fte_calcs.fte_plan_change "m" "s" "fmt_percentage1"}}.
    {{/if}}
+
+spending:
+  en: "Spending"
+  fr: "Dépenses"
+
+employment:
+  en: "Employment"
+  fr: "Emploi"


### PR DESCRIPTION
Separated the spending and FTE visuals on the welcome mat so that they are displayed using tabs to select which trend data the user would like to see, as shown in the screenshot below:
![image](https://github.com/TBS-EACPD/infobase/assets/72468587/0826b915-1146-4166-9e4a-aa534d622a32)

Note that changes were also made so that at the government level the welcome mat has no tabs displayed and only the spending trend data is shown.