### PR TITLE
Update Results Summary Chart

### DIFF
--- a/client/src/charts/wrapped_nivo/WrappedNivoPie/WrappedNivoPie.js
+++ b/client/src/charts/wrapped_nivo/WrappedNivoPie/WrappedNivoPie.js
@@ -136,7 +136,7 @@ export class WrappedNivoPie extends React.Component {
                 return percent_value_tooltip(
                   [data_with_original_values],
                   get_formatter(is_money, text_formatter, false),
-                  _.sumBy(data_with_absolute_values, "value")
+                  _.sumBy(this.props.data, "value")
                 );
               } else {
                 return tooltip(


### PR DESCRIPTION
The NivioPie component was calculating the percentage of each item in the chart using the total sum of all the possible items in the chart. Ex. In the 'Departmental Results Reports Summary' panel, the pie chart total was always being calculated as (chart total = target met + not met + not available + future) regardless of whether all these items were selected or not. Calculating the percentage using this total value results in inaccurate tooltip values when all the items are not selected.

Solution: Updated the WrappedNivioPie component to calculate the pie chart total by summing only the selected items. Example of corrected version shown below:
![image](https://github.com/TBS-EACPD/infobase/assets/72468587/327110cc-88a2-444b-af10-9d57ad4510f2)
