### PR TITLE
Link-in-text-block axe violation fix

### DIFF
--- a/client/cypress/integration/InfoBase/cypress-snapshots.js
+++ b/client/cypress/integration/InfoBase/cypress-snapshots.js
@@ -19,9 +19,6 @@ module.exports = {
         "Axe violations allow list": {
           "color-contrast, serious": [
             "<button class=\"btn btn-ib-primary floating-button floating-button--fixed\" aria-label=\"Back to top\" style=\"top: auto;\">Back to top</button>"
-          ],
-          "link-in-text-block, serious": [
-            "<a href=\"https://www.canada.ca/en/government/system/transparency/gender-diversity-impacts-programs.html\" target=\"_blank\" rel=\"noopener noreferrer\">here</a>"
           ]
         }
       },
@@ -29,157 +26,48 @@ module.exports = {
         "Axe violations allow list": {
           "color-contrast, serious": [
             "<button class=\"btn btn-ib-primary floating-button floating-button--fixed\" aria-label=\"Back to top\" style=\"top: auto;\">Back to top</button>"
-          ],
-          "link-in-text-block, serious": [
-            "<a href=\"https://www.canada.ca/en/government/system/transparency/gender-diversity-impacts-programs.html\" target=\"_blank\" rel=\"noopener noreferrer\">here</a>"
           ]
         }
       }
     },
     "Datasets": {
       "Tested on index-eng.html#datasets": {
-        "Axe violations allow list": {
-          "link-in-text-block, serious": [
-            "<a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://www.canada.ca/en/department-finance/economic-response-plan.html\">Canada's COVID-19 Economic Response Plan</a>",
-            "<a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://www.budget.gc.ca/fes-eea/2020/report-rapport/toc-tdm-en.html\">Fall Economic Statement 2020</a>"
-          ]
-        }
+        "Axe violations allow list": null
       },
       "Tested on index-basic-eng.html#datasets": {
-        "Axe violations allow list": {
-          "link-in-text-block, serious": [
-            "<a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://www.canada.ca/en/department-finance/economic-response-plan.html\">Canada's COVID-19 Economic Response Plan</a>",
-            "<a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://www.budget.gc.ca/fes-eea/2020/report-rapport/toc-tdm-en.html\">Fall Economic Statement 2020</a>"
-          ]
-        }
+        "Axe violations allow list": null
       }
     },
     "About": {
       "Tested on index-eng.html#about": {
-        "Axe violations allow list": {
-          "link-in-text-block, serious": [
-            "<a target=\"_blank\" rel=\"noopener noreferrer\" href=\"http://www.pbo-dpb.gc.ca/web/default/files/Documents/Reports/2016/Mains 2016-17/Main Estimates 2016-17_EN.pdf\">Parliamentary Budget Officer (PBO)</a>",
-            "<a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://www.oecd.org/governance/observatory-public-sector-innovation/innovations/\">Observatory of Public Sector Innovation (OPSI)</a>",
-            "<a target=\"_blank\" rel=\"noopener noreferrer\" href=\"http://www.ourcommons.ca/DocumentViewer/en/41-1/OGGO/report-7/page-144\">a Parliamentary request</a>",
-            "<a href=\"#metadata\">Datasets page</a>",
-            "<a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://open.canada.ca/en/open-data\">Open Data portal</a>",
-            "<a href=\"#contact\">contact us</a>",
-            "<a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://github.com/TBS-EACPD/infobase\">on GitHub</a>",
-            "<a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://github.com/TBS-EACPD/infobase/blob/master/LICENSE\">MIT License</a>",
-            "<a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://www.canada.ca/en/treasury-board-secretariat/topics/government-communications/federal-identity-requirements.html\">Federal identity requirements</a>",
-            "<a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://github.com/FortAwesome/Font-Awesome\">Font Awesome</a>",
-            "<a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://creativecommons.org/licenses/by/4.0/\">CC BY 4.0 License</a>",
-            "<a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://material.io/\">Material Design</a>",
-            "<a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://www.apache.org/licenses/LICENSE-2.0\">Apache license version 2.0</a>",
-            "<a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://commons.wikimedia.org/wiki/Main_Page\">The Wikimedia Foundation, Inc</a>",
-            "<a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://opensource.org/licenses/MIT\">MIT license</a>",
-            "<a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://www.canada.ca/en/treasury-board-secretariat/corporate/job-opportunities.html\">website</a>",
-            "<a href=\"mailto:gcinfobasefeedback-infobasedugcretroaction@tbs-sct.gc.ca\">gcinfobasefeedback-infobasedugcretroaction@tbs-sct.gc.ca</a>"
-          ]
-        }
+        "Axe violations allow list": null
       },
       "Tested on index-basic-eng.html#about": {
-        "Axe violations allow list": {
-          "link-in-text-block, serious": [
-            "<a target=\"_blank\" rel=\"noopener noreferrer\" href=\"http://www.pbo-dpb.gc.ca/web/default/files/Documents/Reports/2016/Mains 2016-17/Main Estimates 2016-17_EN.pdf\">Parliamentary Budget Officer (PBO)</a>",
-            "<a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://www.oecd.org/governance/observatory-public-sector-innovation/innovations/\">Observatory of Public Sector Innovation (OPSI)</a>",
-            "<a target=\"_blank\" rel=\"noopener noreferrer\" href=\"http://www.ourcommons.ca/DocumentViewer/en/41-1/OGGO/report-7/page-144\">a Parliamentary request</a>",
-            "<a href=\"#metadata\">Datasets page</a>",
-            "<a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://open.canada.ca/en/open-data\">Open Data portal</a>",
-            "<a href=\"#contact\">contact us</a>",
-            "<a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://github.com/TBS-EACPD/infobase\">on GitHub</a>",
-            "<a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://github.com/TBS-EACPD/infobase/blob/master/LICENSE\">MIT License</a>",
-            "<a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://www.canada.ca/en/treasury-board-secretariat/topics/government-communications/federal-identity-requirements.html\">Federal identity requirements</a>",
-            "<a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://github.com/FortAwesome/Font-Awesome\">Font Awesome</a>",
-            "<a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://creativecommons.org/licenses/by/4.0/\">CC BY 4.0 License</a>",
-            "<a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://material.io/\">Material Design</a>",
-            "<a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://www.apache.org/licenses/LICENSE-2.0\">Apache license version 2.0</a>",
-            "<a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://commons.wikimedia.org/wiki/Main_Page\">The Wikimedia Foundation, Inc</a>",
-            "<a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://opensource.org/licenses/MIT\">MIT license</a>",
-            "<a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://www.canada.ca/en/treasury-board-secretariat/corporate/job-opportunities.html\">website</a>",
-            "<a href=\"mailto:gcinfobasefeedback-infobasedugcretroaction@tbs-sct.gc.ca\">gcinfobasefeedback-infobasedugcretroaction@tbs-sct.gc.ca</a>"
-          ]
-        }
+        "Axe violations allow list": null
       }
     },
     "FAQ": {
       "Tested on index-eng.html#faq": {
-        "Axe violations allow list": {
-          "link-in-text-block, serious": [
-            "<a href=\"http://publications.gc.ca/site/eng/home.html\" rel=\"noopener noreferrer\" target=\"_blank\">Government of Canada Publications website</a>",
-            "<a title=\"GC InfoBase source code on GitHub\" href=\"https://github.com/TBS-EACPD/infobase\" rel=\"noopener noreferrer\" target=\"_blank\">here</a>",
-            "<a href=\"#about\" target=\"_blank\" rel=\"noopener noreferrer\">About</a>",
-            "<a href=\"https://github.com/TBS-EACPD/infobase\" rel=\"noopener noreferrer\" target=\"_blank\">our source code</a>",
-            "<a href=\"http://www.ourcommons.ca/DocumentViewer/en/41-1/OGGO/report-7/page-144\" rel=\"noopener noreferrer\" target=\"_blank\">a Parliamentary request</a>",
-            "<a href=\"#metadata\" target=\"_blank\" rel=\"noopener noreferrer\">Datasets page</a>",
-            "<a href=\"#metadata\" target=\"_blank\" rel=\"noopener noreferrer\">Datasets page</a>",
-            "<a href=\"#tag-explorer\" target=\"_blank\" rel=\"noopener noreferrer\">Tag Explorer page</a>",
-            "<a href=\"#partition\" target=\"_blank\" rel=\"noopener noreferrer\">Government at a Glance diagram</a>",
-            "<a href=\"#contact\" target=\"_blank\" rel=\"noopener noreferrer\">contact us</a>"
-          ]
-        }
+        "Axe violations allow list": null
       },
       "Tested on index-basic-eng.html#faq": {
-        "Axe violations allow list": {
-          "link-in-text-block, serious": [
-            "<a href=\"http://publications.gc.ca/site/eng/home.html\" rel=\"noopener noreferrer\" target=\"_blank\">Government of Canada Publications website</a>",
-            "<a title=\"GC InfoBase source code on GitHub\" href=\"https://github.com/TBS-EACPD/infobase\" rel=\"noopener noreferrer\" target=\"_blank\">here</a>",
-            "<a href=\"#about\" target=\"_blank\" rel=\"noopener noreferrer\">About</a>",
-            "<a href=\"https://github.com/TBS-EACPD/infobase\" rel=\"noopener noreferrer\" target=\"_blank\">our source code</a>",
-            "<a href=\"http://www.ourcommons.ca/DocumentViewer/en/41-1/OGGO/report-7/page-144\" rel=\"noopener noreferrer\" target=\"_blank\">a Parliamentary request</a>",
-            "<a href=\"#metadata\" target=\"_blank\" rel=\"noopener noreferrer\">Datasets page</a>",
-            "<a href=\"#metadata\" target=\"_blank\" rel=\"noopener noreferrer\">Datasets page</a>",
-            "<a href=\"#tag-explorer\" target=\"_blank\" rel=\"noopener noreferrer\">Tag Explorer page</a>",
-            "<a href=\"#partition\" target=\"_blank\" rel=\"noopener noreferrer\">Government at a Glance diagram</a>",
-            "<a href=\"#contact\" target=\"_blank\" rel=\"noopener noreferrer\">contact us</a>"
-          ]
-        }
+        "Axe violations allow list": null
       }
     },
     "Privacy": {
       "Tested on index-eng.html#privacy": {
-        "Axe violations allow list": {
-          "link-in-text-block, serious": [
-            "<a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://www.canada.ca/en/treasury-board-secretariat.html\">Treasury Board Secretariat (TBS)</a>",
-            "<a target=\"_blank\" rel=\"noopener noreferrer\" href=\"http://www.infosource.gc.ca/emp/emp03-eng.asp#psu914\">Public Communications (PSU 914)</a>",
-            "<a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://tools.google.com/dlpage/gaoptout?hl=en\">Google Analytics Opt-Out Browser Add-On</a>",
-            "<a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://www.google.com/policies/privacy/partners/\">Google Analytics terms of service</a>",
-            "<a target=\"_blank\" rel=\"noopener noreferrer\" href=\"http://laws-lois.justice.gc.ca/eng/acts/F-11/page-70.html#s-161\">section 161 of the Financial Administration Act</a>",
-            "<a target=\"_blank\" rel=\"noopener noreferrer\" href=\"http://www.infosource.gc.ca/emp/emp03-eng.asp#psu939\">Security Incidents (PSU 939)</a>",
-            "<a href=\"mailto:ATIP.AIPRP@tbs-sct.gc.ca\">ATIP.AIPRP@tbs-sct.gc.ca</a>",
-            "<a href=\"mailto:info@priv.gc.ca\">info@priv.gc.ca</a>"
-          ]
-        }
+        "Axe violations allow list": null
       },
       "Tested on index-basic-eng.html#privacy": {
-        "Axe violations allow list": {
-          "link-in-text-block, serious": [
-            "<a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://www.canada.ca/en/treasury-board-secretariat.html\">Treasury Board Secretariat (TBS)</a>",
-            "<a target=\"_blank\" rel=\"noopener noreferrer\" href=\"http://www.infosource.gc.ca/emp/emp03-eng.asp#psu914\">Public Communications (PSU 914)</a>",
-            "<a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://tools.google.com/dlpage/gaoptout?hl=en\">Google Analytics Opt-Out Browser Add-On</a>",
-            "<a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://www.google.com/policies/privacy/partners/\">Google Analytics terms of service</a>",
-            "<a target=\"_blank\" rel=\"noopener noreferrer\" href=\"http://laws-lois.justice.gc.ca/eng/acts/F-11/page-70.html#s-161\">section 161 of the Financial Administration Act</a>",
-            "<a target=\"_blank\" rel=\"noopener noreferrer\" href=\"http://www.infosource.gc.ca/emp/emp03-eng.asp#psu939\">Security Incidents (PSU 939)</a>",
-            "<a href=\"mailto:ATIP.AIPRP@tbs-sct.gc.ca\">ATIP.AIPRP@tbs-sct.gc.ca</a>",
-            "<a href=\"mailto:info@priv.gc.ca\">info@priv.gc.ca</a>"
-          ]
-        }
+        "Axe violations allow list": null
       }
     },
     "IGOC": {
       "Tested on index-eng.html#igoc": {
-        "Axe violations allow list": {
-          "link-in-text-block, serious": [
-            "<a target=\"_blank\" rel=\"noopener noreferrer\" href=\"http://www.tbs-sct.gc.ca/hgw-cgf/finances/rgs-erdg/cc-se/index-eng.asp\">Inventory of Federal Organizations and Interests</a>"
-          ]
-        }
+        "Axe violations allow list": null
       },
       "Tested on index-basic-eng.html#igoc": {
-        "Axe violations allow list": {
-          "link-in-text-block, serious": [
-            "<a target=\"_blank\" rel=\"noopener noreferrer\" href=\"http://www.tbs-sct.gc.ca/hgw-cgf/finances/rgs-erdg/cc-se/index-eng.asp\">Inventory of Federal Organizations and Interests</a>"
-          ]
-        }
+        "Axe violations allow list": null
       }
     },
     "Estimates Comparison": {
@@ -224,24 +112,10 @@ module.exports = {
     },
     "Infographic - Gov - About": {
       "Tested on index-eng.html#infographic/gov/gov/intro": {
-        "Axe violations allow list": {
-          "link-in-text-block, serious": [
-            "<a href=\"#infographic/dept/128\" title=\"Infographic for Employment and Social Development Canada\">Employment and Social Development Canada</a>",
-            "<a href=\"#infographic/dept/124\" title=\"Infographic for Department of Finance Canada\">Department of Finance Canada</a>",
-            "<a href=\"#infographic/dept/124\" title=\"Infographic for Department of Finance Canada\">Department of Finance Canada</a>",
-            "<a href=\"#igoc/inst_form_filter\">federal organizations</a>"
-          ]
-        }
+        "Axe violations allow list": null
       },
       "Tested on index-basic-eng.html#infographic/gov/gov/intro": {
-        "Axe violations allow list": {
-          "link-in-text-block, serious": [
-            "<a href=\"#infographic/dept/128\" title=\"Infographic for Employment and Social Development Canada\">Employment and Social Development Canada</a>",
-            "<a href=\"#infographic/dept/124\" title=\"Infographic for Department of Finance Canada\">Department of Finance Canada</a>",
-            "<a href=\"#infographic/dept/124\" title=\"Infographic for Department of Finance Canada\">Department of Finance Canada</a>",
-            "<a href=\"#igoc/inst_form_filter\">federal organizations</a>"
-          ]
-        }
+        "Axe violations allow list": null
       }
     },
     "Infographic - Gov - Finance": {
@@ -254,20 +128,10 @@ module.exports = {
     },
     "Infographic - Gov - COVID-19 Response": {
       "Tested on index-eng.html#infographic/gov/gov/covid": {
-        "Axe violations allow list": {
-          "link-in-text-block, serious": [
-            "<a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://www.budget.gc.ca/2022/home-accueil-en.html\">Budget 2022</a>",
-            "<a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://open.canada.ca/data/en/dataset/9fa1da9a-8c0f-493e-b207-0cc95889823e\">Open Data</a>"
-          ]
-        }
+        "Axe violations allow list": null
       },
       "Tested on index-basic-eng.html#infographic/gov/gov/covid": {
-        "Axe violations allow list": {
-          "link-in-text-block, serious": [
-            "<a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://www.budget.gc.ca/2022/home-accueil-en.html\">Budget 2022</a>",
-            "<a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://open.canada.ca/data/en/dataset/9fa1da9a-8c0f-493e-b207-0cc95889823e\">Open Data</a>"
-          ]
-        }
+        "Axe violations allow list": null
       }
     },
     "Infographic - Gov - People": {
@@ -288,22 +152,10 @@ module.exports = {
     },
     "Infographic - Gov - Results": {
       "Tested on index-eng.html#infographic/gov/gov/results": {
-        "Axe violations allow list": {
-          "link-in-text-block, serious": [
-            "<a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://www.tbs-sct.gc.ca/pol/doc-eng.aspx?id=31300\">Policy on Results</a>",
-            "<a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://www.canada.ca/en/treasury-board-secretariat/services/planned-government-spending/reports-plans-priorities/2023-24-departmental-plans.html\" title=\"index of Departmental Plans\">here</a>",
-            "<a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://www.canada.ca/en/treasury-board-secretariat/services/departmental-performance-reports/2021-22-departmental-results-reports.html\" title=\"index of Departmental Results Reports\">here</a>"
-          ]
-        }
+        "Axe violations allow list": null
       },
       "Tested on index-basic-eng.html#infographic/gov/gov/results": {
-        "Axe violations allow list": {
-          "link-in-text-block, serious": [
-            "<a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://www.tbs-sct.gc.ca/pol/doc-eng.aspx?id=31300\">Policy on Results</a>",
-            "<a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://www.canada.ca/en/treasury-board-secretariat/services/planned-government-spending/reports-plans-priorities/2023-24-departmental-plans.html\" title=\"index of Departmental Plans\">here</a>",
-            "<a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://www.canada.ca/en/treasury-board-secretariat/services/departmental-performance-reports/2021-22-departmental-results-reports.html\" title=\"index of Departmental Results Reports\">here</a>"
-          ]
-        }
+        "Axe violations allow list": null
       }
     },
     "Infographic - Gov - Where can I go from here?": {
@@ -340,20 +192,10 @@ module.exports = {
     },
     "Infographic - Dept - COVID-19 Response": {
       "Tested on index-eng.html#infographic/dept/1/covid": {
-        "Axe violations allow list": {
-          "link-in-text-block, serious": [
-            "<a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://www.budget.gc.ca/2021/home-accueil-en.html\">Budget 2021</a>",
-            "<a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://open.canada.ca/data/en/dataset/9fa1da9a-8c0f-493e-b207-0cc95889823e\">Open Data</a>"
-          ]
-        }
+        "Axe violations allow list": null
       },
       "Tested on index-basic-eng.html#infographic/dept/1/covid": {
-        "Axe violations allow list": {
-          "link-in-text-block, serious": [
-            "<a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://www.budget.gc.ca/2021/home-accueil-en.html\">Budget 2021</a>",
-            "<a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://open.canada.ca/data/en/dataset/9fa1da9a-8c0f-493e-b207-0cc95889823e\">Open Data</a>"
-          ]
-        }
+        "Axe violations allow list": null
       }
     },
     "Infographic - Dept - People": {
@@ -377,39 +219,10 @@ module.exports = {
     },
     "Infographic - Dept - Results": {
       "Tested on index-eng.html#infographic/dept/326/results": {
-        "Axe violations allow list": {
-          "link-in-text-block, serious": [
-            "<a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://www.tbs-sct.gc.ca/pol/doc-eng.aspx?id=31300\">Policy on Results</a>",
-            "<a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://www.canada.ca/en/treasury-board-secretariat/services/planned-government-spending/reports-plans-priorities/2023-24-departmental-plans.html\" title=\"index of Departmental Plans\">here</a>",
-            "<a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://www.canada.ca/en/treasury-board-secretariat/services/departmental-performance-reports/2021-22-departmental-results-reports.html\" title=\"index of Departmental Results Reports\">here</a>"
-          ]
-        }
+        "Axe violations allow list": null
       },
       "Tested on index-basic-eng.html#infographic/dept/326/results": {
-        "Axe violations allow list": {
-          "link-in-text-block, serious": [
-            "<a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://www.tbs-sct.gc.ca/pol/doc-eng.aspx?id=31300\">Policy on Results</a>",
-            "<a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://www.canada.ca/en/treasury-board-secretariat/services/planned-government-spending/reports-plans-priorities/2023-24-departmental-plans.html\" title=\"index of Departmental Plans\">here</a>",
-            "<a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://www.canada.ca/en/treasury-board-secretariat/services/departmental-performance-reports/2021-22-departmental-results-reports.html\" title=\"index of Departmental Results Reports\">here</a>",
-            "<a href=\"#infographic/crso/TBC-BXA00/results\">Spending Oversight</a>",
-            "<a href=\"#infographic/crso/TBC-BXA00/results\">Spending Oversight</a>",
-            "<a href=\"#infographic/crso/TBC-BXC00/results\">Employer</a>",
-            "<a href=\"#infographic/crso/TBC-BXC00/results\">Employer</a>",
-            "<a href=\"#infographic/crso/TBC-BXC00/results\">Employer</a>",
-            "<a href=\"#infographic/crso/TBC-BXC00/results\">Employer</a>",
-            "<a href=\"#infographic/crso/TBC-BXC00/results\">Employer</a>",
-            "<a href=\"#infographic/crso/TBC-BXC00/results\">Employer</a>",
-            "<a href=\"#infographic/crso/TBC-BXC00/results\">Employer</a>",
-            "<a href=\"#infographic/crso/TBC-BXC00/results\">Employer</a>",
-            "<a href=\"#infographic/crso/TBC-BXC00/results\">Employer</a>",
-            "<a href=\"#infographic/crso/TBC-BXC00/results\">Employer</a>",
-            "<a href=\"#infographic/crso/TBC-BXD00/results\">Regulatory Oversight</a>",
-            "<a href=\"#infographic/crso/TBC-BXD00/results\">Regulatory Oversight</a>",
-            "<a href=\"#infographic/crso/TBC-BXD00/results\">Regulatory Oversight</a>",
-            "<a href=\"#infographic/crso/TBC-BXD00/results\">Regulatory Oversight</a>",
-            "<a href=\"#infographic/crso/TBC-BXD00/results\">Regulatory Oversight</a>"
-          ]
-        }
+        "Axe violations allow list": null
       }
     },
     "Infographic - Dept - Where can I go from here?": {
@@ -473,12 +286,7 @@ module.exports = {
         "Axe violations allow list": null
       },
       "Tested on index-basic-eng.html#infographic/crso/TBC-BXA00/results": {
-        "Axe violations allow list": {
-          "link-in-text-block, serious": [
-            "<a href=\"#infographic/crso/TBC-BXA00/results\">Spending Oversight</a>",
-            "<a href=\"#infographic/crso/TBC-BXA00/results\">Spending Oversight</a>"
-          ]
-        }
+        "Axe violations allow list": null
       }
     },
     "Infographic - CRSO - Where can I go from here?": {

--- a/client/src/InfoBase/site.scss
+++ b/client/src/InfoBase/site.scss
@@ -120,15 +120,15 @@ strong,
   font-weight: $lightFontWeight;
 }
 
+a,
 .link-styled {
   cursor: pointer;
-  text-decoration: none;
+  text-decoration: underline;
   color: $linkColor;
   background-color: transparent;
   &:focus,
   &:hover {
     color: $linkFocusColor;
-    text-decoration: underline;
   }
 }
 .border-radius {


### PR DESCRIPTION
Axe plugin was picking up some link-in-text-block violations: https://dequeuniversity.com/rules/axe/4.1/link-in-text-block

Modified our styling constants for links to include underlines (not just when hovered). Also included < a > to this styling constant. This underline styling seems to match up with other GC websites: https://www.canada.ca/en/services/taxes/income-tax.html