### PR TITLE
Bar Chart for Gross Expenditure by SOBJ Panel

### DIFF
--- a/client/src/panels/panel_declarations/finances/sobj/top_spending_areas.js
+++ b/client/src/panels/panel_declarations/finances/sobj/top_spending_areas.js
@@ -2,14 +2,19 @@ import { sum } from "d3-array";
 import _ from "lodash";
 import React from "react";
 
-import { StdPanel, Col } from "src/panels/panel_declarations/InfographicPanel";
+import { InfographicPanel } from "src/panels/panel_declarations/InfographicPanel";
 import { declare_panel } from "src/panels/PanelRegistry";
 
-import { create_text_maker_component } from "src/components/index";
+import {
+  create_text_maker_component,
+  DisplayTable,
+} from "src/components/index";
 
-import { is_a11y_mode } from "src/core/injected_build_constants";
+import { formats } from "src/core/format";
 
-import { WrappedNivoPie } from "src/charts/wrapped_nivo/index";
+import { WrappedNivoHBar } from "src/charts/wrapped_nivo/index";
+
+import { highlightColor, secondaryColor, textColor } from "src/style_constants";
 
 import text from "./top_spending_areas.yaml";
 
@@ -39,52 +44,91 @@ const collapse_by_so = function (programs, table, filter) {
     .value();
 };
 
