### PR TITLE
Fix RPB sort function for 'Not Applicable' cases

### DIFF
--- a/client/src/components/DisplayTable/DisplayTable.tsx
+++ b/client/src/components/DisplayTable/DisplayTable.tsx
@@ -333,6 +333,7 @@ export class _DisplayTable extends React.Component<
     );
 
     const determine_text_align = (row: DisplayTableData, col: string) => {
+      console.log(row, col);
       const current_col_formatter = col_configs_with_defaults[col].formatter;
       const current_col_plain_formatter =
         col_configs_with_defaults[col].plain_formatter;
@@ -383,15 +384,11 @@ export class _DisplayTable extends React.Component<
                 .map((row) => row[sort_by])
                 .thru(([value_a, value_b]) =>
                   sort_func(
-                    value_a === "Not Applicable"
-                      ? -1
-                      : plain_formatter(value_a),
-                    value_b === "Not Applicable"
-                      ? -1
-                      : plain_formatter(value_b),
+                    value_a === "-" ? -1 : plain_formatter(value_a),
+                    value_b === "-" ? -1 : plain_formatter(value_b),
                     descending,
-                    value_a === "Not Applicable" ? -1 : value_a,
-                    value_b === "Not Applicable" ? -1 : value_b
+                    value_a === "-" ? -1 : value_a,
+                    value_b === "-" ? -1 : value_b
                   )
                 )
                 .value()

--- a/client/src/components/DisplayTable/DisplayTable.tsx
+++ b/client/src/components/DisplayTable/DisplayTable.tsx
@@ -333,14 +333,20 @@ export class _DisplayTable extends React.Component<
     );
 
     const determine_text_align = (row: DisplayTableData, col: string) => {
-      console.log(row, col);
       const current_col_formatter = col_configs_with_defaults[col].formatter;
       const current_col_plain_formatter =
         col_configs_with_defaults[col].plain_formatter;
-      return (_.isString(current_col_formatter) && _.isNumber(row[col])) ||
+
+      if (
+        (_.isString(current_col_formatter) && _.isNumber(row[col])) ||
         _.isNumber(current_col_plain_formatter(row[col]))
-        ? "right"
-        : "left";
+      ) {
+        return "right";
+      } else if (current_col_plain_formatter(row[col]) === "-") {
+        return "center";
+      } else {
+        return "left";
+      }
     };
 
     const clean_search_string = (search_string: CellValue) =>

--- a/client/src/components/DisplayTable/DisplayTable.tsx
+++ b/client/src/components/DisplayTable/DisplayTable.tsx
@@ -383,11 +383,15 @@ export class _DisplayTable extends React.Component<
                 .map((row) => row[sort_by])
                 .thru(([value_a, value_b]) =>
                   sort_func(
-                    plain_formatter(value_a),
-                    plain_formatter(value_b),
+                    value_a === "Not Applicable"
+                      ? -1
+                      : plain_formatter(value_a),
+                    value_b === "Not Applicable"
+                      ? -1
+                      : plain_formatter(value_b),
                     descending,
-                    value_a,
-                    value_b
+                    value_a === "Not Applicable" ? -1 : value_a,
+                    value_b === "Not Applicable" ? -1 : value_b
                   )
                 )
                 .value()

--- a/client/src/rpb/granular_view.js
+++ b/client/src/rpb/granular_view.js
@@ -108,8 +108,7 @@ class GranularView extends React.Component {
       // remove planned spending projections from crown corps
       if (org.inst_form_id === "crown_corp") {
         planning_years.forEach((year) => {
-          if (year in filtered_columns)
-            filtered_columns[year] = "Not Applicable";
+          if (year in filtered_columns) filtered_columns[year] = "-";
         });
       }
 
@@ -209,6 +208,8 @@ class GranularView extends React.Component {
       ),
     };
 
+    console.log(table_data);
+    console.log(column_configs);
     return (
       <DisplayTable
         data={table_data}

--- a/client/src/rpb/granular_view.js
+++ b/client/src/rpb/granular_view.js
@@ -208,8 +208,6 @@ class GranularView extends React.Component {
       ),
     };
 
-    console.log(table_data);
-    console.log(column_configs);
     return (
       <DisplayTable
         data={table_data}

--- a/client/src/tables/programSpending.js
+++ b/client/src/tables/programSpending.js
@@ -86,7 +86,7 @@ export default {
     _.each(planning_years, (header) => {
       this.add_col(header).add_child([
         {
-          type: "big_int",
+          type: "dollar",
           nick: header,
           header: {
             en: "Planned Spending",


### PR DESCRIPTION
Follow up to #1592

To Do:

- [ ]  ~~Crown corps were given 'Not Applicable' value in RPB, but this is breaking the sort function because the columns now have both a string and number to sort. Fix the sort function to be able to handle 'Not Applicable' cases.~~
    - [ ]  Decided to give crown corps null value instead so don’t need to modify sort function
- [x]  Stop null values from being given a value of '0'
    - Currently RPB displays '0' when the csv has an empty value
    - in `TableClass` we gave any `“.”, “”, “-”` a value of zero so it doesn’t break other functionalities such as summing the column values of a csv
        - Changing this to give a value of null instead (This doesn’t cause any issues with the summing function, but need to check if it’ll break anything else on the site)
- [ ]  When populating programSpending remove any pipeline generated planned spending calculations
    - it’s using the old Table API instead of graphQL?
- [ ]  On ‘Authorities and Expenditures’ panel ensure consistency between the items selected in the legend and the ‘Table of Data’ view
- [ ]  Write unit tests

In the future, instead of retroactively removing the pipeline generated planned spending values for crown corps maybe the pipeline shouldn’t generate these values in the first place.