### PR TITLE
RPB Crown Corps planned years removal

### DIFF
--- a/client/src/components/DisplayTable/DisplayTable.tsx
+++ b/client/src/components/DisplayTable/DisplayTable.tsx
@@ -401,12 +401,12 @@ export class _DisplayTable extends React.Component<
     const total_row = _.reduce<DisplayTableData, { [key: string]: number }>(
       sorted_filtered_data,
       (totals, row: DisplayTableData) =>
-        _.mapValues(totals, (total: number, col_key) =>
-          col_configs_with_defaults[col_key].sum_func(
+        _.mapValues(totals, (total: number, col_key) => {
+          return col_configs_with_defaults[col_key].sum_func(
             total,
-            row[col_key] as number
-          )
-        ),
+            typeof row[col_key] === "number" ? (row[col_key] as number) : 0
+          );
+        }),
       _.chain(col_configs_with_defaults)
         .toPairs()
         .filter(([_key, col]) => col.is_summable)

--- a/client/src/components/DisplayTable/DisplayTable.tsx
+++ b/client/src/components/DisplayTable/DisplayTable.tsx
@@ -401,12 +401,12 @@ export class _DisplayTable extends React.Component<
     const total_row = _.reduce<DisplayTableData, { [key: string]: number }>(
       sorted_filtered_data,
       (totals, row: DisplayTableData) =>
-        _.mapValues(totals, (total: number, col_key) => {
-          return col_configs_with_defaults[col_key].sum_func(
+        _.mapValues(totals, (total: number, col_key) =>
+          col_configs_with_defaults[col_key].sum_func(
             total,
             typeof row[col_key] === "number" ? (row[col_key] as number) : 0
-          );
-        }),
+          )
+        ),
       _.chain(col_configs_with_defaults)
         .toPairs()
         .filter(([_key, col]) => col.is_summable)

--- a/client/src/rpb/granular_view.js
+++ b/client/src/rpb/granular_view.js
@@ -107,9 +107,10 @@ class GranularView extends React.Component {
 
       // remove planned spending projections from crown corps
       if (org.inst_form_id === "crown_corp") {
-        planning_years.forEach(
-          (year) => (filtered_columns[year] = "Not Applicable")
-        );
+        planning_years.forEach((year) => {
+          if (year in filtered_columns)
+            filtered_columns[year] = "Not Applicable";
+        });
       }
 
       if (grouping_default_or_dept) {

--- a/client/src/rpb/granular_view.js
+++ b/client/src/rpb/granular_view.js
@@ -97,8 +97,22 @@ class GranularView extends React.Component {
         .fromPairs()
         .value();
 
+      const org = Dept.store.lookup(row.dept);
+
+      const planning_years = [
+        "{{planning_year_1}}",
+        "{{planning_year_2}}",
+        "{{planning_year_3}}",
+      ];
+
+      // remove planned spending projections from crown corps
+      if (org.inst_form_id === "crown_corp") {
+        planning_years.forEach(
+          (year) => (filtered_columns[year] = "Not Applicable")
+        );
+      }
+
       if (grouping_default_or_dept) {
-        const org = Dept.store.lookup(row.dept);
         return {
           dept: org.name,
           legal_title: org.legal_title ? org.legal_title : org.name,


### PR DESCRIPTION
Planning year spending values for crown corps in our Report Builder were still getting displayed (projection from current spending). This information is not necessarily accurate as they aren't required to submit planned spending. This information had been removed from their Infographics but was still being displayed in the RPB.