### PR TITLE
Single line break

### DIFF
--- a/client/src/general_utils.ts
+++ b/client/src/general_utils.ts
@@ -25,7 +25,7 @@ export const sanitize_html = (markup: string | Node) => {
 };
 
 export const sanitized_marked = (markdown: string) =>
-  sanitize_html(marked(markdown, { sanitize: false, gfm: true }));
+  sanitize_html(marked(markdown, { sanitize: false, gfm: true, breaks: true }));
 
 export const sanitized_dangerous_inner_html = (html: string) => ({
   __html: sanitize_html(html),


### PR DESCRIPTION
InfoBase is not rendering all the single line breaks that a user inputted into titan for indicators. For example, in TBS the indicator "Percentage of institutions that respond to 90% or more of personal information requests within legislated timelines" (PROGRAM-dp24-16195) methodology is being displayed as one big paragraph:
![image](https://github.com/user-attachments/assets/58148dc6-8feb-41ab-8b26-0ba43d92b3de)

The user was expecting rationale, calculation/formula, measurement strategy, and baseline to be on a separate line because that's how they formatted it in titan when they inputted the result:
![image](https://github.com/user-attachments/assets/1e1dbd8d-d6dd-4cfe-b32a-c50c6845db94)

Currently infobase is only rendering single line breaks if it's a hard line break (look at the gfm resource). To fix this, I updated the marked function which takes our text and converts it to html so that it respects single line breaks by enabling the `breaks` option. 

Resources used:
-Marked: https://marked.js.org/using_advanced#options
-GitHub Flavored Markdown: https://github.github.com/gfm/