-const common_cal = (programs, programSobjs) => {
-  const cut_off_index = 3;
-  const rows_by_so = collapse_by_so(programs, programSobjs, is_non_revenue);
-
-  if (
-    rows_by_so.length <= 1 ||
-    _.every(rows_by_so, ({ value }) => value === 0)
-  ) {
-    return false;
-  }
-
-  const top_3_sos = _.take(rows_by_so, cut_off_index);
-  const remainder =
-    top_3_sos.length > cut_off_index - 1
-      ? {
-          label: text_maker("other_s"),
-          value: sum(
-            _.takeRight(rows_by_so, rows_by_so.length - cut_off_index),
-            _.property("value")
-          ),
-        }
-      : [];
-
-  return top_3_sos.concat(remainder);
-};
-
 const render_w_options =
   ({ text_key }) =>
   ({ title, calculations, footnotes, sources, datasets }) => {
-    const { top_3_sos_and_remainder, text_calculations } = calculations;
+    const { text_calculations, rows_by_so } = calculations;
 
-    const graph_data = top_3_sos_and_remainder.map((d) => ({
-      label: d["label"],
-      id: d["label"],
-      value: d["value"],
+    const graph_data = _.chain(rows_by_so)
+      .map((d) => ({
+        label: d["label"],
+        id: d["so_num"],
+        value: d["value"],
+      }))
+      .orderBy("id", "desc")
+      .value();
+
+    // Increase height of the graph region for y-axis labels to have sufficient room
+    // This is required to corretly display the labels when too many programs are present
+    const divHeight = _.chain([1000 * (graph_data.length / 30) * 2, 100]) // 100 is the minimum graph height
+      .max()
+      .thru((maxVal) => [maxVal, 500]) // 500 is the max graph height
+      .min()
+      .value();
+
+    const markers = _.map(graph_data, ({ label, value }) => ({
+      axis: "y",
+      value: label,
+      lineStyle: { strokeWidth: 0 },
+      textStyle: {
+        fill: value < 0 ? highlightColor : textColor,
+        fontSize: "11px",
+      },
+      legend: formats.compact1_raw(value),
+      legendOffsetX: -60,
+      legendOffsetY: Math.max(-(divHeight / (3.3 * graph_data.length)), -18), // Math.max so that there would be a set value for when the graph has one bar/data point
     }));
 
+    const column_configs = {
+      so_num: {
+        index: 0,
+        header: "ID",
+      },
+      label: {
+        index: 1,
+        header: "Standard Objects",
+        is_searchable: true,
+      },
+      value: {
+        index: 2,
+        header: "Expenditure",
+        is_summable: true,
+        formatter: "dollar",
+      },
+    };
+
+    const custom_table_data = _.sortBy(rows_by_so, "so_num");
+
     return (
-      <StdPanel {...{ title, footnotes, sources, datasets }}>
-        <Col isText size={5}>
-          <TM k={text_key} args={text_calculations} />
-        </Col>
-        <Col isGraph={!is_a11y_mode} size={7}>
-          <WrappedNivoPie data={graph_data} graph_height="450px" />
-        </Col>
-      </StdPanel>
+      <InfographicPanel {...{ title, footnotes, sources, datasets }}>
+        <TM k={text_key} args={text_calculations} />
+        <WrappedNivoHBar
+          data={graph_data}
+          keys={["value"]}
+          indexBy="label"
+          colors={(d) => (d.data[d.id] < 0 ? highlightColor : secondaryColor)}
+          margin={{
+            top: 0,
+            right: 100,
+            bottom: 50,
+            left: 250,
+          }}
+          bttm_axis={{
+            tickSize: 5,
+            tickPadding: 5,
+            tickValues: 6,
+            tickRotation: -20,
+            format: (d) => formats.compact1_raw(d),
+          }}
+          markers={markers}
+          custom_table={
+            <DisplayTable
+              column_configs={column_configs}
+              data={custom_table_data}
+            />
+          }
+        />
+      </InfographicPanel>
     );
   };
 
@@ -101,31 +145,34 @@ export const declare_top_spending_areas_panel = () =>
           return false;
         }
 
-        const top_3_sos_and_remainder = common_cal(
+        const rows_by_so = collapse_by_so(
           [subject],
-          tables.programSobjs
+          tables.programSobjs,
+          is_non_revenue
         );
-        if (!top_3_sos_and_remainder) {
+
+        if (_.isEmpty(rows_by_so)) {
           return false;
         }
 
-        const total_spent = _.sum(
-          _.map(top_3_sos_and_remainder, (so) => so.value)
-        );
-        const top_so_pct = top_3_sos_and_remainder[0].value / total_spent;
+        const total_spent = _.sum(_.map(rows_by_so, (so) => so.value));
+
+        const top_so = _.maxBy(rows_by_so, "value");
+
+        const low_so = _.minBy(rows_by_so, "value");
 
         const text_calculations = {
           subject,
-          top_3_sos_and_remainder,
-          top_so_name: top_3_sos_and_remainder[0].label,
-          top_so_spent: top_3_sos_and_remainder[0].value,
+          top_so_name: top_so.label,
+          top_so_value: top_so.value,
+          low_so_name: low_so.label,
+          low_so_value: low_so.value,
           total_spent,
-          top_so_pct,
         };
 
         return {
           text_calculations,
-          top_3_sos_and_remainder,
+          rows_by_so,
         };
       },
       render: render_w_options({ text_key: "program_top_spending_areas_text" }),

--- a/client/src/panels/panel_declarations/finances/sobj/top_spending_areas.js
+++ b/client/src/panels/panel_declarations/finances/sobj/top_spending_areas.js
@@ -95,11 +95,11 @@ const render_w_options =
       },
       label: {
         index: 1,
-        header: "Standard Objects",
+        header: text_maker("sos"),
       },
       value: {
         index: 2,
-        header: "Expenditure",
+        header: text_maker("expenditures"),
         is_summable: true,
         formatter: "dollar",
       },

--- a/client/src/panels/panel_declarations/finances/sobj/top_spending_areas.js
+++ b/client/src/panels/panel_declarations/finances/sobj/top_spending_areas.js
@@ -87,7 +87,6 @@ const render_w_options =
       label: {
         index: 1,
         header: "Standard Objects",
-        is_searchable: true,
       },
       value: {
         index: 2,
@@ -145,10 +144,9 @@ export const declare_top_spending_areas_panel = () =>
           return false;
         }
 
-        const rows_by_so = collapse_by_so(
-          [subject],
-          tables.programSobjs,
-          is_non_revenue
+        const rows_by_so = _.filter(
+          collapse_by_so([subject], tables.programSobjs, is_non_revenue),
+          (row) => row.value
         );
 
         if (_.isEmpty(rows_by_so)) {

--- a/client/src/panels/panel_declarations/finances/sobj/top_spending_areas.js
+++ b/client/src/panels/panel_declarations/finances/sobj/top_spending_areas.js
@@ -53,7 +53,7 @@ const render_w_options =
       .map((d) => ({
         label: d["label"],
         id: d["so_num"],
-        value: d["value"],
+        Expenditure: d["value"],
       }))
       .orderBy("id", "desc")
       .value();
@@ -79,6 +79,15 @@ const render_w_options =
       legendOffsetY: Math.max(-(divHeight / (3.3 * graph_data.length)), -18), // Math.max so that there would be a set value for when the graph has one bar/data point
     }));
 
+    const custom_table_data = _.chain(rows_by_so)
+      .map((d) => ({
+        label: d["label"],
+        so_num: d["so_num"],
+        value: d["value"],
+      }))
+      .sortBy("so_num")
+      .value();
+
     const column_configs = {
       so_num: {
         index: 0,
@@ -96,14 +105,12 @@ const render_w_options =
       },
     };
 
-    const custom_table_data = _.sortBy(rows_by_so, "so_num");
-
     return (
       <InfographicPanel {...{ title, footnotes, sources, datasets }}>
         <TM k={text_key} args={text_calculations} />
         <WrappedNivoHBar
           data={graph_data}
-          keys={["value"]}
+          keys={["Expenditure"]}
           indexBy="label"
           colors={(d) => (d.data[d.id] < 0 ? highlightColor : secondaryColor)}
           margin={{

--- a/client/src/panels/panel_declarations/finances/sobj/top_spending_areas.yaml
+++ b/client/src/panels/panel_declarations/finances/sobj/top_spending_areas.yaml
@@ -1,7 +1,7 @@
 top_spending_areas_title:
   transform: [handlebars]
-  en: Gross Spending by Standard Object ({{pa_last_year}})
-  fr: Dépenses brutes par article courant ({{pa_last_year}})
+  en: Gross Expenditure by Standard Object ({{pa_last_year}})
+  fr: (update) Dépenses brutes par article courant ({{pa_last_year}})
 
 std_obj_quick_def:
   transform: [handlebars, markdown]
@@ -29,14 +29,12 @@ tag_top_spending_areas_text:
 program_top_spending_areas_text:
   transform: [handlebars, markdown]
   en: | 
-    In {{pa_last_year}}, the largest share of expenditures for "**{{subject.name}}**" were recorded under the 
+    In {{pa_last_year}}, the total _gross_ expenditure for "**{{subject.name}}**" was **{{fmt_compact1_written total_spent}}**. The largest share of expenditures were recorded under the 
     "**{{top_so_name}}**" standard object **({{fmt_compact1_written top_so_value}})** and the smallest share of expenditures were recorded under the
-    "**{{low_so_name}}**" standard object **({{fmt_compact1_written low_so_value}})**. The total _gross_ expenditure for this program was **{{fmt_compact1_written total_spent}}**.
-
-    {{{gt "std_obj_quick_def"}}}
+    "**{{low_so_name}}**" standard object **({{fmt_compact1_written low_so_value}})**. {{gl_sidebar_link "Standard Objects" "SOBJ"}} are the highest level of classification for categorizing expenditures. 
 
   fr: |
-    {{{gt "std_obj_quick_def"}}}
+    (update) {{{gt "std_obj_quick_def"}}}
     
     En {{pa_last_year}}, la partie la plus importante des dépenses du programme «**{{subject.name}}**» a été enregistrée 
     sous l'article courant «**{{top_so_name}}**» **({{fmt_compact1_written top_so_spent}})**, soit **{{fmt_percentage1 top_so_pct}}** des dépenses _brutes_ du programme totalisant **{{fmt_compact1_written total_spent}}**.

--- a/client/src/panels/panel_declarations/finances/sobj/top_spending_areas.yaml
+++ b/client/src/panels/panel_declarations/finances/sobj/top_spending_areas.yaml
@@ -1,7 +1,7 @@
 top_spending_areas_title:
   transform: [handlebars]
   en: Gross Expenditure by Standard Object ({{pa_last_year}})
-  fr: (update) Dépenses brutes par article courant ({{pa_last_year}})
+  fr: Dépenses brutes par article courant ({{pa_last_year}})
 
 std_obj_quick_def:
   transform: [handlebars, markdown]
@@ -34,7 +34,6 @@ program_top_spending_areas_text:
     "**{{low_so_name}}**" standard object **({{fmt_compact1_written low_so_value}})**. {{gl_sidebar_link "Standard Objects" "SOBJ"}} are the highest level of classification for categorizing expenditures. 
 
   fr: |
-    (update) {{{gt "std_obj_quick_def"}}}
-    
-    En {{pa_last_year}}, la partie la plus importante des dépenses du programme «**{{subject.name}}**» a été enregistrée 
-    sous l'article courant «**{{top_so_name}}**» **({{fmt_compact1_written top_so_spent}})**, soit **{{fmt_percentage1 top_so_pct}}** des dépenses _brutes_ du programme totalisant **{{fmt_compact1_written total_spent}}**.
+    En {{pa_last_year}}, les dépenses brutes _totales_ pour "**{{subject.name}}**" s'élevaient à **{{fmt_compact1_written total_spent}}**.
+    La plus grande part des dépenses a été enregistrée sous l'article courant  "**{{top_so_name}}**" **({{fmt_compact1_written top_so_value}})** et la plus petite part des dépenses a été enregistrée sous l'article courant "**{{low_so_name}}**" **({{fmt_compact1_written low_so_value}})**.
+    Les {{gl_sidebar_link "articles courants" "SOBJ"}} constituent le niveau de classification le plus élevé pour catégoriser les dépenses.

--- a/client/src/panels/panel_declarations/finances/sobj/top_spending_areas.yaml
+++ b/client/src/panels/panel_declarations/finances/sobj/top_spending_areas.yaml
@@ -29,11 +29,12 @@ tag_top_spending_areas_text:
 program_top_spending_areas_text:
   transform: [handlebars, markdown]
   en: | 
-    {{{gt "std_obj_quick_def"}}}
-    
     In {{pa_last_year}}, the largest share of expenditures for "**{{subject.name}}**" were recorded under the 
-    "**{{top_so_name}}**" standard object **({{fmt_compact1_written top_so_spent}})**, representing **{{fmt_percentage1 top_so_pct}}** of the program's total _gross_ expenditures of **{{fmt_compact1_written total_spent}}**.
-  
+    "**{{top_so_name}}**" standard object **({{fmt_compact1_written top_so_value}})** and the smallest share of expenditures were recorded under the
+    "**{{low_so_name}}**" standard object **({{fmt_compact1_written low_so_value}})**. The total _gross_ expenditure for this program was **{{fmt_compact1_written total_spent}}**.
+
+    {{{gt "std_obj_quick_def"}}}
+
   fr: |
     {{{gt "std_obj_quick_def"}}}
     


### PR DESCRIPTION
Old PRs: 

- https://github.com/TBS-EACPD/infobase/pull/1643
-  https://github.com/TBS-EACPD/infobase/pull/1649

*I created a new PR because it was getting hard to keep track of all the chart changes and the new sobj csv files we were testing out

Background: There were some programs that had some standard objects with negative values, which would cause issues with the gross spending by standard object pie chart. For example, employment insurance: https://www.tbs-sct.canada.ca/ems-sgd/edb-bdd/index-eng.html#infographic/program/HRSD-BGO01/financial.

Final solution is to convert the pie chart to horizontal bar chart that displays each standard object a program has: 
![image](https://github.com/user-attachments/assets/e54b2d61-9045-4bbd-a928-269d70f02b74)
