### PR TITLE
Program results not displaying

### DIFF
--- a/server/src/models/results/populate.js
+++ b/server/src/models/results/populate.js
@@ -225,21 +225,10 @@ export default async function ({ models }) {
     .filter(valid_doc_filter)
     .value();
 
-  const dr_result_record = _.filter(result_records, ({ result_id }) =>
-    _.startsWith(result_id, "DR")
-  );
-
-  const pr_result_record = _.filter(result_records, ({ result_id }) =>
-    _.startsWith(result_id, "PROGRAM")
-  );
-
-  const dr_indicator_record = _.filter(indicator_records, ({ result_id }) =>
-    _.startsWith(result_id, "DR")
-  );
-
-  const pr_indicator_record = _.filter(indicator_records, ({ result_id }) =>
-    _.startsWith(result_id, "PROGRAM")
-  );
+  const get_records_by_level = (records, level) =>
+    _.filter(records, ({ result_id }) =>
+      _.startsWith(result_id.toLowerCase(), level)
+    );
 
   const result_count_records = get_result_count_records(
     result_records,
@@ -247,13 +236,13 @@ export default async function ({ models }) {
   );
 
   const dr_result_count_records = get_result_count_records(
-    dr_result_record,
-    dr_indicator_record
+    get_records_by_level(result_records, "dr"),
+    get_records_by_level(indicator_records, "dr")
   );
 
   const pr_result_count_records = get_result_count_records(
-    pr_result_record,
-    pr_indicator_record
+    get_records_by_level(result_records, "program"),
+    get_records_by_level(indicator_records, "program")
   );
 
   await Result.insertMany(result_records);


### PR DESCRIPTION
The `id` field in results.csv and the `result_id` field in indicators.csv were previously formatted using uppercase `PROGRAM` but were recently changed to use the `Program`.

Our filtering logic for program result and indicator records was case-sensitive, so after this change, it stopped grabbing any rows related to program results.

Fix:

- [x] Update the filter logic to be case-insensitive so it continues to work regardless of how `Program` is capitalized in csv
- [x] Extend this to the `DR` filter as well (ie. our filter for dept results and indicators)